### PR TITLE
增加及修订中文翻译

### DIFF
--- a/static/blizzard.j
+++ b/static/blizzard.j
@@ -798,25 +798,46 @@ globals
 
     // Triggered sounds
     //sound              bj_pingMinimapSound         = null
+    // 音效 救援音效
     sound              bj_rescueSound              = null
+    // 音效 发现任务音效
     sound              bj_questDiscoveredSound     = null
+    // 音效 任务更新音效
     sound              bj_questUpdatedSound        = null
+    // 音效 任务完成音效
     sound              bj_questCompletedSound      = null
+    // 音效 任务失败音效
     sound              bj_questFailedSound         = null
+    // 音效 任务提示音效
     sound              bj_questHintSound           = null
+    // 音效 发现任务秘密音效
     sound              bj_questSecretSound         = null
+    // 音效 获得新任务物品音效
     sound              bj_questItemAcquiredSound   = null
+    // 音效 任务警告音效
     sound              bj_questWarningSound        = null
+    // 音效 胜利对话框音效
     sound              bj_victoryDialogSound       = null
+    // 音效 失败对话框音效
     sound              bj_defeatDialogSound        = null
 
     // Marketplace vars
+    // 市场相关变量 任意物品被购买触发
     trigger            bj_stockItemPurchased       = null
+    // 市场相关变量 物品更新计时器
     timer              bj_stockUpdateTimer         = null
+    // 市场相关变量 物品分类布尔值数组 永久
     boolean array      bj_stockAllowedPermanent
+    // 市场相关变量 物品分类布尔值数组 可充
     boolean array      bj_stockAllowedCharged
+    // 市场相关变量 物品分类布尔值数组 人造
     boolean array      bj_stockAllowedArtifact
+    // 市场相关变量 物品等级 用于获取各物品分类尔值数组检查到的值
+    // bj_stockPickedItemLevel = bj_stockAllowedPermanent[Level]
+    // bj_stockPickedItemLevel = bj_stockAllowedCharged[Level]
+    // bj_stockPickedItemLevel = bj_stockAllowedArtifact[Level]
     integer            bj_stockPickedItemLevel     = 0
+    // 市场相关变量 物品分类
     itemtype           bj_stockPickedItemType
 
     // Melee vars
@@ -844,8 +865,11 @@ globals
     boolean            bj_rescueChangeColorBldg    = true
 
     // Transmission vars
+    // 电影场景结束计时器
     timer              bj_cineSceneEndingTimer     = null
+    // 最后播放的电影场景声音
     sound              bj_cineSceneLastSound       = null
+    // 跳过电影场景触发器
     trigger            bj_cineSceneBeingSkipped    = null
 
     // Cinematic mode vars
@@ -867,10 +891,15 @@ globals
     string             bj_cineFadeContinueTex      = ""
 
     // QueuedTriggerExecute vars
+    // 动作队列执行次数统计
     integer            bj_queuedExecTotal          = 0
+    // 动作队列执行触发器数组
     trigger array      bj_queuedExecTriggers
+    // 动作队列执行布尔值数组 用于登记当前动作是否使用了条件
     boolean array      bj_queuedExecUseConds
+    // 动作队列执行计时器
     timer              bj_queuedExecTimeoutTimer   = CreateTimer()
+    // 动作队列执行超时触发器
     trigger            bj_queuedExecTimeout        = null
 
     // Helper vars (for Filter and Enum funcs)
@@ -917,8 +946,11 @@ globals
     widget             bj_lastDyingWidget          = null
 
     // Random distribution vars
+    // 随机分布数
     integer            bj_randDistCount            = 0
+    // 随机分布ID数组
     integer array      bj_randDistID
+    // 随机分布几率数组
     integer array      bj_randDistChance
 
     // Last X'd vars
@@ -11439,7 +11471,7 @@ endfunction
 
 
 // Update stock inventory.
-//
+// 更新商店物品库存
 function PerformStockUpdates takes nothing returns nothing
     local integer  pickedItemId
     local itemtype pickedItemType

--- a/static/blizzard.j
+++ b/static/blizzard.j
@@ -1171,7 +1171,7 @@ endfunction
 //***************************************************************************
 
 
-// 对比实数，取最小值
+// 取最小值(比对实数)
 function RMinBJ takes real a, real b returns real
     if (a < b) then
         return a
@@ -1181,7 +1181,7 @@ function RMinBJ takes real a, real b returns real
 endfunction
 
 
-// 对比实数，取最大值
+// 取最大值(比对实数)
 function RMaxBJ takes real a, real b returns real
     if (a < b) then
         return b
@@ -1191,7 +1191,7 @@ function RMaxBJ takes real a, real b returns real
 endfunction
 
 
-// 取实数的绝对值
+// 取绝对值(实数)
 function RAbsBJ takes real a returns real
     if (a >= 0) then
         return a
@@ -1201,7 +1201,7 @@ function RAbsBJ takes real a returns real
 endfunction
 
 
-// 取实数正负标记，输入数值大于等于0返回 1.0，小于0返回 -1.0
+// 取正负标记(实数)，输入值大于等于0返回 1.0，小于0返回 -1.0
 function RSignBJ takes real a returns real
     if (a >= 0.0) then
         return 1.0
@@ -1211,7 +1211,7 @@ function RSignBJ takes real a returns real
 endfunction
 
 
-// 对比整数，取最小值
+// 取最小值(比对整数)
 function IMinBJ takes integer a, integer b returns integer
     if (a < b) then
         return a
@@ -1221,7 +1221,7 @@ function IMinBJ takes integer a, integer b returns integer
 endfunction
 
 
-// 对比整数，取最大值
+// 取最大值(比对整数)
 function IMaxBJ takes integer a, integer b returns integer
     if (a < b) then
         return b
@@ -1231,7 +1231,7 @@ function IMaxBJ takes integer a, integer b returns integer
 endfunction
 
 
-// 取整数的绝对值
+// 取绝对值(整数)
 function IAbsBJ takes integer a returns integer
     if (a >= 0) then
         return a
@@ -1241,7 +1241,7 @@ function IAbsBJ takes integer a returns integer
 endfunction
 
 
-// 取整数正负标记，输入数值大于等于0返回 1，小于0返回 -1
+// 取正负标记(整数)，输入数值大于等于0返回 1，小于0返回 -1
 function ISignBJ takes integer a returns integer
     if (a >= 0) then
         return 1
@@ -1251,55 +1251,55 @@ function ISignBJ takes integer a returns integer
 endfunction
 
 
-// 正弦
+// 取正弦
 function SinBJ takes real degrees returns real
     return Sin(degrees * bj_DEGTORAD)
 endfunction
 
 
-// 余弦
+// 取余弦
 function CosBJ takes real degrees returns real
     return Cos(degrees * bj_DEGTORAD)
 endfunction
 
 
-// 正切
+// 取正切
 function TanBJ takes real degrees returns real
     return Tan(degrees * bj_DEGTORAD)
 endfunction
 
 
-// 反正弦
+// 取反正弦
 function AsinBJ takes real degrees returns real
     return Asin(degrees) * bj_RADTODEG
 endfunction
 
 
-// 反余弦
+// 取反余弦
 function AcosBJ takes real degrees returns real
     return Acos(degrees) * bj_RADTODEG
 endfunction
 
 
-// 2象限反正切 (From Angle)
+// 取2象限反正切 (From Angle)
 function AtanBJ takes real degrees returns real
     return Atan(degrees) * bj_RADTODEG
 endfunction
 
 
-// 4象限反正切
+// 取4象限反正切
 function Atan2BJ takes real y, real x returns real
     return Atan2(y, x) * bj_RADTODEG
 endfunction
 
 
-// 两点之间的角度
+// 取两点之间的角度
 function AngleBetweenPoints takes location locA, location locB returns real
     return bj_RADTODEG * Atan2(GetLocationY(locB) - GetLocationY(locA), GetLocationX(locB) - GetLocationX(locA))
 endfunction
 
 
-// 两点之间的距离
+// 取两点之间的距离
 function DistanceBetweenPoints takes location locA, location locB returns real
     local real dx = GetLocationX(locB) - GetLocationX(locA)
     local real dy = GetLocationY(locB) - GetLocationY(locA)
@@ -1307,7 +1307,7 @@ function DistanceBetweenPoints takes location locA, location locB returns real
 endfunction
 
 
-// 点向指定方向 位移指定距离 
+// 点向指定方向位移指定距离
 function PolarProjectionBJ takes location source, real dist, real angle returns location
     local real x = GetLocationX(source) + dist * Cos(angle * bj_DEGTORAD)
     local real y = GetLocationY(source) + dist * Sin(angle * bj_DEGTORAD)
@@ -1336,7 +1336,7 @@ endfunction
 // Calculate the modulus/remainder of (dividend) divided by (divisor).
 // Examples:  18 mod 5 = 3.  15 mod 5 = 0.  -8 mod 5 = 2.
 //
-// 取余数
+// 取余数（整数）
 function ModuloInteger takes integer dividend, integer divisor returns integer
     local integer modulus = dividend - (dividend / divisor) * divisor
 
@@ -1354,7 +1354,7 @@ endfunction
 // Calculate the modulus/remainder of (dividend) divided by (divisor).
 // Examples:  13.000 mod 2.500 = 0.500.  -6.000 mod 2.500 = 1.500.
 //
-// 取余数
+// 取余数（实数）
 function ModuloReal takes real dividend, real divisor returns real
     local real modulus = dividend - I2R(R2I(dividend / divisor)) * divisor
 
@@ -1381,7 +1381,7 @@ function OffsetRectBJ takes rect r, real dx, real dy returns rect
 endfunction
 
 
-// 将点大小转换为区域
+// 将点转换为区域
 // @param center 中心点位置
 // @param width 宽
 // @param height 高
@@ -1392,13 +1392,13 @@ function RectFromCenterSizeBJ takes location center, real width, real height ret
 endfunction
 
 
-// 矩形是否包含坐标
+// 坐标是否在矩形内
 function RectContainsCoords takes rect r, real x, real y returns boolean
     return (GetRectMinX(r) <= x) and (x <= GetRectMaxX(r)) and (GetRectMinY(r) <= y) and (y <= GetRectMaxY(r))
 endfunction
 
 
-// 区域是否包含点
+// 点是否在矩形内
 function RectContainsLoc takes rect r, location loc returns boolean
     return RectContainsCoords(r, GetLocationX(loc), GetLocationY(loc))
 endfunction
@@ -4868,25 +4868,25 @@ function GetTransportUnitBJ takes nothing returns unit
 endfunction
 
 
-// 载入单位
+// 装载单位
 function GetLoadedUnitBJ takes nothing returns unit
     return GetLoadedUnit()
 endfunction
 
 
-// 单位已经装载
+// 单位是否已被装载
 function IsUnitInTransportBJ takes unit whichUnit, unit whichTransport returns boolean
     return IsUnitInTransport(whichUnit, whichTransport)
 endfunction
 
 
-// 单位正在被送
+// 单位是否正被传送
 function IsUnitLoadedBJ takes unit whichUnit returns boolean
     return IsUnitLoaded(whichUnit)
 endfunction
 
 
-// 单位是隐形的
+// 单位是否隐形
 function IsUnitIllusionBJ takes unit whichUnit returns boolean
     return IsUnitIllusion(whichUnit)
 endfunction
@@ -4986,7 +4986,7 @@ function ReplaceUnitBJ takes unit whichUnit, integer newUnitId, integer unitStat
 endfunction
 
 
-// 最后替换的单位
+// 获取最后替换的单位
 function GetLastReplacedUnitBJ takes nothing returns unit
     return bj_lastReplacedUnit
 endfunction
@@ -5030,7 +5030,7 @@ function RemoveUnitFromStockBJ takes integer unitId, unit whichUnit returns noth
 endfunction
 
 
-// 允许/禁止 使用人口
+// 允许/禁止 单位占用人口
 function SetUnitUseFoodBJ takes boolean enable, unit whichUnit returns nothing
     call SetUnitUseFood(whichUnit, enable)
 endfunction
@@ -5063,7 +5063,7 @@ function CreateDestructableLoc takes integer objectid, location loc, real facing
 endfunction
 
 
-// 创造[可毁坏物](毁坏的)
+// 创造 [可毁坏物](毁坏的)
 function CreateDeadDestructableLocBJ takes integer objectid, location loc, real facing, real scale, integer variation returns destructable
     set bj_lastCreatedDestructable = CreateDeadDestructable(objectid, GetLocationX(loc), GetLocationY(loc), facing, scale, variation)
     return bj_lastCreatedDestructable
@@ -5082,31 +5082,31 @@ function ShowDestructableBJ takes boolean flag, destructable d returns nothing
 endfunction
 
 
-// 设置 无敌/可攻击
+// 设置 可破坏物无敌/可攻击
 function SetDestructableInvulnerableBJ takes destructable d, boolean flag returns nothing
     call SetDestructableInvulnerable(d, flag)
 endfunction
 
 
-// 可毁坏物是无敌的
+// 可毁坏物是否无敌
 function IsDestructableInvulnerableBJ takes destructable d returns boolean
     return IsDestructableInvulnerable(d)
 endfunction
 
 
-// 可毁坏物的位置
+// 获取可毁坏物的位置
 function GetDestructableLoc takes destructable whichDestructable returns location
     return Location(GetDestructableX(whichDestructable), GetDestructableY(whichDestructable))
 endfunction
 
 
-// 选取所有可毁坏物 在区域 做 动作(单一的)
+// 选取指定方形区域所有可毁坏物做动作(单一的)
 function EnumDestructablesInRectAll takes rect r, code actionFunc returns nothing
     call EnumDestructablesInRect(r, null, actionFunc)
 endfunction
 
 
-// 选取所有可毁坏物 在圆周 做 动作(单一的)
+// 选取指定圆形区域所有可毁坏物做动作(单一的)
 function EnumDestructablesInCircleBJFilter takes nothing returns boolean
     local location destLoc = GetDestructableLoc(GetFilterDestructable())
     local boolean result
@@ -5117,13 +5117,13 @@ function EnumDestructablesInCircleBJFilter takes nothing returns boolean
 endfunction
 
 
-// 可毁坏物是死的
+// 可毁坏物是否死亡
 function IsDestructableDeadBJ takes destructable d returns boolean
     return GetDestructableLife(d) <= 0
 endfunction
 
 
-// 可毁坏物是活者的
+// 可毁坏物是否存活
 function IsDestructableAliveBJ takes destructable d returns boolean
     return not IsDestructableDeadBJ(d)
 endfunction
@@ -5131,7 +5131,7 @@ endfunction
 
 // See GroupPickRandomUnitEnum for the details of this algorithm.
 //
-// 区域的 随机可毁坏物 且匹配条件
+// 随机选取方形区域满足指定条件的可毁坏物触发器
 function RandomDestructableInRectBJEnum takes nothing returns nothing
     set bj_destRandomConsidered = bj_destRandomConsidered + 1
     if (GetRandomInt(1,bj_destRandomConsidered) == 1) then
@@ -5141,7 +5141,7 @@ endfunction
 
 
 // Picks a random destructable from within a rect, matching a condition
-//
+// 随机选取方形区域满足指定条件的可毁坏物
 function RandomDestructableInRectBJ takes rect r, boolexpr filter returns destructable
     set bj_destRandomConsidered = 0
     set bj_destRandomCurrentPick = null
@@ -5153,7 +5153,7 @@ endfunction
 
 // Picks a random destructable from within a rect
 //
-// 区域的 随机可毁坏物
+// 随机选取方形区域的可毁坏物
 function RandomDestructableInRectSimpleBJ takes rect r returns destructable
     return RandomDestructableInRectBJ(r, null)
 endfunction
@@ -5161,7 +5161,7 @@ endfunction
 
 // Enumerates within a rect, with a filter to narrow the enumeration down
 // objects within a circular area.
-//
+// 随机选取圆形区域满足指定条件的可毁坏物
 function EnumDestructablesInCircleBJ takes real radius, location loc, code actionFunc returns nothing
     local rect r
 
@@ -5212,7 +5212,7 @@ endfunction
 
 // Determine the elevator's height from its occlusion height.
 //
-// 升降机高度
+// 获取升降机高度
 function GetElevatorHeight takes destructable d returns integer
     local integer height
 

--- a/static/blizzard.j
+++ b/static/blizzard.j
@@ -1344,6 +1344,7 @@ endfunction
 
 
 // 点向指定方向位移指定距离
+// 会生成点，需要排泄
 function PolarProjectionBJ takes location source, real dist, real angle returns location
     local real x = GetLocationX(source) + dist * Cos(angle * bj_DEGTORAD)
     local real y = GetLocationY(source) + dist * Sin(angle * bj_DEGTORAD)
@@ -1364,6 +1365,7 @@ endfunction
 
 
 // 取区域内的随机地点
+// 会生成点，需要排泄
 function GetRandomLocInRect takes rect whichRect returns location
     return Location(GetRandomReal(GetRectMinX(whichRect), GetRectMaxX(whichRect)), GetRandomReal(GetRectMinY(whichRect), GetRectMaxY(whichRect)))
 endfunction
@@ -1406,6 +1408,7 @@ endfunction
 
 
 // 点位移
+// 会生成点，需要排泄
 function OffsetLocation takes location loc, real dx, real dy returns location
     return Location(GetLocationX(loc) + dx, GetLocationY(loc) + dy)
 endfunction
@@ -3615,6 +3618,7 @@ endfunction
 
 
 // 物品的位置
+// 会生成点，需要排泄
 function GetItemLoc takes item whichItem returns location
     return Location(GetItemX(whichItem), GetItemY(whichItem))
 endfunction
@@ -5137,6 +5141,7 @@ endfunction
 
 
 // 获取可毁坏物的位置
+// 会生成点，需要排泄
 function GetDestructableLoc takes destructable whichDestructable returns location
     return Location(GetDestructableX(whichDestructable), GetDestructableY(whichDestructable))
 endfunction
@@ -5501,6 +5506,7 @@ endfunction
 
 
 // 获取传送门的目的地
+// 会生成点，需要排泄
 function WaygateGetDestinationLocBJ takes unit waygate returns location
     return Location(WaygateGetDestinationX(waygate), WaygateGetDestinationY(waygate))
 endfunction
@@ -8895,6 +8901,7 @@ endfunction
 
 
 // <1.24> 从哈希表提取点
+// 若仍需使用该点，请勿排泄
 function LoadLocationHandleBJ takes integer key, integer missionKey, hashtable table returns location
     return LoadLocationHandle(table, missionKey, key)
 endfunction
@@ -9202,12 +9209,14 @@ endfunction
 
 
 // 玩家的初始位置
+// 会生成点，需要排泄
 function GetPlayerStartLocationLoc takes player whichPlayer returns location
     return GetStartLocationLoc(GetPlayerStartLocation(whichPlayer))
 endfunction
 
 
 // 区域中心
+// 会生成点，需要排泄
 function GetRectCenter takes rect whichRect returns location
     return Location(GetRectCenterX(whichRect), GetRectCenterY(whichRect))
 endfunction
@@ -9716,7 +9725,8 @@ endfunction
 //*
 //***************************************************************************
 
-
+// 删除当前开始点多余单位触发器
+// 多余单位是指中立敌对玩家的单位 或 中立被动玩家的非建筑类单位
 function MeleeClearExcessUnit takes nothing returns nothing
     local unit    theUnit = GetEnumUnit()
     local integer owner   = GetPlayerId(GetOwningPlayer(theUnit))
@@ -9732,7 +9742,7 @@ function MeleeClearExcessUnit takes nothing returns nothing
     endif
 endfunction
 
-
+// 选取当前开始点的多余单位
 function MeleeClearNearbyUnits takes real x, real y, real range returns nothing
     local group nearbyUnits
     
@@ -9743,7 +9753,7 @@ function MeleeClearNearbyUnits takes real x, real y, real range returns nothing
 endfunction
 
 
-// 删除多余单位
+// 删除所有玩家开始点多余单位
 function MeleeClearExcessUnits takes nothing returns nothing
     local integer index
     local real    locX
@@ -9775,7 +9785,7 @@ endfunction
 //*
 //***************************************************************************
 
-
+// 寻找玩家开始点附近的金矿触发器
 function MeleeEnumFindNearestMine takes nothing returns nothing
     local unit enumUnit = GetEnumUnit()
     local real dist
@@ -9794,7 +9804,8 @@ function MeleeEnumFindNearestMine takes nothing returns nothing
     endif
 endfunction
 
-
+// 寻找玩家开始点附近的金矿
+// 主要用于对战初始化时创建被缠绕的金矿或闹鬼金矿
 function MeleeFindNearestMine takes location src, real range returns unit
     local group nearbyMines
 
@@ -9810,7 +9821,8 @@ function MeleeFindNearestMine takes location src, real range returns unit
     return bj_meleeNearestMine
 endfunction
 
-// 创建随机英雄（进入游戏前在高级勾选 使用随机英雄）
+// 创建随机英雄
+// 进入游戏前在高级勾选 使用随机英雄
 function MeleeRandomHeroLoc takes player p, integer id1, integer id2, integer id3, integer id4, location loc returns unit
     local unit    hero = null
     local integer roll
@@ -9849,7 +9861,8 @@ endfunction
 
 
 // Returns a location which is (distance) away from (src) in the direction of (targ).
-//
+// 极坐标位移点，点src 沿 点src 到 点targ 的方向位移distance ，附带偏移量 deltaAngle
+// 会生成点，需要排泄
 function MeleeGetProjectedLoc takes location src, location targ, real distance, real deltaAngle returns location
     local real srcX = GetLocationX(src)
     local real srcY = GetLocationY(src)
@@ -9857,7 +9870,8 @@ function MeleeGetProjectedLoc takes location src, location targ, real distance, 
     return Location(srcX + distance * Cos(direction), srcY + distance * Sin(direction))
 endfunction
 
-
+// 取区间值
+// val在minVal~maxVal之外时，若小于minVal，则返回minVal，若大于maxVal，则返回maxVal，在区间内时返回val
 function MeleeGetNearestValueWithin takes real val, real minVal, real maxVal returns real
     if (val < minVal) then
         return minVal
@@ -9868,7 +9882,9 @@ function MeleeGetNearestValueWithin takes real val, real minVal, real maxVal ret
     endif
 endfunction
 
-
+// 取区域内的点（不影响输入点）
+// 当输入点在区域内时，会返回一个相同坐标的新点，当输入点在区域外时，会返回距离输入点最近的区域边界上的新点
+// 会生成点，需要排泄
 function MeleeGetLocWithinRect takes location src, rect r returns location
     local real withinX = MeleeGetNearestValueWithin(GetLocationX(src), GetRectMinX(r), GetRectMaxX(r))
     local real withinY = MeleeGetNearestValueWithin(GetLocationY(src), GetRectMinY(r), GetRectMaxY(r))
@@ -9880,7 +9896,9 @@ endfunction
 //   - 1 Town Hall, placed at start location
 //   - 5 Peasants, placed between start location and nearest gold mine
 //
-// 创建初始单位
+// 创建初始单位 - 人族
+// 创建点 - 玩家开始点
+// 默认包含5个农民，一个一本基地，若启用随机英雄会随机创建1个英雄
 function MeleeStartingUnitsHuman takes player whichPlayer, location startLoc, boolean doHeroes, boolean doCamera, boolean doPreload returns nothing
     local boolean  useRandomHero = IsMapFlagSet(MAP_RANDOM_HERO)
     local real     unitSpacing   = 64.00
@@ -9955,7 +9973,9 @@ endfunction
 // Starting Units for Orc Players
 //   - 1 Great Hall, placed at start location
 //   - 5 Peons, placed between start location and nearest gold mine
-//
+// 创建初始单位 - 兽族
+// 创建点 - 玩家开始点
+// 默认包含5个农民，一个一本基地，若启用随机英雄会随机创建1个英雄
 function MeleeStartingUnitsOrc takes player whichPlayer, location startLoc, boolean doHeroes, boolean doCamera, boolean doPreload returns nothing
     local boolean  useRandomHero = IsMapFlagSet(MAP_RANDOM_HERO)
     local real     unitSpacing   = 64.00
@@ -10027,7 +10047,9 @@ endfunction
 //   - 3 Acolytes, placed between start location and nearest gold mine
 //   - 1 Ghoul, placed between start location and nearest gold mine
 //   - Blight, centered on nearest gold mine, spread across a "large area"
-//
+// 创建初始单位 - 亡灵
+// 创建点 - 玩家开始点
+// 默认包含3个农民，1个食尸鬼，一个一本基地，一座闹鬼金矿（如果附近有金矿），若启用随机英雄会随机创建1个英雄
 function MeleeStartingUnitsUndead takes player whichPlayer, location startLoc, boolean doHeroes, boolean doCamera, boolean doPreload returns nothing
     local boolean  useRandomHero = IsMapFlagSet(MAP_RANDOM_HERO)
     local real     unitSpacing   = 64.00
@@ -10111,7 +10133,9 @@ endfunction
 // Starting Units for Night Elf Players
 //   - 1 Tree of Life, placed by nearest gold mine, already entangled
 //   - 5 Wisps, placed between Tree of Life and nearest gold mine
-//
+// 创建初始单位 - 暗夜
+// 创建点 - 玩家开始点
+// 默认包含5个农民，一个一本基地，一座被缠绕的金矿（如果附近有金矿），若启用随机英雄会随机创建1个英雄
 function MeleeStartingUnitsNightElf takes player whichPlayer, location startLoc, boolean doHeroes, boolean doCamera, boolean doPreload returns nothing
     local boolean  useRandomHero = IsMapFlagSet(MAP_RANDOM_HERO)
     local real     unitSpacing   = 64.00
@@ -10189,7 +10213,9 @@ endfunction
 
 // Starting Units for Players Whose Race is Unknown
 //   - 12 Sheep, placed randomly around the start location
-//
+// 创建初始单位 - 未知种族
+// 创建点 - 随机
+// 默认包含12只绵羊，是的，12只绵羊（'nshe'）
 function MeleeStartingUnitsUnknownRace takes player whichPlayer, location startLoc, boolean doHeroes, boolean doCamera, boolean doPreload returns nothing
     local integer index
 
@@ -10215,7 +10241,7 @@ function MeleeStartingUnitsUnknownRace takes player whichPlayer, location startL
     endif
 endfunction
 
-
+// 创建对战初始单位
 function MeleeStartingUnits takes nothing returns nothing
     local integer  index
     local player   indexPlayer
@@ -10252,7 +10278,8 @@ function MeleeStartingUnits takes nothing returns nothing
 endfunction
 
 
-// 创建初始单位为了玩家
+// 创建初始单位（指定玩家及种族）
+// 默认只支持创建4大对战种族的初始单位，其他种族使用该命令无效
 function MeleeStartingUnitsForPlayer takes race whichRace, player whichPlayer, location loc, boolean doHeroes returns nothing
     // Create initial race-specific starting units
     if (whichRace == RACE_HUMAN) then

--- a/static/blizzard.j
+++ b/static/blizzard.j
@@ -1330,12 +1330,14 @@ endfunction
 
 
 // 取两点之间的角度
+// 两个点仍会保留，如不再使用则需要排泄
 function AngleBetweenPoints takes location locA, location locB returns real
     return bj_RADTODEG * Atan2(GetLocationY(locB) - GetLocationY(locA), GetLocationX(locB) - GetLocationX(locA))
 endfunction
 
 
 // 取两点之间的距离
+// 两个点仍会保留，如不再使用则需要排泄
 function DistanceBetweenPoints takes location locA, location locB returns real
     local real dx = GetLocationX(locB) - GetLocationX(locA)
     local real dy = GetLocationY(locB) - GetLocationY(locA)
@@ -1352,13 +1354,13 @@ function PolarProjectionBJ takes location source, real dist, real angle returns 
 endfunction
 
 
-// 取随机角度
+// 取随机角度（0~360，可以取非整数）
 function GetRandomDirectionDeg takes nothing returns real
     return GetRandomReal(0, 360)
 endfunction
 
 
-// 取随机百分数
+// 取随机实数（0~100，可以取非整数）
 function GetRandomPercentageBJ takes nothing returns real
     return GetRandomReal(0, 100)
 endfunction
@@ -1651,7 +1653,7 @@ endfunction
 // Denotes the end of a queued trigger. Be sure to call this only once per
 // queued trigger, lest you step on the toes of other queued triggers.
 //
-// 完成触发器队列
+// 触发器队列完成
 function QueuedTriggerDoneBJ takes nothing returns nothing
     local integer index
 
@@ -1698,7 +1700,7 @@ function IsTriggerQueueEmptyBJ takes nothing returns boolean
 endfunction
 
 
-// 触发器在队列中
+// 触发器是否在队列中
 function IsTriggerQueuedBJ takes trigger trig returns boolean
     return QueuedTriggerGetIndex(trig) != -1
 endfunction
@@ -1755,7 +1757,8 @@ function PolledWait takes real duration returns nothing
     endif
 endfunction
 
-
+// 根据布尔值获取整数
+// flag为是时返回valueA，反之返回valueB
 function IntegerTertiaryOp takes boolean flag, integer valueA, integer valueB returns integer
     if flag then
         return valueA
@@ -1886,7 +1889,9 @@ endfunction
 
 // Returns a square rect that exactly encompasses the specified circle.
 //
-// 内切圆矩形
+// 将圆形区域转换为矩形区域
+// 以圆心和为中心，直径为边长创建区域
+// 原有区域仍然保留，如不再使用则需要排泄
 function GetRectFromCircleBJ takes location center, real radius returns rect
     local real centerX = GetLocationX(center)
     local real centerY = GetLocationY(center)
@@ -2264,7 +2269,7 @@ function SetCameraOrientControllerForPlayerBJ takes player whichPlayer, unit whi
 endfunction
 
 
-// 改变镜头平滑参数
+// 设置镜头平滑参数
 function CameraSetSmoothingFactorBJ takes real factor returns nothing
     call CameraSetSmoothingFactor(factor)
 endfunction
@@ -2592,7 +2597,7 @@ function RegisterDestDeathInRegionEnum takes nothing returns nothing
 endfunction
 
 
-// 选取指定区域内可毁坏物(毁坏的)
+// 选取指定区域内可破坏物(毁坏的)
 function TriggerRegisterDestDeathInRegionEvent takes trigger trig, rect r returns nothing
     set bj_destInRegionDiesTrig = trig
     set bj_destInRegionDiesCount = 0
@@ -2687,7 +2692,7 @@ function TerrainDeformationStopBJ takes terraindeformation deformation, real dur
 endfunction
 
 
-// 最后创建的可毁坏物
+// 最后创建的可破坏物
 function GetLastCreatedTerrainDeformation takes nothing returns terraindeformation
     return bj_lastCreatedTerrainDeformation
 endfunction
@@ -2779,7 +2784,7 @@ function GetTerrainVarianceBJ takes location where returns integer
 endfunction
 
 
-// 改变地形类型
+// 设置地形类型
 function SetTerrainTypeBJ takes location where, integer terrainType, integer variation, integer area, integer shape returns nothing
     call SetTerrainType(GetLocationX(where), GetLocationY(where), terrainType, variation, area, shape)
 endfunction
@@ -2925,13 +2930,13 @@ function ShowImageBJ takes boolean flag, image whichImage returns nothing
 endfunction
 
 
-// 改变图像位置
+// 设置图像位置
 function SetImagePositionBJ takes image whichImage, location where, real zOffset returns nothing
     call SetImagePosition(whichImage, GetLocationX(where), GetLocationY(where), zOffset)
 endfunction
 
 
-// 改变图像颜色
+// 设置图像颜色
 function SetImageColorBJ takes image whichImage, real red, real green, real blue, real alpha returns nothing
     call SetImageColor(whichImage, PercentTo255(red), PercentTo255(green), PercentTo255(blue), PercentTo255(100.0-alpha))
 endfunction
@@ -3896,7 +3901,7 @@ endfunction
 // Two distinct trigger actions can't share the same function name, so this
 // dummy function simply mimics the behavior of an existing call.
 //
-// 对可毁坏物使用物品
+// 对可破坏物使用物品
 function UnitUseItemDestructable takes unit whichUnit, item whichItem, widget target returns boolean
     return UnitUseItemTarget(whichUnit, whichItem, target)
 endfunction
@@ -3998,7 +4003,7 @@ function SetItemDroppableBJ takes item whichItem, boolean flag returns nothing
 endfunction
 
 
-// 改变物品的所有者
+// 设置物品的所有者
 function SetItemPlayerBJ takes item whichItem, player whichPlayer, boolean changeColor returns nothing
     call SetItemPlayer(whichItem, whichPlayer, changeColor)
 endfunction
@@ -4554,7 +4559,7 @@ function IsUnitGroupEmptyBJ takes group g returns boolean
 endfunction
 
 
-// 单位组的单位在区域触发器动作
+// 选取单位是否在区域内
 function IsUnitGroupInRectBJEnum takes nothing returns nothing
     if not RectContainsUnit(bj_isUnitGroupInRectRect, GetEnumUnit()) then
         set bj_isUnitGroupInRectResult = false
@@ -4563,7 +4568,8 @@ endfunction
 
 
 // Returns true if every unit of the group is within the given rect.
-// 单位组的单位在区域
+// 单位组中的单位是否在指定区域内
+// 全都在区域内才返回是，任意一个单位不在区域内时返回否
 function IsUnitGroupInRectBJ takes group g, rect r returns boolean
     set bj_isUnitGroupInRectResult = true
     set bj_isUnitGroupInRectRect = r
@@ -4698,7 +4704,7 @@ function SetUnitBlendTimeBJ takes unit whichUnit, real blendTime returns nothing
 endfunction
 
 
-// 设置感知敌人距离
+// 设置主动攻击范围
 function SetUnitAcquireRangeBJ takes unit whichUnit, real acquireRange returns nothing
     call SetUnitAcquireRange(whichUnit, acquireRange)
 endfunction
@@ -4722,7 +4728,7 @@ function UnitWakeUpBJ takes unit whichUnit returns nothing
 endfunction
 
 
-// 单位正在睡觉
+// 单位是否正在睡觉
 function UnitIsSleepingBJ takes unit whichUnit returns boolean
     return UnitIsSleeping(whichUnit)
 endfunction
@@ -5053,25 +5059,25 @@ function SetUnitPositionLocFacingLocBJ takes unit whichUnit, location loc, locat
 endfunction
 
 
-// 增加 物品-类型 (到商店)
+// 增加 物品-类型 (指定商店)
 function AddItemToStockBJ takes integer itemId, unit whichUnit, integer currentStock, integer stockMax returns nothing
     call AddItemToStock(whichUnit, itemId, currentStock, stockMax)
 endfunction
 
 
-// 增加 单位-类型 (到商店)
+// 增加 单位-类型 (指定商店)
 function AddUnitToStockBJ takes integer unitId, unit whichUnit, integer currentStock, integer stockMax returns nothing
     call AddUnitToStock(whichUnit, unitId, currentStock, stockMax)
 endfunction
 
 
-// 删除 物品-类型 (从商店)
+// 删除 物品-类型 (指定商店)
 function RemoveItemFromStockBJ takes integer itemId, unit whichUnit returns nothing
     call RemoveItemFromStock(whichUnit, itemId)
 endfunction
 
 
-// 删除 单位-类型 (从商店)
+// 删除 单位-类型 (指定商店)
 function RemoveUnitFromStockBJ takes integer unitId, unit whichUnit returns nothing
     call RemoveUnitFromStock(whichUnit, unitId)
 endfunction
@@ -5103,27 +5109,27 @@ endfunction
 //***************************************************************************
 
 
-// 创造 可毁坏物
+// 创建可破坏物
 function CreateDestructableLoc takes integer objectid, location loc, real facing, real scale, integer variation returns destructable
     set bj_lastCreatedDestructable = CreateDestructable(objectid, GetLocationX(loc), GetLocationY(loc), facing, scale, variation)
     return bj_lastCreatedDestructable
 endfunction
 
 
-// 创造 [可毁坏物](毁坏的)
+// 创建可破坏物(毁坏的)
 function CreateDeadDestructableLocBJ takes integer objectid, location loc, real facing, real scale, integer variation returns destructable
     set bj_lastCreatedDestructable = CreateDeadDestructable(objectid, GetLocationX(loc), GetLocationY(loc), facing, scale, variation)
     return bj_lastCreatedDestructable
 endfunction
 
 
-// 最后创建的可毁坏物
+// 最后创建的可破坏物
 function GetLastCreatedDestructable takes nothing returns destructable
     return bj_lastCreatedDestructable
 endfunction
 
 
-// 显示/隐藏 可毁坏物
+// 显示/隐藏 可破坏物
 function ShowDestructableBJ takes boolean flag, destructable d returns nothing
     call ShowDestructable(d, flag)
 endfunction
@@ -5135,26 +5141,26 @@ function SetDestructableInvulnerableBJ takes destructable d, boolean flag return
 endfunction
 
 
-// 可毁坏物是否无敌
+// 可破坏物是否无敌
 function IsDestructableInvulnerableBJ takes destructable d returns boolean
     return IsDestructableInvulnerable(d)
 endfunction
 
 
-// 获取可毁坏物的位置
+// 获取可破坏物的位置
 // 会生成点，需要排泄
 function GetDestructableLoc takes destructable whichDestructable returns location
     return Location(GetDestructableX(whichDestructable), GetDestructableY(whichDestructable))
 endfunction
 
 
-// 选取指定矩形区域所有可毁坏物做动作(单个动作)
+// 选取指定矩形区域所有可破坏物做动作(单个动作)
 function EnumDestructablesInRectAll takes rect r, code actionFunc returns nothing
     call EnumDestructablesInRect(r, null, actionFunc)
 endfunction
 
 
-// 选取指定圆形区域所有可毁坏物做动作(单个动作)
+// 选取指定圆形区域所有可破坏物做动作(单个动作)
 function EnumDestructablesInCircleBJFilter takes nothing returns boolean
     local location destLoc = GetDestructableLoc(GetFilterDestructable())
     local boolean result
@@ -5165,13 +5171,13 @@ function EnumDestructablesInCircleBJFilter takes nothing returns boolean
 endfunction
 
 
-// 可毁坏物是否死亡
+// 可破坏物是否死亡
 function IsDestructableDeadBJ takes destructable d returns boolean
     return GetDestructableLife(d) <= 0
 endfunction
 
 
-// 可毁坏物是否存活
+// 可破坏物是否存活
 function IsDestructableAliveBJ takes destructable d returns boolean
     return not IsDestructableDeadBJ(d)
 endfunction
@@ -5179,7 +5185,7 @@ endfunction
 
 // See GroupPickRandomUnitEnum for the details of this algorithm.
 //
-// 随机选取矩形区域的可毁坏物触发器
+// 随机选取矩形区域的可破坏物触发器
 function RandomDestructableInRectBJEnum takes nothing returns nothing
     set bj_destRandomConsidered = bj_destRandomConsidered + 1
     if (GetRandomInt(1,bj_destRandomConsidered) == 1) then
@@ -5189,7 +5195,7 @@ endfunction
 
 
 // Picks a random destructable from within a rect, matching a condition
-// 随机选取矩形区域满足过滤的可毁坏物
+// 随机选取矩形区域满足过滤的可破坏物
 function RandomDestructableInRectBJ takes rect r, boolexpr filter returns destructable
     set bj_destRandomConsidered = 0
     set bj_destRandomCurrentPick = null
@@ -5201,7 +5207,7 @@ endfunction
 
 // Picks a random destructable from within a rect
 //
-// 随机选取矩形区域的可毁坏物
+// 随机选取矩形区域的可破坏物
 function RandomDestructableInRectSimpleBJ takes rect r returns destructable
     return RandomDestructableInRectBJ(r, null)
 endfunction
@@ -5209,7 +5215,7 @@ endfunction
 
 // Enumerates within a rect, with a filter to narrow the enumeration down
 // objects within a circular area.
-// 随机选取圆形区域满足过滤的可毁坏物
+// 随机选取圆形区域满足过滤的可破坏物
 function EnumDestructablesInCircleBJ takes real radius, location loc, code actionFunc returns nothing
     local rect r
 
@@ -5223,13 +5229,13 @@ function EnumDestructablesInCircleBJ takes real radius, location loc, code actio
 endfunction
 
 
-// 设置 可毁坏物 生命 (百分比)
+// 设置 可破坏物 生命 (百分比)
 function SetDestructableLifePercentBJ takes destructable d, real percent returns nothing
     call SetDestructableLife(d, GetDestructableMaxLife(d) * percent * 0.01)
 endfunction
 
 
-// 设置 可毁坏物 最大生命
+// 设置 可破坏物 最大生命
 function SetDestructableMaxLifeBJ takes destructable d, real max returns nothing
     call SetDestructableMaxLife(d, max)
 endfunction
@@ -5692,7 +5698,7 @@ function ForcePickRandomPlayer takes force whichForce returns player
     return bj_forceRandomCurrentPick
 endfunction
 
-// 选取区域内所有单位触发器动作
+// 选取矩形区域内所有单位触发器动作
 function EnumUnitsSelected takes player whichPlayer, boolexpr enumFilter, code enumAction returns nothing
     local group g = CreateGroup()
     call SyncSelections()
@@ -5703,7 +5709,7 @@ function EnumUnitsSelected takes player whichPlayer, boolexpr enumFilter, code e
 endfunction
 
 
-// 选取区域内所有单位（过滤）
+// 选取矩形区域内所有单位（过滤）
 function GetUnitsInRectMatching takes rect r, boolexpr filter returns group
     local group g = CreateGroup()
     call GroupEnumUnitsInRect(g, r, filter)
@@ -5712,7 +5718,7 @@ function GetUnitsInRectMatching takes rect r, boolexpr filter returns group
 endfunction
 
 
-// 选取区域内所有单位
+// 选取矩形区域内所有单位
 function GetUnitsInRectAll takes rect r returns group
     return GetUnitsInRectMatching(r, null)
 endfunction
@@ -5976,13 +5982,13 @@ function ResetUnitAnimation takes unit whichUnit returns nothing
 endfunction
 
 
-// 改变单位动画速度
+// 设置单位动画速度
 function SetUnitTimeScalePercent takes unit whichUnit, real percentScale returns nothing
     call SetUnitTimeScale(whichUnit, percentScale * 0.01)
 endfunction
 
 
-// 改变单位尺寸
+// 设置单位尺寸
 function SetUnitScalePercent takes unit whichUnit, real percentScaleX, real percentScaleY, real percentScaleZ returns nothing
     call SetUnitScale(whichUnit, percentScaleX * 0.01, percentScaleY * 0.01, percentScaleZ * 0.01)
 endfunction
@@ -5992,25 +5998,25 @@ endfunction
 // is reversed so as to be displayed as transparency, and all four parameters
 // are treated as percentages rather than bytes.
 //
-// 改变单位着色
+// 设置单位着色
 function SetUnitVertexColorBJ takes unit whichUnit, real red, real green, real blue, real transparency returns nothing
     call SetUnitVertexColor(whichUnit, PercentTo255(red), PercentTo255(green), PercentTo255(blue), PercentTo255(100.0-transparency))
 endfunction
 
 
-// 闪动指示器为了单位
+// 闪动指示器（指定单位）
 function UnitAddIndicatorBJ takes unit whichUnit, real red, real green, real blue, real transparency returns nothing
     call AddIndicator(whichUnit, PercentTo255(red), PercentTo255(green), PercentTo255(blue), PercentTo255(100.0-transparency))
 endfunction
 
 
-// 闪动指示器为了可毁坏物
+// 闪动指示器（指定可破坏物）
 function DestructableAddIndicatorBJ takes destructable whichDestructable, real red, real green, real blue, real transparency returns nothing
     call AddIndicator(whichDestructable, PercentTo255(red), PercentTo255(green), PercentTo255(blue), PercentTo255(100.0-transparency))
 endfunction
 
 
-// 闪动指示器为了物品
+// 闪动指示器（指定物品）
 function ItemAddIndicatorBJ takes item whichItem, real red, real green, real blue, real transparency returns nothing
     call AddIndicator(whichItem, PercentTo255(red), PercentTo255(green), PercentTo255(blue), PercentTo255(100.0-transparency))
 endfunction
@@ -6044,19 +6050,19 @@ function QueueUnitAnimationBJ takes unit whichUnit, string whichAnimation return
 endfunction
 
 
-// 设置可毁坏物动画
+// 设置可破坏物动画
 function SetDestructableAnimationBJ takes destructable d, string whichAnimation returns nothing
     call SetDestructableAnimation(d, whichAnimation)
 endfunction
 
 
-// 队列可毁坏物动画
+// 队列可破坏物动画
 function QueueDestructableAnimationBJ takes destructable d, string whichAnimation returns nothing
     call QueueDestructableAnimation(d, whichAnimation)
 endfunction
 
 
-// 改变可毁坏物动画速度
+// 设置可破坏物动画速度
 function SetDestAnimationSpeedPercent takes destructable d, real percentScale returns nothing
     call SetDestructableAnimationSpeed(d, percentScale * 0.01)
 endfunction
@@ -6076,7 +6082,7 @@ function DialogDisplayBJ takes boolean flag, dialog whichDialog, player whichPla
 endfunction
 
 
-// 改变 对话框 标题
+// 设置 对话框 标题
 function DialogSetMessageBJ takes dialog whichDialog, string message returns nothing
     call DialogSetMessage(whichDialog, message)
 endfunction
@@ -6256,7 +6262,7 @@ endfunction
 
 
 // Test to see if two players are co-allied (allied with each other).
-// 玩家组是否联盟
+// 玩家组是否相互联盟（被动联盟，互不侵犯）
 function PlayersAreCoAllied takes player playerA, player playerB returns boolean
     // Players are considered to be allied with themselves.
     if (playerA == playerB) then
@@ -6323,7 +6329,8 @@ endfunction
 
 // Creates a 'Neutral Victim' player slot.  This slot is passive towards all
 // other players, but all other players are aggressive towards him/her.
-// 
+// 配置中立被动玩家联盟状态
+// 设置所有玩家和中立被动玩家相互结盟（被动结盟，互不侵犯）
 function ConfigureNeutralVictim takes nothing returns nothing
     local integer index
     local player indexPlayer
@@ -6350,14 +6357,14 @@ function ConfigureNeutralVictim takes nothing returns nothing
 endfunction
 
 
-// 设置玩家所有单位变更为中立受害玩家控制
+// 设置玩家所有单位变更为中立被动玩家控制
 function MakeUnitsPassiveForPlayerEnum takes nothing returns nothing
     call SetUnitOwner(GetEnumUnit(), Player(bj_PLAYER_NEUTRAL_VICTIM), false)
 endfunction
 
 
 // Change ownership for every unit of (whichPlayer)'s team to neutral passive.
-// 创建中立被动玩家单位
+// 将指定玩家的单位移交给中立被动玩家
 function MakeUnitsPassiveForPlayer takes player whichPlayer returns nothing
     local group   playerUnits = CreateGroup()
     call CachePlayerHeroData(whichPlayer)
@@ -6368,7 +6375,7 @@ endfunction
 
 
 // Change ownership for every unit of (whichPlayer)'s team to neutral passive.
-// 创建中立被动玩家队伍
+// 联盟玩家的单位全部移交给中立被动玩家
 function MakeUnitsPassiveForTeam takes player whichPlayer returns nothing
     local integer playerIndex
     local player  indexPlayer
@@ -6460,7 +6467,7 @@ function MeleeDefeatDialogBJ takes player whichPlayer, boolean leftGame returns 
     call StartSoundForPlayerBJ( whichPlayer, bj_defeatDialogSound )
 endfunction
 
-//游戏结束
+// 游戏结束
 function GameOverDialogBJ takes player whichPlayer, boolean leftGame returns nothing
     local trigger t = CreateTrigger()
     local dialog  d = DialogCreate()
@@ -6484,7 +6491,7 @@ function GameOverDialogBJ takes player whichPlayer, boolean leftGame returns not
     call StartSoundForPlayerBJ( whichPlayer, bj_defeatDialogSound )
 endfunction
 
-//删除存档
+// 剔除玩家并保留单位
 function RemovePlayerPreserveUnitsBJ takes player whichPlayer, playergameresult gameResult, boolean leftGame returns nothing
     if AllowVictoryDefeat(gameResult) then
 
@@ -6748,13 +6755,13 @@ function QuestSetEnabledBJ takes boolean enabled, quest whichQuest returns nothi
 endfunction
 
 
-// 改变任务标题
+// 设置任务标题
 function QuestSetTitleBJ takes quest whichQuest, string title returns nothing
     call QuestSetTitle(whichQuest, title)
 endfunction
 
 
-// 改变任务文本内容
+// 设置任务文本内容
 function QuestSetDescriptionBJ takes quest whichQuest, string description returns nothing
     call QuestSetDescription(whichQuest, description)
 endfunction
@@ -6793,7 +6800,7 @@ function CreateQuestItemBJ takes quest whichQuest, string description returns qu
 endfunction
 
 
-// 改变任务完成条件内容
+// 设置任务完成条件内容
 function QuestItemSetDescriptionBJ takes questitem whichQuestItem, string description returns nothing
     call QuestItemSetDescription(whichQuestItem, description)
 endfunction
@@ -6825,7 +6832,7 @@ function DestroyDefeatConditionBJ takes defeatcondition whichCondition returns n
 endfunction
 
 
-// 改变失败条件的内容
+// 设置失败条件的内容
 function DefeatConditionSetDescriptionBJ takes defeatcondition whichCondition, string description returns nothing
     call DefeatConditionSetDescription(whichCondition, description)
 endfunction
@@ -6981,25 +6988,25 @@ function DestroyTimerDialogBJ takes timerdialog td returns nothing
 endfunction
 
 
-// 改变计时器窗口标题
+// 设置计时器窗口标题
 function TimerDialogSetTitleBJ takes timerdialog td, string title returns nothing
     call TimerDialogSetTitle(td, title)
 endfunction
 
 
-// 改变计时器标题颜色
+// 设置计时器标题颜色
 function TimerDialogSetTitleColorBJ takes timerdialog td, real red, real green, real blue, real transparency returns nothing
     call TimerDialogSetTitleColor(td, PercentTo255(red), PercentTo255(green), PercentTo255(blue), PercentTo255(100.0-transparency))
 endfunction
 
 
-// 改变计时器窗口时间颜色
+// 设置计时器窗口时间颜色
 function TimerDialogSetTimeColorBJ takes timerdialog td, real red, real green, real blue, real transparency returns nothing
     call TimerDialogSetTimeColor(td, PercentTo255(red), PercentTo255(green), PercentTo255(blue), PercentTo255(100.0-transparency))
 endfunction
 
 
-// 改变计时器窗口速度
+// 设置计时器窗口速度
 function TimerDialogSetSpeedBJ takes timerdialog td, real speedMultFactor returns nothing
     call TimerDialogSetSpeed(td, speedMultFactor)
 endfunction
@@ -7044,56 +7051,56 @@ function LeaderboardResizeBJ takes leaderboard lb returns nothing
 endfunction
 
 
-// 改变排行榜中玩家的 数值
+// 设置排行榜中玩家的 数值
 function LeaderboardSetPlayerItemValueBJ takes player whichPlayer, leaderboard lb, integer val returns nothing
     call LeaderboardSetItemValue(lb, LeaderboardGetPlayerIndex(lb, whichPlayer), val)
 endfunction
 
 
-// 改变排行榜中玩家 标签
+// 设置排行榜中玩家 标签
 function LeaderboardSetPlayerItemLabelBJ takes player whichPlayer, leaderboard lb, string val returns nothing
     call LeaderboardSetItemLabel(lb, LeaderboardGetPlayerIndex(lb, whichPlayer), val)
 endfunction
 
 
-// 改变排行榜中玩家的 风格
+// 设置排行榜中玩家的 风格
 function LeaderboardSetPlayerItemStyleBJ takes player whichPlayer, leaderboard lb, boolean showLabel, boolean showValue, boolean showIcon returns nothing
     call LeaderboardSetItemStyle(lb, LeaderboardGetPlayerIndex(lb, whichPlayer), showLabel, showValue, showIcon)
 endfunction
 
 
-// 改变排行榜中玩家的 标签颜色
+// 设置排行榜中玩家的 标签颜色
 function LeaderboardSetPlayerItemLabelColorBJ takes player whichPlayer, leaderboard lb, real red, real green, real blue, real transparency returns nothing
     call LeaderboardSetItemLabelColor(lb, LeaderboardGetPlayerIndex(lb, whichPlayer), PercentTo255(red), PercentTo255(green), PercentTo255(blue), PercentTo255(100.0-transparency))
 endfunction
 
 
-// 改变排行榜中玩家的 数值颜色
+// 设置排行榜中玩家的 数值颜色
 function LeaderboardSetPlayerItemValueColorBJ takes player whichPlayer, leaderboard lb, real red, real green, real blue, real transparency returns nothing
     call LeaderboardSetItemValueColor(lb, LeaderboardGetPlayerIndex(lb, whichPlayer), PercentTo255(red), PercentTo255(green), PercentTo255(blue), PercentTo255(100.0-transparency))
 endfunction
 
 
-// 改变排行榜 标签颜色
+// 设置排行榜 标签颜色
 function LeaderboardSetLabelColorBJ takes leaderboard lb, real red, real green, real blue, real transparency returns nothing
     call LeaderboardSetLabelColor(lb, PercentTo255(red), PercentTo255(green), PercentTo255(blue), PercentTo255(100.0-transparency))
 endfunction
 
 
-// 改变排行榜 数值颜色
+// 设置排行榜 数值颜色
 function LeaderboardSetValueColorBJ takes leaderboard lb, real red, real green, real blue, real transparency returns nothing
     call LeaderboardSetValueColor(lb, PercentTo255(red), PercentTo255(green), PercentTo255(blue), PercentTo255(100.0-transparency))
 endfunction
 
 
-// 改变排行榜标题
+// 设置排行榜标题
 function LeaderboardSetLabelBJ takes leaderboard lb, string label returns nothing
     call LeaderboardSetLabel(lb, label)
     call LeaderboardResizeBJ(lb)
 endfunction
 
 
-// 改变排行榜风格
+// 设置排行榜风格
 function LeaderboardSetStyleBJ takes leaderboard lb, boolean showLabel, boolean showNames, boolean showValues, boolean showIcons returns nothing
     call LeaderboardSetStyle(lb, showLabel, showNames, showValues, showIcons)
 endfunction
@@ -7272,7 +7279,7 @@ function MultiboardMinimizeBJ takes boolean minimize, multiboard mb returns noth
 endfunction
 
 
-// 改变 多列面板 标题颜色
+// 设置 多列面板 标题颜色
 function MultiboardSetTitleTextColorBJ takes multiboard mb, real red, real green, real blue, real transparency returns nothing
     call MultiboardSetTitleTextColor(mb, PercentTo255(red), PercentTo255(green), PercentTo255(blue), PercentTo255(100.0-transparency))
 endfunction
@@ -7473,7 +7480,7 @@ function TextTagSpeed2Velocity takes real speed returns real
 endfunction
 
 
-// 改变漂浮文字颜色
+// 设置漂浮文字颜色
 function SetTextTagColorBJ takes texttag tt, real red, real green, real blue, real transparency returns nothing
     call SetTextTagColor(tt, PercentTo255(red), PercentTo255(green), PercentTo255(blue), PercentTo255(100.0-transparency))
 endfunction
@@ -7489,7 +7496,7 @@ function SetTextTagVelocityBJ takes texttag tt, real speed, real angle returns n
 endfunction
 
 
-// 改变漂浮文字内容
+// 设置漂浮文字内容
 function SetTextTagTextBJ takes texttag tt, string s, real size returns nothing
     local real textHeight = TextTagSize2Height(size)
 
@@ -7497,13 +7504,13 @@ function SetTextTagTextBJ takes texttag tt, string s, real size returns nothing
 endfunction
 
 
-// 改变漂浮文字位置到指定点
+// 设置漂浮文字位置到指定点
 function SetTextTagPosBJ takes texttag tt, location loc, real zOffset returns nothing
     call SetTextTagPos(tt, GetLocationX(loc), GetLocationY(loc), zOffset)
 endfunction
 
 
-// 改变漂浮文字位置到指定单位
+// 设置漂浮文字位置到指定单位
 function SetTextTagPosUnitBJ takes texttag tt, unit whichUnit, real zOffset returns nothing
     call SetTextTagPosUnit(tt, whichUnit, zOffset)
 endfunction
@@ -7521,25 +7528,25 @@ function SetTextTagPermanentBJ takes texttag tt, boolean flag returns nothing
 endfunction
 
 
-// 改变漂浮文字已存在时间
+// 设置漂浮文字已存在时间
 function SetTextTagAgeBJ takes texttag tt, real age returns nothing
     call SetTextTagAge(tt, age)
 endfunction
 
 
-// 改变漂浮文字存在时限
+// 设置漂浮文字存在时限
 function SetTextTagLifespanBJ takes texttag tt, real lifespan returns nothing
     call SetTextTagLifespan(tt, lifespan)
 endfunction
 
 
-// 改变漂浮文字淡化点
+// 设置漂浮文字淡化点
 function SetTextTagFadepointBJ takes texttag tt, real fadepoint returns nothing
     call SetTextTagFadepoint(tt, fadepoint)
 endfunction
 
 
-// 创建漂浮文字在 点
+// 创建漂浮文字在指定点
 function CreateTextTagLocBJ takes string s, location loc, real zOffset, real size, real red, real green, real blue, real transparency returns texttag
     set bj_lastCreatedTextTag = CreateTextTag()
     call SetTextTagTextBJ(bj_lastCreatedTextTag, s, size)
@@ -7550,7 +7557,7 @@ function CreateTextTagLocBJ takes string s, location loc, real zOffset, real siz
 endfunction
 
 
-// 创建漂浮文字在单位
+// 创建漂浮文字在指定单位
 function CreateTextTagUnitBJ takes string s, unit whichUnit, real zOffset, real size, real red, real green, real blue, real transparency returns texttag
     set bj_lastCreatedTextTag = CreateTextTag()
     call SetTextTagTextBJ(bj_lastCreatedTextTag, s, size)
@@ -7620,7 +7627,7 @@ function SetUserControlForceOff takes force whichForce returns nothing
 endfunction
 
 
-// 信箱模式关
+// 关闭信箱模式
 function ShowInterfaceForceOn takes force whichForce, real fadeDuration returns nothing
     if (IsPlayerInForce(GetLocalPlayer(), whichForce)) then
         // Use only local code (no net traffic) within this block to avoid desyncs.
@@ -7629,7 +7636,7 @@ function ShowInterfaceForceOn takes force whichForce, real fadeDuration returns 
 endfunction
 
 
-// 信箱模式开
+// 开启信箱模式
 function ShowInterfaceForceOff takes force whichForce, real fadeDuration returns nothing
     if (IsPlayerInForce(GetLocalPlayer(), whichForce)) then
         // Use only local code (no net traffic) within this block to avoid desyncs.
@@ -7637,7 +7644,7 @@ function ShowInterfaceForceOff takes force whichForce, real fadeDuration returns
     endif
 endfunction
 
-
+// 发送小地图信号（指定坐标，指定玩家组）触发器动作
 function PingMinimapForForce takes force whichForce, real x, real y, real duration returns nothing
     if (IsPlayerInForce(GetLocalPlayer(), whichForce)) then
         // Use only local code (no net traffic) within this block to avoid desyncs.
@@ -7647,12 +7654,12 @@ function PingMinimapForForce takes force whichForce, real x, real y, real durati
 endfunction
 
 
-// 小地图闪光
+// 发送小地图信号（指定点，指定玩家组）
 function PingMinimapLocForForce takes force whichForce, location loc, real duration returns nothing
     call PingMinimapForForce(whichForce, GetLocationX(loc), GetLocationY(loc), duration)
 endfunction
 
-
+// 发送小地图信号（指定坐标，指定玩家）
 function PingMinimapForPlayer takes player whichPlayer, real x, real y, real duration returns nothing
     if (GetLocalPlayer() == whichPlayer) then
         // Use only local code (no net traffic) within this block to avoid desyncs.
@@ -7661,12 +7668,12 @@ function PingMinimapForPlayer takes player whichPlayer, real x, real y, real dur
     endif
 endfunction
 
-
+// 发送小地图信号（指定点，指定玩家）
 function PingMinimapLocForPlayer takes player whichPlayer, location loc, real duration returns nothing
     call PingMinimapForPlayer(whichPlayer, GetLocationX(loc), GetLocationY(loc), duration)
 endfunction
 
-
+// 发送小地图信号颜色（指定坐标，指定颜色，指定玩家组）
 function PingMinimapForForceEx takes force whichForce, real x, real y, real duration, integer style, real red, real green, real blue returns nothing
     local integer red255   = PercentTo255(red)
     local integer green255 = PercentTo255(green)
@@ -7695,7 +7702,7 @@ function PingMinimapForForceEx takes force whichForce, real x, real y, real dura
 endfunction
 
 
-// 小地图闪光有颜色
+// 发送小地图信号颜色（指定点，指定颜色，指定玩家组）
 function PingMinimapLocForForceEx takes force whichForce, location loc, real duration, integer style, real red, real green, real blue returns nothing
     call PingMinimapForForceEx(whichForce, GetLocationX(loc), GetLocationY(loc), duration, style, red, green, blue)
 endfunction
@@ -8189,7 +8196,7 @@ endfunction
 // including a rescue sound, flashing selection circle, ownership change,
 // and optionally a unit color change.
 //
-// 可营救单位
+// 设置可营救单位
 function RescueUnitBJ takes unit whichUnit, player rescuer, boolean changeColor returns nothing
     if IsUnitDeadBJ(whichUnit) or (GetOwningPlayer(whichUnit) == rescuer) then
         return
@@ -8201,7 +8208,7 @@ function RescueUnitBJ takes unit whichUnit, player rescuer, boolean changeColor 
     call PingMinimapForPlayer(rescuer, GetUnitX(whichUnit), GetUnitY(whichUnit), bj_RESCUE_PING_TIME)
 endfunction
 
-
+// 初始化可营救玩家单位触发器动作
 function TriggerActionUnitRescuedBJ takes nothing returns nothing
     local unit theUnit = GetTriggerUnit()
 
@@ -8303,19 +8310,19 @@ function SetPlayerTechMaxAllowedSwap takes integer techid, integer maximum, play
 endfunction
 
 
-// 设置英雄 的训练限制
+// 设置英雄的训练数量上限
 function SetPlayerMaxHeroesAllowed takes integer maximum, player whichPlayer returns nothing
     call SetPlayerTechMaxAllowed(whichPlayer, 'HERO', maximum)
 endfunction
 
 
-// 科技等级
+// 获取科技等级
 function GetPlayerTechCountSimple takes integer techid, player whichPlayer returns integer
     return GetPlayerTechCount(whichPlayer, techid, true)
 endfunction
 
 
-// 最大科技等级
+// 获取最大科技等级
 function GetPlayerTechMaxAllowedSwap takes integer techid, player whichPlayer returns integer
     return GetPlayerTechMaxAllowed(whichPlayer, techid)
 endfunction
@@ -8334,7 +8341,7 @@ endfunction
 //*
 //***************************************************************************
 
-// 设置读取地图画面
+// 设置读图背景（根据战役关卡设置）
 function SetCampaignMenuRaceBJ takes integer campaignNumber returns nothing
     if (campaignNumber == bj_CAMPAIGN_INDEX_T) then
         call SetCampaignMenuRace(RACE_OTHER)
@@ -8461,44 +8468,44 @@ function GetLastCreatedGameCacheBJ takes nothing returns gamecache
 endfunction
 
 
-// <1.24> 新建哈希表
+// <1.24> 创建哈希表
 function InitHashtableBJ takes nothing returns hashtable
     set bj_lastCreatedHashtable = InitHashtable()
     return bj_lastCreatedHashtable
 endfunction
 
 
-// 最后创建的哈希表
+// 获取最后创建的哈希表
 function GetLastCreatedHashtableBJ takes nothing returns hashtable
     return bj_lastCreatedHashtable
 endfunction
 
 
-// 贮藏 实数
+// 记录 实数
 function StoreRealBJ takes real value, string key, string missionKey, gamecache cache returns nothing
     call StoreReal(cache, missionKey, key, value)
 endfunction
 
 
-// 贮藏 整数
+// 记录 整数
 function StoreIntegerBJ takes integer value, string key, string missionKey, gamecache cache returns nothing
     call StoreInteger(cache, missionKey, key, value)
 endfunction
 
 
-// 贮藏 布尔变量
+// 记录 布尔值
 function StoreBooleanBJ takes boolean value, string key, string missionKey, gamecache cache returns nothing
     call StoreBoolean(cache, missionKey, key, value)
 endfunction
 
 
-// 贮藏 字串符
+// 记录 字串符
 function StoreStringBJ takes string value, string key, string missionKey, gamecache cache returns boolean
     return StoreString(cache, missionKey, key, value)
 endfunction
 
 
-// 贮藏 单位
+// 记录 单位
 function StoreUnitBJ takes unit whichUnit, string key, string missionKey, gamecache cache returns boolean
     return StoreUnit(cache, missionKey, key, whichUnit)
 endfunction
@@ -9373,7 +9380,7 @@ function IsPointBlightedBJ takes location where returns boolean
 endfunction
 
 
-// 改变玩家颜色
+// 设置玩家颜色
 function SetPlayerColorBJEnum takes nothing returns nothing
     call SetUnitColor(GetEnumUnit(), bj_setPlayerTargetColor)
 endfunction
@@ -9428,7 +9435,7 @@ endfunction
 // Two distinct trigger actions can't share the same function name, so this
 // dummy function simply mimics the behavior of an existing call.
 //
-// 给单位发送命令到 可毁坏物
+// 给单位发送命令到 可破坏物
 function IssueTargetDestructableOrder takes unit whichUnit, string order, widget targetWidget returns boolean
     return IssueTargetOrder( whichUnit, order, targetWidget )
 endfunction
@@ -9462,7 +9469,7 @@ endfunction
 // Two distinct trigger actions can't share the same function name, so this
 // dummy function simply mimics the behavior of an existing call.
 //
-// 发送单位组命令到 可毁坏物
+// 发送单位组命令到 可破坏物
 function GroupTargetDestructableOrder takes group whichGroup, string order, widget targetWidget returns boolean
     return GroupTargetOrder( whichGroup, order, targetWidget )
 endfunction
@@ -9473,7 +9480,7 @@ function GroupTargetItemOrder takes group whichGroup, string order, widget targe
 endfunction
 
 
-// 垂死的可毁坏物
+// 垂死的可破坏物
 function GetDyingDestructable takes nothing returns destructable
     return GetTriggerDestructable()
 endfunction
@@ -9493,7 +9500,7 @@ function SetUnitRallyUnit takes unit whichUnit, unit targUnit returns nothing
 endfunction
 
 
-// 设置 聚集点 在可毁坏物
+// 设置 聚集点 在可破坏物
 function SetUnitRallyDestructable takes unit whichUnit, destructable targDest returns nothing
     call IssueTargetOrder(whichUnit, "setrally", targDest)
 endfunction
@@ -10384,7 +10391,7 @@ endfunction
 //*
 //***************************************************************************
 
-
+// 判断指定玩家是否仍有敌人，即判断是否未胜利
 function MeleePlayerIsOpponent takes integer playerIndex, integer opponentIndex returns boolean
     local player thePlayer = Player(playerIndex)
     local player theOpponent = Player(opponentIndex)
@@ -10420,7 +10427,7 @@ endfunction
 
 
 // Count buildings currently owned by all allies, including the player themself.
-//
+// 统计所有盟友（包括玩家自己）拥有的建筑数量
 function MeleeGetAllyStructureCount takes player whichPlayer returns integer
     local integer    playerIndex
     local integer    buildingCount
@@ -10474,7 +10481,7 @@ endfunction
 // structures currently upgrading or under construction.
 //
 // Key structures: Town Hall, Great Hall, Tree of Life, Necropolis
-//
+// 统计所有尚未被击败的盟友（包括玩家自己）建筑数量
 function MeleeGetAllyKeyStructureCount takes player whichPlayer returns integer
     local integer    playerIndex
     local player     indexPlayer
@@ -10498,7 +10505,8 @@ endfunction
 
 
 // Enum: Draw out a specific player.
-//
+// 选择胜利玩家做动作，该玩家的获胜方式为系统随机抽签
+// 缓存玩家数据，显示胜利对话框
 function MeleeDoDrawEnum takes nothing returns nothing
     local player thePlayer = GetEnumPlayer()
 
@@ -10508,7 +10516,9 @@ endfunction
 
 
 // Enum: Victory out a specific player.
-//
+// 选择胜利玩家做动作，该玩家的获胜方式为凭实力赢得比赛
+// 缓存玩家数据，显示胜利对话框
+// 系统还存在一种随机抽取玩家获胜的骚操作
 function MeleeDoVictoryEnum takes nothing returns nothing
     local player thePlayer = GetEnumPlayer()
     local integer playerIndex = GetPlayerId(thePlayer)
@@ -10522,7 +10532,8 @@ endfunction
 
 
 // Defeat out a specific player.
-//
+// 失败玩家触发器动作
+// 创建失败对话框
 function MeleeDoDefeat takes player whichPlayer returns nothing
     set bj_meleeDefeated[GetPlayerId(whichPlayer)] = true
     call RemovePlayerPreserveUnitsBJ(whichPlayer, PLAYER_GAME_RESULT_DEFEAT, false)
@@ -10530,7 +10541,8 @@ endfunction
 
 
 // Enum: Defeat out a specific player.
-//
+// 选择失败玩家做动作
+// 缓存玩家数据，移交玩家所有单位给中立被动玩家，显示失败对话框
 function MeleeDoDefeatEnum takes nothing returns nothing
     local player thePlayer = GetEnumPlayer()
 
@@ -10542,7 +10554,7 @@ endfunction
 
 
 // A specific player left the game.
-//
+// 玩家离开游戏触发器动作
 function MeleeDoLeave takes player whichPlayer returns nothing
     if (GetIntegerGameState(GAME_STATE_DISCONNECTED) != 0) then
         call GameOverDialogBJ( whichPlayer, true )
@@ -10722,12 +10734,13 @@ endfunction
 
 
 // Returns a race-specific "build X" label for cripple timers.
-//
+// 显示默认暴露信息
+// 告知所有玩家，哪个玩家因为失去了基地而被暴露位置
 function MeleeGetCrippledRevealedMessage takes player whichPlayer returns string
     return GetLocalizedString("CRIPPLE_REVEALING_PREFIX") + GetPlayerName(whichPlayer) + GetLocalizedString("CRIPPLE_REVEALING_POSTFIX")
 endfunction
 
-
+// 设置指定玩家是否暴露位置（开始点）
 function MeleeExposePlayer takes player whichPlayer, boolean expose returns nothing
     local integer playerIndex
     local player  indexPlayer
@@ -10751,7 +10764,8 @@ function MeleeExposePlayer takes player whichPlayer, boolean expose returns noth
     call DestroyForce(toExposeTo)
 endfunction
 
-
+// 对所有玩家暴露 在规定时间未补造基地玩家 的位置（开始点）
+// 默认在对战模式胜负判定规则下运行
 function MeleeExposeAllPlayers takes nothing returns nothing
     local integer playerIndex
     local player  indexPlayer
@@ -10789,7 +10803,7 @@ function MeleeExposeAllPlayers takes nothing returns nothing
     call DestroyForce( toExposeTo )
 endfunction
 
-
+// 暴露计时器倒计时结束
 function MeleeCrippledPlayerTimeout takes nothing returns nothing
     local timer expiredTimer = GetExpiredTimer()
     local integer playerIndex
@@ -10906,6 +10920,7 @@ endfunction
 
 // Determine if the lost unit should result in any defeats or victories.
 // 检查残余单位
+// 残余单位：判断玩家当前是否有任意单位存活
 function MeleeCheckLostUnit takes unit lostUnit returns nothing
     local player lostUnitOwner = GetOwningPlayer(lostUnit)
 
@@ -10934,11 +10949,13 @@ function MeleeCheckAddedUnit takes unit addedUnit returns nothing
 endfunction
 
 // 检查是否需要添加残余单位（取消建筑建造触发）
+// 残余单位：判断玩家当前是否有任意单位存活
 function MeleeTriggerActionConstructCancel takes nothing returns nothing
     call MeleeCheckLostUnit(GetCancelledStructure())
 endfunction
 
 // 检查是否需要添加残余单位（单位死亡触发）
+// 残余单位：判断玩家当前是否有任意单位存活
 function MeleeTriggerActionUnitDeath takes nothing returns nothing
     if (IsUnitType(GetDyingUnit(), UNIT_TYPE_STRUCTURE)) then
         call MeleeCheckLostUnit(GetDyingUnit())
@@ -10946,6 +10963,7 @@ function MeleeTriggerActionUnitDeath takes nothing returns nothing
 endfunction
 
 // 检查是否需要添加残余单位（建造建筑触发）
+// 残余单位：判断玩家当前是否有任意单位存活
 function MeleeTriggerActionUnitConstructionStart takes nothing returns nothing
     call MeleeCheckAddedUnit(GetConstructingStructure())
 endfunction
@@ -10973,7 +10991,7 @@ function MeleeTriggerActionPlayerDefeated takes nothing returns nothing
     call MeleeCheckForLosersAndVictors()
 endfunction
 
-// 游戏结束时玩家存活触发器
+// 游戏结束时操作存活玩家的触发器
 function MeleeTriggerActionPlayerLeft takes nothing returns nothing
     local player thePlayer = GetTriggerPlayer()
 
@@ -11002,7 +11020,7 @@ function MeleeTriggerActionPlayerLeft takes nothing returns nothing
     call MeleeCheckForLosersAndVictors()
 endfunction
 
-// 改变联盟状态触发器动作
+// 判定盟友胜负
 function MeleeTriggerActionAllianceChange takes nothing returns nothing
     call MeleeCheckForLosersAndVictors()
     call MeleeCheckForCrippledPlayers()
@@ -11387,7 +11405,7 @@ function OneOnOneInitPlayerSlots takes nothing returns nothing
 endfunction
 
 // 初始化玩家队伍（按游戏类型）
-// 包含1V1、2支队伍、3支队伍、4支队伍、FFA、混战
+// 游戏类型包含1V1、2支队伍、3支队伍、4支队伍、FFA、混战
 function InitGenericPlayerSlots takes nothing returns nothing
     local gametype gType = GetGameTypeSelected()
 
@@ -11713,7 +11731,7 @@ function StartStockUpdates takes nothing returns nothing
     call TimerStart(bj_stockUpdateTimer, bj_STOCK_RESTOCK_INTERVAL, true, function PerformStockUpdates)
 endfunction
 
-// 删除购买物品
+// 删除购买物品（游戏化初始化时初始化商店库存）
 function RemovePurchasedItem takes nothing returns nothing
     call RemoveItemFromStock(GetSellingUnit(), GetItemTypeId(GetSoldItem()))
 endfunction
@@ -11746,13 +11764,13 @@ function InitNeutralBuildings takes nothing returns nothing
     call TriggerAddAction(bj_stockItemPurchased, function RemovePurchasedItem)
 endfunction
 
-
+// 删除设置开局阈值计时器（bj_gameStartedTimer）
 function MarkGameStarted takes nothing returns nothing
     set bj_gameStarted = true
     call DestroyTimer(bj_gameStartedTimer)
 endfunction
 
-
+// 设置开局阈值
 function DetectGameStarted takes nothing returns nothing
     set bj_gameStartedTimer = CreateTimer()
     call TimerStart(bj_gameStartedTimer, bj_GAME_STARTED_THRESHOLD, false, function MarkGameStarted)
@@ -11796,19 +11814,19 @@ endfunction
 //*
 //***************************************************************************
 
-
+// 重置随机分布数为0
 function RandomDistReset takes nothing returns nothing
     set bj_randDistCount = 0
 endfunction
 
-
+// 添加随机分布数
 function RandomDistAddItem takes integer inID, integer inChance returns nothing
     set bj_randDistID[bj_randDistCount] = inID
     set bj_randDistChance[bj_randDistCount] = inChance
     set bj_randDistCount = bj_randDistCount + 1
 endfunction
 
-
+// 获取随机分布数
 function RandomDistChoose takes nothing returns integer
     local integer sum = 0
     local integer chance = 0
@@ -11926,182 +11944,182 @@ endfunction
 //*
 //***************************************************************************
 
-
+// 获取最后的值域操作结果
 function BlzIsLastInstanceObjectFunctionSuccessful takes nothing returns boolean
     return bj_lastInstObjFuncSuccessful
 endfunction
 
 // Ability
-
+// 设置技能布尔值域
 function BlzSetAbilityBooleanFieldBJ takes ability whichAbility, abilitybooleanfield whichField, boolean value returns nothing
     set bj_lastInstObjFuncSuccessful = BlzSetAbilityBooleanField(whichAbility, whichField, value)
 endfunction
 
-
+// 设置技能整数域
 function BlzSetAbilityIntegerFieldBJ takes ability whichAbility, abilityintegerfield whichField, integer value returns nothing
     set bj_lastInstObjFuncSuccessful = BlzSetAbilityIntegerField(whichAbility, whichField, value)
 endfunction
 
-
+// 设置技能实数域
 function BlzSetAbilityRealFieldBJ takes ability whichAbility, abilityrealfield whichField, real value returns nothing
     set bj_lastInstObjFuncSuccessful = BlzSetAbilityRealField(whichAbility, whichField, value)
 endfunction
 
-
+// 设置技能字串符域
 function BlzSetAbilityStringFieldBJ takes ability whichAbility, abilitystringfield whichField, string value returns nothing
     set bj_lastInstObjFuncSuccessful = BlzSetAbilityStringField(whichAbility, whichField, value)
 endfunction
 
-
+// 设置技能随等级改变的布尔值域
 function BlzSetAbilityBooleanLevelFieldBJ takes ability whichAbility, abilitybooleanlevelfield whichField, integer level, boolean value returns nothing
     set bj_lastInstObjFuncSuccessful = BlzSetAbilityBooleanLevelField(whichAbility, whichField, level, value)
 endfunction
 
-
+// 设置技能随等级改变的整数域
 function BlzSetAbilityIntegerLevelFieldBJ takes ability whichAbility, abilityintegerlevelfield whichField, integer level, integer value returns nothing
     set bj_lastInstObjFuncSuccessful = BlzSetAbilityIntegerLevelField(whichAbility, whichField, level, value)
 endfunction
 
-
+// 设置技能随等级改变的实数域
 function BlzSetAbilityRealLevelFieldBJ takes ability whichAbility, abilityreallevelfield whichField, integer level, real value returns nothing
     set bj_lastInstObjFuncSuccessful = BlzSetAbilityRealLevelField(whichAbility, whichField, level, value)
 endfunction
 
-
+// 设置技能随等级改变的字串符域
 function BlzSetAbilityStringLevelFieldBJ takes ability whichAbility, abilitystringlevelfield whichField, integer level, string value returns nothing
     set bj_lastInstObjFuncSuccessful = BlzSetAbilityStringLevelField(whichAbility, whichField, level, value)
 endfunction
 
-
+// 设置技能随等级改变的布尔值数组域
 function BlzSetAbilityBooleanLevelArrayFieldBJ takes ability whichAbility, abilitybooleanlevelarrayfield whichField, integer level, integer index, boolean value returns nothing
     set bj_lastInstObjFuncSuccessful = BlzSetAbilityBooleanLevelArrayField(whichAbility, whichField, level, index, value)
 endfunction
 
-
+// 设置技能随等级改变的整数数组域
 function BlzSetAbilityIntegerLevelArrayFieldBJ takes ability whichAbility, abilityintegerlevelarrayfield whichField, integer level, integer index, integer value returns nothing
     set bj_lastInstObjFuncSuccessful = BlzSetAbilityIntegerLevelArrayField(whichAbility, whichField, level, index, value)
 endfunction
 
-
+// 设置技能随等级改变的实数数组域
 function BlzSetAbilityRealLevelArrayFieldBJ takes ability whichAbility, abilityreallevelarrayfield whichField, integer level, integer index, real value returns nothing
     set bj_lastInstObjFuncSuccessful = BlzSetAbilityRealLevelArrayField(whichAbility, whichField, level, index, value)
 endfunction
 
-
+// 设置技能随等级改变的字串符数组域
 function BlzSetAbilityStringLevelArrayFieldBJ takes ability whichAbility, abilitystringlevelarrayfield whichField, integer level, integer index, string value returns nothing
     set bj_lastInstObjFuncSuccessful = BlzSetAbilityStringLevelArrayField(whichAbility, whichField, level, index, value)
 endfunction
 
-
+// 添加技能随等级改变的布尔值数组域
 function BlzAddAbilityBooleanLevelArrayFieldBJ takes ability whichAbility, abilitybooleanlevelarrayfield whichField, integer level, boolean value returns nothing
     set bj_lastInstObjFuncSuccessful = BlzAddAbilityBooleanLevelArrayField(whichAbility, whichField, level, value)
 endfunction
 
-
+// 添加技能随等级改变的整数数组域
 function BlzAddAbilityIntegerLevelArrayFieldBJ takes ability whichAbility, abilityintegerlevelarrayfield whichField, integer level, integer value returns nothing
     set bj_lastInstObjFuncSuccessful = BlzAddAbilityIntegerLevelArrayField(whichAbility, whichField, level, value)
 endfunction
 
-
+// 添加技能随等级改变的实数数组域
 function BlzAddAbilityRealLevelArrayFieldBJ takes ability whichAbility, abilityreallevelarrayfield whichField, integer level, real value returns nothing
     set bj_lastInstObjFuncSuccessful = BlzAddAbilityRealLevelArrayField(whichAbility, whichField, level, value)
 endfunction
 
-
+// 添加技能随等级改变的字串符数组域
 function BlzAddAbilityStringLevelArrayFieldBJ takes ability whichAbility, abilitystringlevelarrayfield whichField, integer level, string value returns nothing
     set bj_lastInstObjFuncSuccessful = BlzAddAbilityStringLevelArrayField(whichAbility, whichField, level, value)
 endfunction
 
-
+// 移除技能随等级改变的布尔值数组域
 function BlzRemoveAbilityBooleanLevelArrayFieldBJ takes ability whichAbility, abilitybooleanlevelarrayfield whichField, integer level, boolean value returns nothing
     set bj_lastInstObjFuncSuccessful = BlzRemoveAbilityBooleanLevelArrayField(whichAbility, whichField, level, value)
 endfunction
 
-
+// 移除技能随等级改变的整数数组域
 function BlzRemoveAbilityIntegerLevelArrayFieldBJ takes ability whichAbility, abilityintegerlevelarrayfield whichField, integer level, integer value returns nothing
     set bj_lastInstObjFuncSuccessful = BlzRemoveAbilityIntegerLevelArrayField(whichAbility, whichField, level, value)
 endfunction
 
-
+// 移除技能随等级改变的实数数组域
 function BlzRemoveAbilityRealLevelArrayFieldBJ takes ability whichAbility, abilityreallevelarrayfield whichField, integer level, real value returns nothing
     set bj_lastInstObjFuncSuccessful = BlzRemoveAbilityRealLevelArrayField(whichAbility, whichField, level, value)
 endfunction
 
-
+// 移除技能随等级改变的字串符数组域
 function BlzRemoveAbilityStringLevelArrayFieldBJ takes ability whichAbility, abilitystringlevelarrayfield whichField, integer level, string value returns nothing
     set bj_lastInstObjFuncSuccessful = BlzRemoveAbilityStringLevelArrayField(whichAbility, whichField, level, value)
 endfunction
 
 // Item 
-
+// 添加物品技能
 function BlzItemAddAbilityBJ takes item whichItem, integer abilCode returns nothing
     set bj_lastInstObjFuncSuccessful = BlzItemAddAbility(whichItem, abilCode)
 endfunction
 
-
+// 移除物品技能
 function BlzItemRemoveAbilityBJ takes item whichItem, integer abilCode returns nothing
     set bj_lastInstObjFuncSuccessful = BlzItemRemoveAbility(whichItem, abilCode)
 endfunction
 
-
+// 添加物品技能
 function BlzSetItemBooleanFieldBJ takes item whichItem, itembooleanfield whichField, boolean value returns nothing
     set bj_lastInstObjFuncSuccessful = BlzSetItemBooleanField(whichItem, whichField, value)
 endfunction
 
-
+// 设置物品整数域
 function BlzSetItemIntegerFieldBJ takes item whichItem, itemintegerfield whichField, integer value returns nothing
     set bj_lastInstObjFuncSuccessful = BlzSetItemIntegerField(whichItem, whichField, value)
 endfunction
 
-
+// 设置物品实数域
 function BlzSetItemRealFieldBJ takes item whichItem, itemrealfield whichField, real value returns nothing
     set bj_lastInstObjFuncSuccessful = BlzSetItemRealField(whichItem, whichField, value)
 endfunction
 
-
+// 设置物品字串符域
 function BlzSetItemStringFieldBJ takes item whichItem, itemstringfield whichField, string value returns nothing
     set bj_lastInstObjFuncSuccessful = BlzSetItemStringField(whichItem, whichField, value)
 endfunction
 
 
 // Unit 
-
+// 设置单位布尔值域
 function BlzSetUnitBooleanFieldBJ takes unit whichUnit, unitbooleanfield whichField, boolean value returns nothing
     set bj_lastInstObjFuncSuccessful = BlzSetUnitBooleanField(whichUnit, whichField, value)
 endfunction
 
-
+// 设置单位整数域
 function BlzSetUnitIntegerFieldBJ takes unit whichUnit, unitintegerfield whichField, integer value returns nothing
     set bj_lastInstObjFuncSuccessful = BlzSetUnitIntegerField(whichUnit, whichField, value)
 endfunction
 
-
+// 设置单位实域
 function BlzSetUnitRealFieldBJ takes unit whichUnit, unitrealfield whichField, real value returns nothing
     set bj_lastInstObjFuncSuccessful = BlzSetUnitRealField(whichUnit, whichField, value)
 endfunction
 
-
+// 设置单位字串符域
 function BlzSetUnitStringFieldBJ takes unit whichUnit, unitstringfield whichField, string value returns nothing
     set bj_lastInstObjFuncSuccessful = BlzSetUnitStringField(whichUnit, whichField, value)
 endfunction
 
 // Unit Weapon
-
+// 设置单位武器布尔值域
 function BlzSetUnitWeaponBooleanFieldBJ takes unit whichUnit, unitweaponbooleanfield whichField, integer index, boolean value returns nothing
     set bj_lastInstObjFuncSuccessful = BlzSetUnitWeaponBooleanField(whichUnit, whichField, index, value)
 endfunction
 
-
+// 设置单位武器整数域
 function BlzSetUnitWeaponIntegerFieldBJ takes unit whichUnit, unitweaponintegerfield whichField, integer index, integer value returns nothing
     set bj_lastInstObjFuncSuccessful = BlzSetUnitWeaponIntegerField(whichUnit, whichField, index, value)
 endfunction
 
-
+// 设置单位武器实数域
 function BlzSetUnitWeaponRealFieldBJ takes unit whichUnit, unitweaponrealfield whichField, integer index, real value returns nothing
     set bj_lastInstObjFuncSuccessful = BlzSetUnitWeaponRealField(whichUnit, whichField, index, value)
 endfunction
 
-
+// 设置单位武器字串符域
 function BlzSetUnitWeaponStringFieldBJ takes unit whichUnit, unitweaponstringfield whichField, integer index, string value returns nothing
     set bj_lastInstObjFuncSuccessful = BlzSetUnitWeaponStringField(whichUnit, whichField, index, value)
 endfunction

--- a/static/blizzard.j
+++ b/static/blizzard.j
@@ -11869,7 +11869,7 @@ endfunction
 //*        item into the unpathable area where nobody can get it...
 //*
 //***************************************************************************
-
+// 创建指定物品（指定单位）
 function UnitDropItem takes unit inUnit, integer inItemID returns item
     local real x
     local real y
@@ -11896,7 +11896,7 @@ function UnitDropItem takes unit inUnit, integer inItemID returns item
     return droppedItem
 endfunction
 
-
+// 创建指定物品（指定目标点）
 function WidgetDropItem takes widget inWidget, integer inItemID returns item
     local real x
     local real y

--- a/static/blizzard.j
+++ b/static/blizzard.j
@@ -5389,7 +5389,7 @@ endfunction
 // This toggles pathing on or off for one wall of an elevator by killing
 // or reviving a pathing blocker at the appropriate location (and creating
 // the pathing blocker in the first place, if it does not yet exist).
-//
+// 设置升降机路径阻断器
 function ChangeElevatorWallBlocker takes real x, real y, real facing, boolean open returns nothing
     local destructable blocker = null
     local real         findThreshold = 32
@@ -5488,7 +5488,7 @@ function WaygateActivateBJ takes boolean activate, unit waygate returns nothing
 endfunction
 
 
-// 传送门是允许的
+// 查询传送门激活状态
 function WaygateIsActiveBJ takes unit waygate returns boolean
     return WaygateIsActive(waygate)
 endfunction
@@ -5500,13 +5500,13 @@ function WaygateSetDestinationLocBJ takes unit waygate, location loc returns not
 endfunction
 
 
-// 传送门的目的地
+// 获取传送门的目的地
 function WaygateGetDestinationLocBJ takes unit waygate returns location
     return Location(WaygateGetDestinationX(waygate), WaygateGetDestinationY(waygate))
 endfunction
 
 
-// 改变单位的小地图图标
+// 设置单位的小地图图标
 function UnitSetUsesAltIconBJ takes boolean flag, unit whichUnit returns nothing
     call UnitSetUsesAltIcon(whichUnit, flag)
 endfunction

--- a/static/blizzard.j
+++ b/static/blizzard.j
@@ -4315,7 +4315,7 @@ function GetUnitStateSwap takes unitstate whichState, unit whichUnit returns rea
     return GetUnitState(whichUnit, whichState)
 endfunction
 
-
+// 获取指定单位指定属性的百分比
 function GetUnitStatePercent takes unit whichUnit, unitstate whichState, unitstate whichMaxState returns real
     local real value    = GetUnitState(whichUnit, whichState)
     local real maxValue = GetUnitState(whichUnit, whichMaxState)
@@ -4341,14 +4341,14 @@ function GetUnitManaPercent takes unit whichUnit returns real
 endfunction
 
 
-// 选定单位
+// 选择单位
 function SelectUnitSingle takes unit whichUnit returns nothing
     call ClearSelection()
     call SelectUnit(whichUnit, true)
 endfunction
 
 
-// 选定单位组
+// 选择单位组中的匹配单位
 function SelectGroupBJEnum takes nothing returns nothing
     call SelectUnit( GetEnumUnit(), true )
 endfunction
@@ -4366,13 +4366,13 @@ function SelectUnitAdd takes unit whichUnit returns nothing
 endfunction
 
 
-// 清除单位选择
+// 移除单位选择(所有玩家)
 function SelectUnitRemove takes unit whichUnit returns nothing
     call SelectUnit(whichUnit, false)
 endfunction
 
 
-// 清除选定对玩家
+// 让指定玩家取消选择单位
 function ClearSelectionForPlayer takes player whichPlayer returns nothing
     if (GetLocalPlayer() == whichPlayer) then
         // Use only local code (no net traffic) within this block to avoid desyncs.
@@ -4381,7 +4381,7 @@ function ClearSelectionForPlayer takes player whichPlayer returns nothing
 endfunction
 
 
-// 选定单位对玩家
+// 让指定玩家取消选择指定单位
 function SelectUnitForPlayerSingle takes unit whichUnit, player whichPlayer returns nothing
     if (GetLocalPlayer() == whichPlayer) then
         // Use only local code (no net traffic) within this block to avoid desyncs.
@@ -4391,7 +4391,7 @@ function SelectUnitForPlayerSingle takes unit whichUnit, player whichPlayer retu
 endfunction
 
 
-// 清除选定单位组对玩家
+// 让指定单位组取消选择指定单位组的指定单位
 function SelectGroupForPlayerBJ takes group g, player whichPlayer returns nothing
     if (GetLocalPlayer() == whichPlayer) then
         // Use only local code (no net traffic) within this block to avoid desyncs.
@@ -4401,7 +4401,7 @@ function SelectGroupForPlayerBJ takes group g, player whichPlayer returns nothin
 endfunction
 
 
-// 增加单位到玩家的选定中
+// 让指定玩家选择指定单位
 function SelectUnitAddForPlayer takes unit whichUnit, player whichPlayer returns nothing
     if (GetLocalPlayer() == whichPlayer) then
         // Use only local code (no net traffic) within this block to avoid desyncs.
@@ -4410,7 +4410,7 @@ function SelectUnitAddForPlayer takes unit whichUnit, player whichPlayer returns
 endfunction
 
 
-// 清除单位的选定为玩家
+// 让指定玩家取消选择指定单位
 function SelectUnitRemoveForPlayer takes unit whichUnit, player whichPlayer returns nothing
     if (GetLocalPlayer() == whichPlayer) then
         // Use only local code (no net traffic) within this block to avoid desyncs.
@@ -4443,19 +4443,19 @@ function SetUnitManaPercentBJ takes unit whichUnit, real percent returns nothing
 endfunction
 
 
-// 单位是已死亡的
+// 单位是否已死亡
 function IsUnitDeadBJ takes unit whichUnit returns boolean
     return GetUnitState(whichUnit, UNIT_STATE_LIFE) <= 0
 endfunction
 
 
-// 单位是活着的
+// 单位是否存活
 function IsUnitAliveBJ takes unit whichUnit returns boolean
     return not IsUnitDeadBJ(whichUnit)
 endfunction
 
 
-// 单位组的单位是已死亡的
+// 单位组的单位是已死亡动作
 function IsUnitGroupDeadBJEnum takes nothing returns nothing
     if not IsUnitDeadBJ(GetEnumUnit()) then
         set bj_isUnitGroupDeadResult = false
@@ -4464,7 +4464,7 @@ endfunction
 
 
 // Returns true if every unit of the group is dead.
-//
+// 单位组的单位是已死亡
 function IsUnitGroupDeadBJ takes group g returns boolean
     // If the user wants the group destroyed, remember that fact and clear
     // the flag, in case it is used again in the callback.
@@ -5754,7 +5754,7 @@ function GetUnitsOfPlayerAndTypeId takes player whichPlayer, integer unitid retu
 endfunction
 
 
-// 选定的单位
+// 选择的单位
 function GetUnitsSelectedAll takes player whichPlayer returns group
     local group g = CreateGroup()
     call SyncSelections()

--- a/static/blizzard.j
+++ b/static/blizzard.j
@@ -12,57 +12,57 @@ globals
     constant real      bj_PI                            = 3.14159
     // 底数，默认2.71828
     constant real      bj_E                             = 2.71828
-    // 单元格宽度，默认128
+    // 单元格宽度，默认128.0
     constant real      bj_CELLWIDTH                     = 128.0
-    // 悬崖高度，默认128
+    // 悬崖高度，默认128.0
     constant real      bj_CLIFFHEIGHT                   = 128.0
-    // 单位默认面向角度，默认270
+    // 单位默认面向角度，默认270.0
     constant real      bj_UNIT_FACING                   = 270.0
     // 弧度转换成为角度
     constant real      bj_RADTODEG                      = 180.0/bj_PI
     // 角度转换成为弧度
     constant real      bj_DEGTORAD                      = bj_PI/180.0
-    // 文本显示延时 - 任务，默认20
+    // 文本显示延时 - 任务，默认20.00
     constant real      bj_TEXT_DELAY_QUEST              = 20.00
-    // 文本显示延时 - 任务更新，默认20
+    // 文本显示延时 - 任务更新，默认20.00
     constant real      bj_TEXT_DELAY_QUESTUPDATE        = 20.00
-    // 文本显示延时 - 任务完成，默认20
+    // 文本显示延时 - 任务完成，默认20.00
     constant real      bj_TEXT_DELAY_QUESTDONE          = 20.00
-    // 文本显示延时 - 任务失败，默认20
+    // 文本显示延时 - 任务失败，默认20.00
     constant real      bj_TEXT_DELAY_QUESTFAILED        = 20.00
-    // 文本显示延时 - 任务要求，默认20
+    // 文本显示延时 - 任务要求，默认20.00
     constant real      bj_TEXT_DELAY_QUESTREQUIREMENT   = 20.00
-    // 文本显示延时 - 失败消息，默认20
+    // 文本显示延时 - 失败消息，默认20.00
     constant real      bj_TEXT_DELAY_MISSIONFAILED      = 20.00
-    // 文本显示延时 - 常驻提示，默认12
+    // 文本显示延时 - 常驻提示，默认12.00
     constant real      bj_TEXT_DELAY_ALWAYSHINT         = 12.00
-    // 文本显示延时 - 提示，默认12
+    // 文本显示延时 - 提示，默认12.00
     constant real      bj_TEXT_DELAY_HINT               = 12.00
-    // 文本显示延时 - 秘密，默认10
+    // 文本显示延时 - 秘密，默认10.00
     constant real      bj_TEXT_DELAY_SECRET             = 10.00
-    // 文本显示延时 - 单位购买，默认15
+    // 文本显示延时 - 单位购买，默认15.00
     constant real      bj_TEXT_DELAY_UNITACQUIRED       = 15.00
-    // 文本显示延时 - 单位可用，默认15
+    // 文本显示延时 - 单位可用，默认10.00
     constant real      bj_TEXT_DELAY_UNITAVAILABLE      = 10.00
-    // 文本显示延时 - 物品购买，默认15
+    // 文本显示延时 - 物品购买，默认10.00
     constant real      bj_TEXT_DELAY_ITEMACQUIRED       = 10.00
-    // 文本显示延时 - 物品购买，默认15
+    // 文本显示延时 - 物品购买，默认12.00
     constant real      bj_TEXT_DELAY_WARNING            = 12.00
-    // 队列延时 - 任务，默认5
+    // 队列延时 - 任务，默认5.00
     constant real      bj_QUEUE_DELAY_QUEST             =  5.00
-    // 队列延时 - 提示，默认5
+    // 队列延时 - 提示，默认5.00
     constant real      bj_QUEUE_DELAY_HINT              =  5.00
-    // 队列延时 - 任务，默认3
+    // 队列延时 - 任务，默认3.00
     constant real      bj_QUEUE_DELAY_SECRET            =  3.00
-    // 障碍 - 简单，默认60
+    // 障碍 - 简单，默认60.00
     constant real      bj_HANDICAP_EASY                 = 60.00
-    // 障碍 - 普通，默认60
+    // 障碍 - 普通，默认90.00
     constant real      bj_HANDICAP_NORMAL               = 90.00
-    // 损伤障碍 - 简单，默认50
+    // 损伤障碍 - 简单，默认50.00
     constant real      bj_HANDICAPDAMAGE_EASY           = 50.00
-    // 损伤障碍 - 普通，默认90
+    // 损伤障碍 - 普通，默认90.00
     constant real      bj_HANDICAPDAMAGE_NORMAL         = 90.00
-    // 损伤障碍 - 非困难，默认50
+    // 损伤障碍 - 非困难，默认50.00
 	constant real      bj_HANDICAPREVIVE_NOTHARD        = 50.00
     // 游戏开局阈值，默认0.01
     constant real      bj_GAME_STARTED_THRESHOLD        =  0.01
@@ -70,7 +70,7 @@ globals
     constant real      bj_WAIT_FOR_COND_MIN_INTERVAL    =  0.10
     // 轮询间隔（游戏时间），默认0.10
     constant real      bj_POLLED_WAIT_INTERVAL          =  0.10
-    // 轮询跳过阈值（游戏时间），默认2
+    // 轮询跳过阈值（游戏时间），默认2.00
     constant real      bj_POLLED_WAIT_SKIP_THRESHOLD    =  2.00
 
     // Game constants  最大库存，默认6
@@ -97,9 +97,9 @@ globals
 
     // Ideally these would be looked up from Units/MiscData.txt,
     // but there is currently no script functionality exposed to do that
-    // 黎明时间（鸡啼），默认早上6点
+    // 黎明时间（鸡啼），默认早上6点整（6.00）
     constant real      bj_TOD_DAWN                      = 6.00
-    // 入夜时间（狼嚎），默认晚上18点
+    // 入夜时间（狼嚎），默认晚上18点整（18.00）
     constant real      bj_TOD_DUSK                      = 18.00
 
     // Melee game settings:
@@ -110,15 +110,15 @@ globals
     //   - Max heroes allowed per player
     //   - Max heroes allowed per hero type
     //   - Distance from start loc to search for nearby mines
-    // 初始时钟，默认早上8点
+    // 初始时钟，默认早上8点整（8.00）
     constant real      bj_MELEE_STARTING_TOD            = 8.00
-    // 初始黄金数量，默认750（V0是混乱之治）
+    // 初始黄金数量，默认750（V0表示混乱之治）
     constant integer   bj_MELEE_STARTING_GOLD_V0        = 750
-    // 初始黄金数量，默认500（V1是冰封王座）
+    // 初始黄金数量，默认500（V1表示冰封王座）
     constant integer   bj_MELEE_STARTING_GOLD_V1        = 500
-    // 初始木材数量，默认200（V0是混乱之治）
+    // 初始木材数量，默认200（V0表示混乱之治）
     constant integer   bj_MELEE_STARTING_LUMBER_V0      = 200
-    // 初始木材数量，默认150（V1是冰封王座）
+    // 初始木材数量，默认150（V1表示冰封王座）
     constant integer   bj_MELEE_STARTING_LUMBER_V1      = 150
     // 使用随机英雄时给予的英雄数量，默认1个
     constant integer   bj_MELEE_STARTING_HERO_TOKENS    = 1
@@ -130,24 +130,25 @@ globals
     constant real      bj_MELEE_MINE_SEARCH_RADIUS      = 2000
     // 清除开始点中立敌对单位的范围，默认1500（使用清除开始点的野怪时，要删除距离开始点多少范围内的野怪）
     constant real      bj_MELEE_CLEAR_UNITS_RADIUS      = 1500
-    // 失去全部基地时，在暴露位置前，留给玩家造基地的时间（暴露倒计时），默认120
+    // 失去全部基地时，在暴露位置前，留给玩家造基地的时间（暴露倒计时），默认120.00
     constant real      bj_MELEE_CRIPPLE_TIMEOUT         = 120.00
-    // 失去全部基地，暴露倒计时结束，玩家依旧没有造基地，显示玩家位置的持续时间，默认20
+    // 失去全部基地，暴露倒计时结束，玩家依旧没有造基地，显示玩家位置的持续时间，默认20.00
     constant real      bj_MELEE_CRIPPLE_MSG_DURATION    = 20.00
-    // 英雄初始物品要给予的次数，默认3次，即前3个获得的英雄都会给（V0是混乱之治）
+    // 英雄初始物品要给予的次数，默认3次，即前3个获得的英雄都会给（V0表示混乱之治）
     constant integer   bj_MELEE_MAX_TWINKED_HEROES_V0   = 3
-    // 英雄初始物品要给予的次数，默认3次，即只给第1个获得的英雄（V1是冰封王座）
+    // 英雄初始物品要给予的次数，默认1次，即只给第1个获得的英雄（V1表示冰封王座）
     constant integer   bj_MELEE_MAX_TWINKED_HEROES_V1   = 1
 
-    // 从单位死亡到掉落物品出现的时间间隔（延时），默认0.5 Delay between a creep's death and the time it may drop an item.
+    // Delay between a creep's death and the time it may drop an item.
+    // 从单位死亡到掉落物品出现的时间间隔（延时），默认0.50
     constant real      bj_CREEP_ITEM_DELAY              = 0.50
 
     // Timing settings for Marketplace inventories.
-    // 初始库存补充延时（开局后，过多久才可购买/雇佣）
+    // 初始库存补充延时（开局后，过多久才可购买/雇佣），默认120
     constant real      bj_STOCK_RESTOCK_INITIAL_DELAY   = 120
-    // 库存补充间隔
+    // 库存补充间隔，默认30
     constant real      bj_STOCK_RESTOCK_INTERVAL        = 30
-    // 库存最大补充次数
+    // 库存最大补充次数，默认20
     constant integer   bj_STOCK_MAX_ITERATIONS          = 20
 
     // Max events registered by a single "dest dies in region" event.
@@ -170,7 +171,7 @@ globals
     // 镜头默认旋转值（Z 轴旋转角度）（90）
     constant integer   bj_CAMERA_DEFAULT_ROTATION       = 90
 
-    // 救援延时，怀疑是中立可救援单位在被救援后变更队伍的延迟 Rescue
+    // 救援延时，怀疑是中立可救援单位在被救援后变更队伍的延迟，默认2.00 Rescue
     constant real      bj_RESCUE_PING_TIME              = 2.00
 
     // Transmission behavior settings
@@ -189,7 +190,7 @@ globals
     // 传输画像悬空时间，默认1.50
     constant real      bj_TRANSMISSION_PORT_HANGTIME    = 1.50
 
-    // 电影模式转换时间，默认0.5 Cinematic mode settings
+    // 电影模式转换时间，默认0.50 Cinematic mode settings
     constant real      bj_CINEMODE_INTERFACEFADE        = 0.50
     // 默认游戏速度--默认正常
     constant gamespeed bj_CINEMODE_GAMESPEED            = MAP_SPEED_NORMAL
@@ -547,9 +548,9 @@ globals
     constant integer   bj_QUESTMESSAGE_COMPLETED     = 2
     // 任务信息类型 发现失败
     constant integer   bj_QUESTMESSAGE_FAILED        = 3
-    // 任务信息类型 发现要求
+    // 任务信息类型 任务要求
     constant integer   bj_QUESTMESSAGE_REQUIREMENT   = 4
-    // 任务信息类型 发现失败
+    // 任务信息类型 任务失败
     constant integer   bj_QUESTMESSAGE_MISSIONFAILED = 5
     // 任务信息类型 提示
     constant integer   bj_QUESTMESSAGE_ALWAYSHINT    = 6
@@ -627,13 +628,13 @@ globals
     constant integer   bj_MODIFYMETHOD_SET    = 2
 
     // Unit state adjustment methods (for replaced units)
-    // 替换单位时，新单位的生命值和魔法值设置 使用旧单位的生命值和魔法值
+    // 替换单位时，新单位生命值和魔法值为 旧单位 的值
     constant integer   bj_UNIT_STATE_METHOD_ABSOLUTE = 0
-    // 替换单位时，新单位的生命值和魔法值设置  使用旧单位相关物的生命值和魔法值
+    // 替换单位时，新单位生命值和魔法值为 旧单位相关物 的值
     constant integer   bj_UNIT_STATE_METHOD_RELATIVE = 1
-    // 替换单位时，新单位的生命值和魔法值设置 使用新单位默认值
+    // 替换单位时，新单位生命值和魔法值为 新单位的默认值
     constant integer   bj_UNIT_STATE_METHOD_DEFAULTS = 2
-    // 替换单位时，新单位的生命值和魔法值设置 使用新单位的最大值
+    // 替换单位时，新单位生命值和魔法值为 使用新单位的最大值
     constant integer   bj_UNIT_STATE_METHOD_MAXIMUM  = 3
 
     // Gate operations
@@ -699,27 +700,27 @@ globals
     constant integer   bj_MINIMAPPINGSTYLE_ATTACK  = 2
 	
     // Campaign Minimap icon styles
-    // 小地图图标类型
+    // 小地图图标样式 主要任务标识
     constant integer   bj_CAMPPINGSTYLE_PRIMARY			= 0
-    // 小地图图标类型
+    // 小地图图标样式 主要任务标识（绿色）
     constant integer   bj_CAMPPINGSTYLE_PRIMARY_GREEN   = 1
-    // 小地图图标类型
+    // 小地图图标样式 主要任务标识（红色）
     constant integer   bj_CAMPPINGSTYLE_PRIMARY_RED     = 2
-    // 小地图图标类型
+    // 小地图图标样式 任务奖励标识
     constant integer   bj_CAMPPINGSTYLE_BONUS			= 3
-    // 小地图图标类型
+    // 小地图图标样式 任务移交标识
     constant integer   bj_CAMPPINGSTYLE_TURNIN			= 4
-    // 小地图图标类型
+    // 小地图图标样式 任务BOSS标识
 	constant integer   bj_CAMPPINGSTYLE_BOSS			= 5
-    // 小地图图标类型
+    // 小地图图标样式 友方占领标识
 	constant integer   bj_CAMPPINGSTYLE_CONTROL_ALLY	= 6
-    // 小地图图标类型
+    // 小地图图标样式 中立标识（无人占领）
 	constant integer   bj_CAMPPINGSTYLE_CONTROL_NEUTRAL	= 7
-    // 小地图图标类型
+    // 小地图图标样式 敌方占领标识
 	constant integer   bj_CAMPPINGSTYLE_CONTROL_ENEMY	= 8
 
     // Corpse creation settings
-    // 尸体最大死亡时间
+    // 尸体最大死亡时间，默认8.00
     constant real      bj_CORPSE_MAX_DEATH_TIME    = 8.00
 
     // Corpse creation styles
@@ -759,9 +760,13 @@ globals
     rect               bj_mapInitialCameraBounds   = null
 
     // Utility function vars
+    // 循环A引索
     integer            bj_forLoopAIndex            = 0
+    // 循环A引索
     integer            bj_forLoopBIndex            = 0
+    // 循环A引索结束值
     integer            bj_forLoopAIndexEnd         = 0
+    // 循环A引索结束值
     integer            bj_forLoopBIndexEnd         = 0
     // 玩家检查是否完成，自动检查，检查完成后自动变为真，用于开局系统自动检查所有玩家槽是电脑（不论是否具备AI）还是真人
     boolean            bj_slotControlReady         = false
@@ -990,9 +995,11 @@ globals
     boolexpr           filterLivingPlayerUnitsOfTypeId   = null
 
     // Memory cleanup vars
+    // 需要清理单位组 - 是 或 否
     boolean            bj_wantDestroyGroup         = false
 
     // Instanced Operation Results
+    // 最后的值域操作结果 - 成功 或 失败
     boolean            bj_lastInstObjFuncSuccessful = true
 endglobals
 

--- a/static/blizzard.j
+++ b/static/blizzard.j
@@ -64,7 +64,7 @@ globals
     constant real      bj_HANDICAPDAMAGE_NORMAL         = 90.00
     // 损伤障碍 - 非困难，默认50
 	constant real      bj_HANDICAPREVIVE_NOTHARD        = 50.00
-    // 游戏开始阈值，默认0.01
+    // 游戏开局阈值，默认0.01
     constant real      bj_GAME_STARTED_THRESHOLD        =  0.01
     // 迷雾等待最小间隔，默认0.10
     constant real      bj_WAIT_FOR_COND_MIN_INTERVAL    =  0.10
@@ -77,19 +77,19 @@ globals
     constant integer   bj_MAX_INVENTORY                 =  6
     // 最大玩家数（包含12或24位玩家和中立敌对玩家，共13/25位）
     constant integer   bj_MAX_PLAYERS                   =  GetBJMaxPlayers()
-    //中立被动玩家
+    // 中立被动玩家
     constant integer   bj_PLAYER_NEUTRAL_VICTIM         =  GetBJPlayerNeutralVictim()
-    //中立可营救玩家
+    // 中立可营救玩家
     constant integer   bj_PLAYER_NEUTRAL_EXTRA          =  GetBJPlayerNeutralExtra()
-    //最大玩家插槽数（包含所有中立玩家）
+    // 最大玩家插槽数（包含所有中立玩家）
     constant integer   bj_MAX_PLAYER_SLOTS              =  GetBJMaxPlayerSlots()
-    //最大尸体数，默认25
+    // 最大尸体数，默认25
     constant integer   bj_MAX_SKELETONS                 =  25
-    //最大物品库存，默认11
+    // 最大物品库存，默认11
     constant integer   bj_MAX_STOCK_ITEM_SLOTS          =  11
-    //最大单位库存，默认11
+    // 最大单位库存，默认11
     constant integer   bj_MAX_STOCK_UNIT_SLOTS          =  11
-    //最大物品等级，默认10级
+    // 最大物品等级，默认10级
     constant integer   bj_MAX_ITEM_LEVEL                =  10
     
     // Auto Save constants  最大保存点数量，默认5
@@ -151,27 +151,42 @@ globals
     constant integer   bj_STOCK_MAX_ITERATIONS          = 20
 
     // Max events registered by a single "dest dies in region" event.
+    // 最大事件注册数，默认64
     constant integer   bj_MAX_DEST_IN_REGION_EVENTS     = 64
 
     // Camera settings
+    // 镜头最小截断距离（远景裁剪），默认100
     constant integer   bj_CAMERA_MIN_FARZ               = 100
+    // 镜头默认距离（1650）
     constant integer   bj_CAMERA_DEFAULT_DISTANCE       = 1650
+    // 镜头默认截断距离（远景裁剪）（5000）
     constant integer   bj_CAMERA_DEFAULT_FARZ           = 5000
+    // 镜头默认水平/攻击角度（X 轴旋转角度）（304）
     constant integer   bj_CAMERA_DEFAULT_AOA            = 304
+    // 镜头默认视场角（70）
     constant integer   bj_CAMERA_DEFAULT_FOV            = 70
+    // 镜头默认滚动值（Y 轴旋转距离）（0）
     constant integer   bj_CAMERA_DEFAULT_ROLL           = 0
+    // 镜头默认旋转值（Z 轴旋转角度）（90）
     constant integer   bj_CAMERA_DEFAULT_ROTATION       = 90
 
     // 救援延时，怀疑是中立可救援单位在被救援后变更队伍的延迟 Rescue
     constant real      bj_RESCUE_PING_TIME              = 2.00
 
     // Transmission behavior settings
+    // 常规声音持续时间，默认5.00
     constant real      bj_NOTHING_SOUND_DURATION        = 5.00
+    // 传输延迟，默认1.00
     constant real      bj_TRANSMISSION_PING_TIME        = 1.00
+    // 传输颜色值（红），默认255
     constant integer   bj_TRANSMISSION_IND_RED          = 255
+    // 传输颜色值（蓝），默认255
     constant integer   bj_TRANSMISSION_IND_BLUE         = 255
+    // 传输颜色值（绿），默认255
     constant integer   bj_TRANSMISSION_IND_GREEN        = 255
+    // 传输颜色值（alpha），默认255
     constant integer   bj_TRANSMISSION_IND_ALPHA        = 255
+    // 传输画像悬空时间，默认1.50
     constant real      bj_TRANSMISSION_PORT_HANGTIME    = 1.50
 
     // 电影模式转换时间，默认0.5 Cinematic mode settings
@@ -208,137 +223,253 @@ globals
     constant real      bj_QUEUED_TRIGGER_TIMEOUT        = 180.00
 
     // Campaign indexing constants
+    // 战役引索常量（0）
     constant integer   bj_CAMPAIGN_INDEX_T        = 0
+    // 战役引索常量（1）
     constant integer   bj_CAMPAIGN_INDEX_H        = 1
+    // 战役引索常量（2）
     constant integer   bj_CAMPAIGN_INDEX_U        = 2
+    // 战役引索常量（3）
     constant integer   bj_CAMPAIGN_INDEX_O        = 3
+    // 战役引索常量（4）
     constant integer   bj_CAMPAIGN_INDEX_N        = 4
+    // 战役引索常量（5）
     constant integer   bj_CAMPAIGN_INDEX_XN       = 5
+    // 战役引索常量（6）
     constant integer   bj_CAMPAIGN_INDEX_XH       = 6
+    // 战役引索常量（7）
     constant integer   bj_CAMPAIGN_INDEX_XU       = 7
+    // 战役引索常量（8）
     constant integer   bj_CAMPAIGN_INDEX_XO       = 8
 
     // Campaign offset constants (for mission indexing)
+    // 任务引索的战役抵消常量（0）
     constant integer   bj_CAMPAIGN_OFFSET_T       = 0
+    // 任务引索的战役抵消常量（1）
     constant integer   bj_CAMPAIGN_OFFSET_H       = 1
+    // 任务引索的战役抵消常量（2）
     constant integer   bj_CAMPAIGN_OFFSET_U       = 2
+    // 任务引索的战役抵消常量（3）
     constant integer   bj_CAMPAIGN_OFFSET_O       = 3
+    // 任务引索的战役抵消常量（4）
     constant integer   bj_CAMPAIGN_OFFSET_N       = 4
+    // 任务引索的战役抵消常量（5）
     constant integer   bj_CAMPAIGN_OFFSET_XN      = 5
+    // 任务引索的战役抵消常量（6）
     constant integer   bj_CAMPAIGN_OFFSET_XH      = 6
+    // 任务引索的战役抵消常量（7）
     constant integer   bj_CAMPAIGN_OFFSET_XU      = 7
+    // 任务引索的战役抵消常量（8）
     constant integer   bj_CAMPAIGN_OFFSET_XO      = 8
 
     // Mission indexing constants
     // Tutorial
+    // 战役任务引索常量 - 混乱之治教程（bj_CAMPAIGN_OFFSET_T * 1000 + 0）
     constant integer   bj_MISSION_INDEX_T00       = bj_CAMPAIGN_OFFSET_T * 1000 + 0
+    // 战役任务引索常量 - 混乱之治教程（bj_CAMPAIGN_OFFSET_T * 1000 + 1）
     constant integer   bj_MISSION_INDEX_T01       = bj_CAMPAIGN_OFFSET_T * 1000 + 1
+    // 战役任务引索常量 - 混乱之治教程（bj_CAMPAIGN_OFFSET_T * 1000 + 2）
     constant integer   bj_MISSION_INDEX_T02       = bj_CAMPAIGN_OFFSET_T * 1000 + 2
+    // 战役任务引索常量 - 混乱之治教程（bj_CAMPAIGN_OFFSET_T * 1000 + 3）
     constant integer   bj_MISSION_INDEX_T03       = bj_CAMPAIGN_OFFSET_T * 1000 + 3
+    // 战役任务引索常量 - 混乱之治教程（bj_CAMPAIGN_OFFSET_T * 1000 + 4）
     constant integer   bj_MISSION_INDEX_T04       = bj_CAMPAIGN_OFFSET_T * 1000 + 4
     // Human
+    // 战役任务引索常量 - 混乱之治人族（bj_CAMPAIGN_OFFSET_H * 1000 + 0）
     constant integer   bj_MISSION_INDEX_H00       = bj_CAMPAIGN_OFFSET_H * 1000 + 0
+    // 战役任务引索常量 - 混乱之治人族（bj_CAMPAIGN_OFFSET_H * 1000 + 1）
     constant integer   bj_MISSION_INDEX_H01       = bj_CAMPAIGN_OFFSET_H * 1000 + 1
+    // 战役任务引索常量 - 混乱之治人族（bj_CAMPAIGN_OFFSET_H * 1000 + 2）
     constant integer   bj_MISSION_INDEX_H02       = bj_CAMPAIGN_OFFSET_H * 1000 + 2
+    // 战役任务引索常量 - 混乱之治人族（bj_CAMPAIGN_OFFSET_H * 1000 + 3）
     constant integer   bj_MISSION_INDEX_H03       = bj_CAMPAIGN_OFFSET_H * 1000 + 3
+    // 战役任务引索常量 - 混乱之治人族（bj_CAMPAIGN_OFFSET_H * 1000 + 4）
     constant integer   bj_MISSION_INDEX_H04       = bj_CAMPAIGN_OFFSET_H * 1000 + 4
+    // 战役任务引索常量 - 混乱之治人族（bj_CAMPAIGN_OFFSET_H * 1000 + 5）
     constant integer   bj_MISSION_INDEX_H05       = bj_CAMPAIGN_OFFSET_H * 1000 + 5
+    // 战役任务引索常量 - 混乱之治人族（bj_CAMPAIGN_OFFSET_H * 1000 + 6）
     constant integer   bj_MISSION_INDEX_H06       = bj_CAMPAIGN_OFFSET_H * 1000 + 6
+    // 战役任务引索常量 - 混乱之治人族（bj_CAMPAIGN_OFFSET_H * 1000 + 7）
     constant integer   bj_MISSION_INDEX_H07       = bj_CAMPAIGN_OFFSET_H * 1000 + 7
+    // 战役任务引索常量 - 混乱之治人族（bj_CAMPAIGN_OFFSET_H * 1000 + 8）
     constant integer   bj_MISSION_INDEX_H08       = bj_CAMPAIGN_OFFSET_H * 1000 + 8
+    // 战役任务引索常量 - 混乱之治人族（bj_CAMPAIGN_OFFSET_H * 1000 + 9）
     constant integer   bj_MISSION_INDEX_H09       = bj_CAMPAIGN_OFFSET_H * 1000 + 9
+    // 战役任务引索常量 - 混乱之治人族（bj_CAMPAIGN_OFFSET_H * 1000 + 10）
     constant integer   bj_MISSION_INDEX_H10       = bj_CAMPAIGN_OFFSET_H * 1000 + 10
+    // 战役任务引索常量 - 混乱之治人族（bj_CAMPAIGN_OFFSET_H * 1000 + 11）
     constant integer   bj_MISSION_INDEX_H11       = bj_CAMPAIGN_OFFSET_H * 1000 + 11
     // Undead
+    // 战役任务引索常量 - 混乱之治不死族（bj_CAMPAIGN_OFFSET_U * 1000 + 0）
     constant integer   bj_MISSION_INDEX_U00       = bj_CAMPAIGN_OFFSET_U * 1000 + 0
+    // 战役任务引索常量 - 混乱之治不死族（bj_CAMPAIGN_OFFSET_U * 1000 + 1）
     constant integer   bj_MISSION_INDEX_U01       = bj_CAMPAIGN_OFFSET_U * 1000 + 1
+    // 战役任务引索常量 - 混乱之治不死族（bj_CAMPAIGN_OFFSET_U * 1000 + 2）
     constant integer   bj_MISSION_INDEX_U02       = bj_CAMPAIGN_OFFSET_U * 1000 + 2
+    // 战役任务引索常量 - 混乱之治不死族（bj_CAMPAIGN_OFFSET_U * 1000 + 3）
     constant integer   bj_MISSION_INDEX_U03       = bj_CAMPAIGN_OFFSET_U * 1000 + 3
+    // 战役任务引索常量 - 混乱之治不死族（bj_CAMPAIGN_OFFSET_U * 1000 + 4）
     constant integer   bj_MISSION_INDEX_U05       = bj_CAMPAIGN_OFFSET_U * 1000 + 4
+    // 战役任务引索常量 - 混乱之治不死族（bj_CAMPAIGN_OFFSET_U * 1000 + 5）
     constant integer   bj_MISSION_INDEX_U07       = bj_CAMPAIGN_OFFSET_U * 1000 + 5
+    // 战役任务引索常量 - 混乱之治不死族（bj_CAMPAIGN_OFFSET_U * 1000 + 6）
     constant integer   bj_MISSION_INDEX_U08       = bj_CAMPAIGN_OFFSET_U * 1000 + 6
+    // 战役任务引索常量 - 混乱之治不死族（bj_CAMPAIGN_OFFSET_U * 1000 + 7）
     constant integer   bj_MISSION_INDEX_U09       = bj_CAMPAIGN_OFFSET_U * 1000 + 7
+    // 战役任务引索常量 - 混乱之治不死族（bj_CAMPAIGN_OFFSET_U * 1000 + 8）
     constant integer   bj_MISSION_INDEX_U10       = bj_CAMPAIGN_OFFSET_U * 1000 + 8
+    // 战役任务引索常量 - 混乱之治不死族（bj_CAMPAIGN_OFFSET_U * 1000 + 9）
     constant integer   bj_MISSION_INDEX_U11       = bj_CAMPAIGN_OFFSET_U * 1000 + 9
     // Orc
+    // 战役任务引索常量 - 混乱之治兽族（bj_CAMPAIGN_OFFSET_O * 1000 + 0）
     constant integer   bj_MISSION_INDEX_O00       = bj_CAMPAIGN_OFFSET_O * 1000 + 0
+    // 战役任务引索常量 - 混乱之治兽族（bj_CAMPAIGN_OFFSET_O * 1000 + 1）
     constant integer   bj_MISSION_INDEX_O01       = bj_CAMPAIGN_OFFSET_O * 1000 + 1
+    // 战役任务引索常量 - 混乱之治兽族（bj_CAMPAIGN_OFFSET_O * 1000 + 2）
     constant integer   bj_MISSION_INDEX_O02       = bj_CAMPAIGN_OFFSET_O * 1000 + 2
+    // 战役任务引索常量 - 混乱之治兽族（bj_CAMPAIGN_OFFSET_O * 1000 + 3）
     constant integer   bj_MISSION_INDEX_O03       = bj_CAMPAIGN_OFFSET_O * 1000 + 3
+    // 战役任务引索常量 - 混乱之治兽族（bj_CAMPAIGN_OFFSET_O * 1000 + 4）
     constant integer   bj_MISSION_INDEX_O04       = bj_CAMPAIGN_OFFSET_O * 1000 + 4
+    // 战役任务引索常量 - 混乱之治兽族（bj_CAMPAIGN_OFFSET_O * 1000 + 5）
     constant integer   bj_MISSION_INDEX_O05       = bj_CAMPAIGN_OFFSET_O * 1000 + 5
+    // 战役任务引索常量 - 混乱之治兽族（bj_CAMPAIGN_OFFSET_O * 1000 + 6）
     constant integer   bj_MISSION_INDEX_O06       = bj_CAMPAIGN_OFFSET_O * 1000 + 6
+    // 战役任务引索常量 - 混乱之治兽族（bj_CAMPAIGN_OFFSET_O * 1000 + 7）
     constant integer   bj_MISSION_INDEX_O07       = bj_CAMPAIGN_OFFSET_O * 1000 + 7
+    // 战役任务引索常量 - 混乱之治兽族（bj_CAMPAIGN_OFFSET_O * 1000 + 8）
     constant integer   bj_MISSION_INDEX_O08       = bj_CAMPAIGN_OFFSET_O * 1000 + 8
+    // 战役任务引索常量 - 混乱之治兽族（bj_CAMPAIGN_OFFSET_O * 1000 + 9）
     constant integer   bj_MISSION_INDEX_O09       = bj_CAMPAIGN_OFFSET_O * 1000 + 9
+    // 战役任务引索常量 - 混乱之治兽族（bj_CAMPAIGN_OFFSET_O * 1000 + 10）
     constant integer   bj_MISSION_INDEX_O10       = bj_CAMPAIGN_OFFSET_O * 1000 + 10
     // Night Elf
+    // 战役任务引索常量 - 混乱之治暗夜精灵族（bj_CAMPAIGN_OFFSET_N * 1000 + 0）
     constant integer   bj_MISSION_INDEX_N00       = bj_CAMPAIGN_OFFSET_N * 1000 + 0
+    // 战役任务引索常量 - 混乱之治暗夜精灵族（bj_CAMPAIGN_OFFSET_N * 1000 + 1）
     constant integer   bj_MISSION_INDEX_N01       = bj_CAMPAIGN_OFFSET_N * 1000 + 1
+    // 战役任务引索常量 - 混乱之治暗夜精灵族（bj_CAMPAIGN_OFFSET_N * 1000 + 2）
     constant integer   bj_MISSION_INDEX_N02       = bj_CAMPAIGN_OFFSET_N * 1000 + 2
+    // 战役任务引索常量 - 混乱之治暗夜精灵族（bj_CAMPAIGN_OFFSET_N * 1000 + 3）
     constant integer   bj_MISSION_INDEX_N03       = bj_CAMPAIGN_OFFSET_N * 1000 + 3
+    // 战役任务引索常量 - 混乱之治暗夜精灵族（bj_CAMPAIGN_OFFSET_N * 1000 + 4）
     constant integer   bj_MISSION_INDEX_N04       = bj_CAMPAIGN_OFFSET_N * 1000 + 4
+    // 战役任务引索常量 - 混乱之治暗夜精灵族（bj_CAMPAIGN_OFFSET_N * 1000 + 5）
     constant integer   bj_MISSION_INDEX_N05       = bj_CAMPAIGN_OFFSET_N * 1000 + 5
+    // 战役任务引索常量 - 混乱之治暗夜精灵族（bj_CAMPAIGN_OFFSET_N * 1000 + 6）
     constant integer   bj_MISSION_INDEX_N06       = bj_CAMPAIGN_OFFSET_N * 1000 + 6
+    // 战役任务引索常量 - 混乱之治暗夜精灵族（bj_CAMPAIGN_OFFSET_N * 1000 + 7）
     constant integer   bj_MISSION_INDEX_N07       = bj_CAMPAIGN_OFFSET_N * 1000 + 7
+    // 战役任务引索常量 - 混乱之治暗夜精灵族（bj_CAMPAIGN_OFFSET_N * 1000 + 8）
     constant integer   bj_MISSION_INDEX_N08       = bj_CAMPAIGN_OFFSET_N * 1000 + 8
+    // 战役任务引索常量 - 混乱之治暗夜精灵族（bj_CAMPAIGN_OFFSET_N * 1000 + 9）
     constant integer   bj_MISSION_INDEX_N09       = bj_CAMPAIGN_OFFSET_N * 1000 + 9
     // Expansion Night Elf
+    // 战役任务引索常量 - 冰封王座暗夜精灵族（bj_CAMPAIGN_OFFSET_XN * 1000 + 0）
     constant integer   bj_MISSION_INDEX_XN00       = bj_CAMPAIGN_OFFSET_XN * 1000 + 0
+    // 战役任务引索常量 - 冰封王座暗夜精灵族（bj_CAMPAIGN_OFFSET_XN * 1000 + 1）
     constant integer   bj_MISSION_INDEX_XN01       = bj_CAMPAIGN_OFFSET_XN * 1000 + 1
+    // 战役任务引索常量 - 冰封王座暗夜精灵族（bj_CAMPAIGN_OFFSET_XN * 1000 + 2）
     constant integer   bj_MISSION_INDEX_XN02       = bj_CAMPAIGN_OFFSET_XN * 1000 + 2
+    // 战役任务引索常量 - 冰封王座暗夜精灵族（bj_CAMPAIGN_OFFSET_XN * 1000 + 3）
     constant integer   bj_MISSION_INDEX_XN03       = bj_CAMPAIGN_OFFSET_XN * 1000 + 3
+    // 战役任务引索常量 - 冰封王座暗夜精灵族（bj_CAMPAIGN_OFFSET_XN * 1000 + 4）
     constant integer   bj_MISSION_INDEX_XN04       = bj_CAMPAIGN_OFFSET_XN * 1000 + 4
+    // 战役任务引索常量 - 冰封王座暗夜精灵族（bj_CAMPAIGN_OFFSET_XN * 1000 + 5）
     constant integer   bj_MISSION_INDEX_XN05       = bj_CAMPAIGN_OFFSET_XN * 1000 + 5
+    // 战役任务引索常量 - 冰封王座暗夜精灵族（bj_CAMPAIGN_OFFSET_XN * 1000 + 6）
     constant integer   bj_MISSION_INDEX_XN06       = bj_CAMPAIGN_OFFSET_XN * 1000 + 6
+    // 战役任务引索常量 - 冰封王座暗夜精灵族（bj_CAMPAIGN_OFFSET_XN * 1000 + 7）
     constant integer   bj_MISSION_INDEX_XN07       = bj_CAMPAIGN_OFFSET_XN * 1000 + 7
+    // 战役任务引索常量 - 冰封王座暗夜精灵族（bj_CAMPAIGN_OFFSET_XN * 1000 + 8）
     constant integer   bj_MISSION_INDEX_XN08       = bj_CAMPAIGN_OFFSET_XN * 1000 + 8
+    // 战役任务引索常量 - 冰封王座暗夜精灵族（bj_CAMPAIGN_OFFSET_XN * 1000 + 9）
     constant integer   bj_MISSION_INDEX_XN09       = bj_CAMPAIGN_OFFSET_XN * 1000 + 9
+    // 战役任务引索常量 - 冰封王座暗夜精灵族（bj_CAMPAIGN_OFFSET_XN * 1000 + 10）
     constant integer   bj_MISSION_INDEX_XN10       = bj_CAMPAIGN_OFFSET_XN * 1000 + 10
     // Expansion Human
+    // 战役任务引索常量 - 冰封王座人族（bj_CAMPAIGN_OFFSET_XH * 1000 + 0）
     constant integer   bj_MISSION_INDEX_XH00       = bj_CAMPAIGN_OFFSET_XH * 1000 + 0
+    // 战役任务引索常量 - 冰封王座人族（bj_CAMPAIGN_OFFSET_XH * 1000 + 1）
     constant integer   bj_MISSION_INDEX_XH01       = bj_CAMPAIGN_OFFSET_XH * 1000 + 1
+    // 战役任务引索常量 - 冰封王座人族（bj_CAMPAIGN_OFFSET_XH * 1000 + 2）
     constant integer   bj_MISSION_INDEX_XH02       = bj_CAMPAIGN_OFFSET_XH * 1000 + 2
+    // 战役任务引索常量 - 冰封王座人族（bj_CAMPAIGN_OFFSET_XH * 1000 + 3）
     constant integer   bj_MISSION_INDEX_XH03       = bj_CAMPAIGN_OFFSET_XH * 1000 + 3
+    // 战役任务引索常量 - 冰封王座人族（bj_CAMPAIGN_OFFSET_XH * 1000 + 4）
     constant integer   bj_MISSION_INDEX_XH04       = bj_CAMPAIGN_OFFSET_XH * 1000 + 4
+    // 战役任务引索常量 - 冰封王座人族（bj_CAMPAIGN_OFFSET_XH * 1000 + 5）
     constant integer   bj_MISSION_INDEX_XH05       = bj_CAMPAIGN_OFFSET_XH * 1000 + 5
+    // 战役任务引索常量 - 冰封王座人族（bj_CAMPAIGN_OFFSET_XH * 1000 + 6）
     constant integer   bj_MISSION_INDEX_XH06       = bj_CAMPAIGN_OFFSET_XH * 1000 + 6
+    // 战役任务引索常量 - 冰封王座人族（bj_CAMPAIGN_OFFSET_XH * 1000 + 7）
     constant integer   bj_MISSION_INDEX_XH07       = bj_CAMPAIGN_OFFSET_XH * 1000 + 7
+    // 战役任务引索常量 - 冰封王座人族（bj_CAMPAIGN_OFFSET_XH * 1000 + 8）
     constant integer   bj_MISSION_INDEX_XH08       = bj_CAMPAIGN_OFFSET_XH * 1000 + 8
+    // 战役任务引索常量 - 冰封王座人族（bj_CAMPAIGN_OFFSET_XH * 1000 + 9）
     constant integer   bj_MISSION_INDEX_XH09       = bj_CAMPAIGN_OFFSET_XH * 1000 + 9
     // Expansion Undead
+    // 战役任务引索常量 - 冰封王座不死族（bj_CAMPAIGN_OFFSET_XU * 1000 + 0）
     constant integer   bj_MISSION_INDEX_XU00       = bj_CAMPAIGN_OFFSET_XU * 1000 + 0
+    // 战役任务引索常量 - 冰封王座不死族（bj_CAMPAIGN_OFFSET_XU * 1000 + 1）
     constant integer   bj_MISSION_INDEX_XU01       = bj_CAMPAIGN_OFFSET_XU * 1000 + 1
+    // 战役任务引索常量 - 冰封王座不死族（bj_CAMPAIGN_OFFSET_XU * 1000 + 2）
     constant integer   bj_MISSION_INDEX_XU02       = bj_CAMPAIGN_OFFSET_XU * 1000 + 2
+    // 战役任务引索常量 - 冰封王座不死族（bj_CAMPAIGN_OFFSET_XU * 1000 + 3）
     constant integer   bj_MISSION_INDEX_XU03       = bj_CAMPAIGN_OFFSET_XU * 1000 + 3
+    // 战役任务引索常量 - 冰封王座不死族（bj_CAMPAIGN_OFFSET_XU * 1000 + 4）
     constant integer   bj_MISSION_INDEX_XU04       = bj_CAMPAIGN_OFFSET_XU * 1000 + 4
+    // 战役任务引索常量 - 冰封王座不死族（bj_CAMPAIGN_OFFSET_XU * 1000 + 5）
     constant integer   bj_MISSION_INDEX_XU05       = bj_CAMPAIGN_OFFSET_XU * 1000 + 5
+    // 战役任务引索常量 - 冰封王座不死族（bj_CAMPAIGN_OFFSET_XU * 1000 + 6）
     constant integer   bj_MISSION_INDEX_XU06       = bj_CAMPAIGN_OFFSET_XU * 1000 + 6
+    // 战役任务引索常量 - 冰封王座不死族（bj_CAMPAIGN_OFFSET_XU * 1000 + 7）
     constant integer   bj_MISSION_INDEX_XU07       = bj_CAMPAIGN_OFFSET_XU * 1000 + 7
+    // 战役任务引索常量 - 冰封王座不死族（bj_CAMPAIGN_OFFSET_XU * 1000 + 8）
     constant integer   bj_MISSION_INDEX_XU08       = bj_CAMPAIGN_OFFSET_XU * 1000 + 8
+    // 战役任务引索常量 - 冰封王座不死族（bj_CAMPAIGN_OFFSET_XU * 1000 + 9）
     constant integer   bj_MISSION_INDEX_XU09       = bj_CAMPAIGN_OFFSET_XU * 1000 + 9
+    // 战役任务引索常量 - 冰封王座不死族（bj_CAMPAIGN_OFFSET_XU * 1000 + 10）
     constant integer   bj_MISSION_INDEX_XU10       = bj_CAMPAIGN_OFFSET_XU * 1000 + 10
+    // 战役任务引索常量 - 冰封王座不死族（bj_CAMPAIGN_OFFSET_XU * 1000 + 11）
     constant integer   bj_MISSION_INDEX_XU11       = bj_CAMPAIGN_OFFSET_XU * 1000 + 11
+    // 战役任务引索常量 - 冰封王座不死族（bj_CAMPAIGN_OFFSET_XU * 1000 + 12）
     constant integer   bj_MISSION_INDEX_XU12       = bj_CAMPAIGN_OFFSET_XU * 1000 + 12
+    // 战役任务引索常量 - 冰封王座不死族（bj_CAMPAIGN_OFFSET_XU * 1000 + 13）
     constant integer   bj_MISSION_INDEX_XU13       = bj_CAMPAIGN_OFFSET_XU * 1000 + 13
 
     // Expansion Orc
+    // 战役任务引索常量 - 冰封王座兽族（额外战役）（bj_CAMPAIGN_OFFSET_XO * 1000 + 0）
     constant integer   bj_MISSION_INDEX_XO00       = bj_CAMPAIGN_OFFSET_XO * 1000 + 0
+    // 战役任务引索常量 - 冰封王座兽族（额外战役）（bj_CAMPAIGN_OFFSET_XO * 1000 + 1）
     constant integer   bj_MISSION_INDEX_XO01       = bj_CAMPAIGN_OFFSET_XO * 1000 + 1
+    // 战役任务引索常量 - 冰封王座兽族（额外战役）（bj_CAMPAIGN_OFFSET_XO * 1000 + 2）
     constant integer   bj_MISSION_INDEX_XO02       = bj_CAMPAIGN_OFFSET_XO * 1000 + 2
+    // 战役任务引索常量 - 冰封王座兽族（额外战役）（bj_CAMPAIGN_OFFSET_XO * 1000 + 3）
     constant integer   bj_MISSION_INDEX_XO03       = bj_CAMPAIGN_OFFSET_XO * 1000 + 3
 
     // Cinematic indexing constants
+    // 电影引索常量（0）
     constant integer   bj_CINEMATICINDEX_TOP      = 0
+    // 电影引索常量（1）
     constant integer   bj_CINEMATICINDEX_HOP      = 1
+    // 电影引索常量（2）
     constant integer   bj_CINEMATICINDEX_HED      = 2
+    // 电影引索常量（3）
     constant integer   bj_CINEMATICINDEX_OOP      = 3
+    // 电影引索常量（4）
     constant integer   bj_CINEMATICINDEX_OED      = 4
+    // 电影引索常量（5）
     constant integer   bj_CINEMATICINDEX_UOP      = 5
+    // 电影引索常量（6）
     constant integer   bj_CINEMATICINDEX_UED      = 6
+    // 电影引索常量（7）
     constant integer   bj_CINEMATICINDEX_NOP      = 7
+    // 电影引索常量（8）
     constant integer   bj_CINEMATICINDEX_NED      = 8
+    // 电影引索常量（9）
     constant integer   bj_CINEMATICINDEX_XOP      = 9
+    // 电影引索常量（10）
     constant integer   bj_CINEMATICINDEX_XED      = 10
 
     // Alliance settings
@@ -372,7 +503,7 @@ globals
     constant integer   bj_KEYEVENTKEY_RIGHT        = 1
     // 键盘按键事件 方向键（上）
     constant integer   bj_KEYEVENTKEY_DOWN         = 2
-    // 键盘按键事件 方向键（下））
+    // 键盘按键事件 方向键（下）
     constant integer   bj_KEYEVENTKEY_UP           = 3
 
     // Mouse Event Types
@@ -398,24 +529,41 @@ globals
     constant integer   bj_CAMERABOUNDS_ADJUST_SUB  = 1
 
     // Quest creation states
+    // 任务类型（创建任务时设置） 主要/主线任务
     constant integer   bj_QUESTTYPE_REQ_DISCOVERED   = 0
+    // 任务类型（创建任务时设置） 主要/主线任务（未发现）
     constant integer   bj_QUESTTYPE_REQ_UNDISCOVERED = 1
+    // 任务类型（创建任务时设置） 可选/支线任务
     constant integer   bj_QUESTTYPE_OPT_DISCOVERED   = 2
+    // 任务类型（创建任务时设置） 可选/支线任务（未发现）
     constant integer   bj_QUESTTYPE_OPT_UNDISCOVERED = 3
 
     // Quest message types
+    // 任务信息类型 发现任务
     constant integer   bj_QUESTMESSAGE_DISCOVERED    = 0
+    // 任务信息类型 任务升级
     constant integer   bj_QUESTMESSAGE_UPDATED       = 1
+    // 任务信息类型 任务完成
     constant integer   bj_QUESTMESSAGE_COMPLETED     = 2
+    // 任务信息类型 发现失败
     constant integer   bj_QUESTMESSAGE_FAILED        = 3
+    // 任务信息类型 发现要求
     constant integer   bj_QUESTMESSAGE_REQUIREMENT   = 4
+    // 任务信息类型 发现失败
     constant integer   bj_QUESTMESSAGE_MISSIONFAILED = 5
+    // 任务信息类型 提示
     constant integer   bj_QUESTMESSAGE_ALWAYSHINT    = 6
+    // 任务信息类型 简单提示
     constant integer   bj_QUESTMESSAGE_HINT          = 7
+    // 任务信息类型 秘密
     constant integer   bj_QUESTMESSAGE_SECRET        = 8
+    // 任务信息类型 获得新单位
     constant integer   bj_QUESTMESSAGE_UNITACQUIRED  = 9
+    // 任务信息类型 新单位可取得
     constant integer   bj_QUESTMESSAGE_UNITAVAILABLE = 10
+    // 任务信息类型 获得新物品
     constant integer   bj_QUESTMESSAGE_ITEMACQUIRED  = 11
+    // 任务信息类型 警告
     constant integer   bj_QUESTMESSAGE_WARNING       = 12
 
     // Leaderboard sorting methods
@@ -435,25 +583,39 @@ globals
     constant integer   bj_CINEFADETYPE_FADEOUTIN   = 2
 
     // Buff removal methods
+    // BUFF 属性 - 按类别删除BUFF 肯定（正面BUFF）
     constant integer   bj_REMOVEBUFFS_POSITIVE     = 0
+    // BUFF 属性 - 按类别删除BUFF 否定（负面BUFF）
     constant integer   bj_REMOVEBUFFS_NEGATIVE     = 1
+    // BUFF 属性 - 按类别删除BUFF 全部（正面BUFF 和 负面BUFF）
     constant integer   bj_REMOVEBUFFS_ALL          = 2
+    // BUFF 属性 - 按类别删除BUFF 除终止计时器外的全部
     constant integer   bj_REMOVEBUFFS_NONTLIFE     = 3
 
     // Buff properties - polarity
+    // BUFF 属性 - 极性 肯定（正面BUFF）
     constant integer   bj_BUFF_POLARITY_POSITIVE   = 0
+    // BUFF 属性 - 极性 否定（负面BUFF）
     constant integer   bj_BUFF_POLARITY_NEGATIVE   = 1
+    // BUFF 属性 - 极性 肯定 或 否定（正面BUFF 或 负面BUFF）
     constant integer   bj_BUFF_POLARITY_EITHER     = 2
 
     // Buff properties - resist type
+    // BUFF 属性 魔法BUFF
     constant integer   bj_BUFF_RESIST_MAGIC        = 0
+    // BUFF 属性 物理BUFF
     constant integer   bj_BUFF_RESIST_PHYSICAL     = 1
+    // BUFF 属性 物理BUFF 或 魔法BUFF
     constant integer   bj_BUFF_RESIST_EITHER       = 2
+    // BUFF 属性 物理BUFF 和 魔法BUFF
     constant integer   bj_BUFF_RESIST_BOTH         = 3
 
     // Hero stats
+    // 英雄数值统计 力量值
     constant integer   bj_HEROSTAT_STR             = 0
+    // 英雄数值统计 敏捷值
     constant integer   bj_HEROSTAT_AGI             = 1
+    // 英雄数值统计 智力值
     constant integer   bj_HEROSTAT_INT             = 2
 
     // Hero skill point modification methods
@@ -465,9 +627,13 @@ globals
     constant integer   bj_MODIFYMETHOD_SET    = 2
 
     // Unit state adjustment methods (for replaced units)
+    // 替换单位时，新单位的生命值和魔法值设置 使用旧单位的生命值和魔法值
     constant integer   bj_UNIT_STATE_METHOD_ABSOLUTE = 0
+    // 替换单位时，新单位的生命值和魔法值设置  使用旧单位相关物的生命值和魔法值
     constant integer   bj_UNIT_STATE_METHOD_RELATIVE = 1
+    // 替换单位时，新单位的生命值和魔法值设置 使用新单位默认值
     constant integer   bj_UNIT_STATE_METHOD_DEFAULTS = 2
+    // 替换单位时，新单位的生命值和魔法值设置 使用新单位的最大值
     constant integer   bj_UNIT_STATE_METHOD_MAXIMUM  = 3
 
     // Gate operations
@@ -503,16 +669,25 @@ globals
 	constant integer   bj_HASHTABLE_HANDLE                  = 4
 
     // Item status types
+    // 物品状态 隐藏的
     constant integer   bj_ITEM_STATUS_HIDDEN       = 0
+    // 物品状态 拥有的
     constant integer   bj_ITEM_STATUS_OWNED        = 1
+    // 物品状态 无敌的
     constant integer   bj_ITEM_STATUS_INVULNERABLE = 2
+    // 物品状态 力量提升的
     constant integer   bj_ITEM_STATUS_POWERUP      = 3
+    // 物品状态 可出售的
     constant integer   bj_ITEM_STATUS_SELLABLE     = 4
+    // 物品状态 可以被抵押掉的
     constant integer   bj_ITEM_STATUS_PAWNABLE     = 5
 
     // Itemcode status types
+    // 物品类型 力量提升的
     constant integer   bj_ITEMCODE_STATUS_POWERUP  = 0
+    // 物品类型 可出售的
     constant integer   bj_ITEMCODE_STATUS_SELLABLE = 1
+    // 物品类型 可以被抵押掉的
     constant integer   bj_ITEMCODE_STATUS_PAWNABLE = 2
 
     // Minimap ping styles
@@ -524,14 +699,23 @@ globals
     constant integer   bj_MINIMAPPINGSTYLE_ATTACK  = 2
 	
     // Campaign Minimap icon styles
+    // 小地图图标类型
     constant integer   bj_CAMPPINGSTYLE_PRIMARY			= 0
+    // 小地图图标类型
     constant integer   bj_CAMPPINGSTYLE_PRIMARY_GREEN   = 1
+    // 小地图图标类型
     constant integer   bj_CAMPPINGSTYLE_PRIMARY_RED     = 2
+    // 小地图图标类型
     constant integer   bj_CAMPPINGSTYLE_BONUS			= 3
+    // 小地图图标类型
     constant integer   bj_CAMPPINGSTYLE_TURNIN			= 4
+    // 小地图图标类型
 	constant integer   bj_CAMPPINGSTYLE_BOSS			= 5
+    // 小地图图标类型
 	constant integer   bj_CAMPPINGSTYLE_CONTROL_ALLY	= 6
+    // 小地图图标类型
 	constant integer   bj_CAMPPINGSTYLE_CONTROL_NEUTRAL	= 7
+    // 小地图图标类型
 	constant integer   bj_CAMPPINGSTYLE_CONTROL_ENEMY	= 8
 
     // Corpse creation settings
@@ -579,12 +763,15 @@ globals
     integer            bj_forLoopBIndex            = 0
     integer            bj_forLoopAIndexEnd         = 0
     integer            bj_forLoopBIndexEnd         = 0
-
+    // 玩家检查是否完成，自动检查，检查完成后自动变为真，用于开局系统自动检查所有玩家槽是电脑（不论是否具备AI）还是真人
     boolean            bj_slotControlReady         = false
+    // 玩家是真人，数组，每位玩家都有标识，系统在开局时自动设置
     boolean array      bj_slotControlUsed
+    // 控制类型，标识当前插槽的玩家是电脑还是真人
     mapcontrol array   bj_slotControl
 
     // Game started detection vars
+    // 开局计时器
     timer              bj_gameStartedTimer         = null
     boolean            bj_gameStarted              = false
     timer              bj_volumeGroupsTimer        = CreateTimer()
@@ -730,36 +917,67 @@ globals
     integer array      bj_randDistChance
 
     // Last X'd vars
+    // 最后创建的单位
     unit               bj_lastCreatedUnit          = null
+    // 最后创建的物品
     item               bj_lastCreatedItem          = null
+    // 最后删除的物品
     item               bj_lastRemovedItem          = null
+    // 最后创建的闹鬼金矿
     unit               bj_lastHauntedGoldMine      = null
+    // 最后创建的可破坏物
     destructable       bj_lastCreatedDestructable  = null
+    // 最后创建的单位组
     group              bj_lastCreatedGroup         = CreateGroup()
+    // 最后创建的可见度修正器
     fogmodifier        bj_lastCreatedFogModifier   = null
+    // 最后创建的特效
     effect             bj_lastCreatedEffect        = null
+    // 最后创建的天气特效
     weathereffect      bj_lastCreatedWeatherEffect = null
+    // 最后创建的地形变化
     terraindeformation bj_lastCreatedTerrainDeformation = null
+    // 最后创建的任务
     quest              bj_lastCreatedQuest         = null
+    // 最后创建的任务要求
     questitem          bj_lastCreatedQuestItem     = null
+    // 最后创建的失败条件
     defeatcondition    bj_lastCreatedDefeatCondition = null
+    // 最后创建的计时器
     timer              bj_lastStartedTimer         = CreateTimer()
+    // 最后创建的计时器窗口
     timerdialog        bj_lastCreatedTimerDialog   = null
+    // 最后创建的排行榜
     leaderboard        bj_lastCreatedLeaderboard   = null
+    // 最后创建的多面板
     multiboard         bj_lastCreatedMultiboard    = null
+    // 最后播放的声音
     sound              bj_lastPlayedSound          = null
+    // 最后播放的音乐
     string             bj_lastPlayedMusic          = ""
+    // 最后传输的消息的持续时间
     real               bj_lastTransmissionDuration = 0
+    // 最后创建的游戏缓存
     gamecache          bj_lastCreatedGameCache     = null
+    // 最后创建的哈希表
     hashtable          bj_lastCreatedHashtable     = null
+    // 最后恢复的单位
     unit               bj_lastLoadedUnit           = null
+    // 最后创建的按钮
     button             bj_lastCreatedButton        = null
+    // 最后替代的单位
     unit               bj_lastReplacedUnit         = null
+    // 最后创建的文本
     texttag            bj_lastCreatedTextTag       = null
+    // 最后创建的闪电效果
     lightning          bj_lastCreatedLightning     = null
+    // 最后创建的图像
     image              bj_lastCreatedImage         = null
+    // 最后创建的地面纹理变化
     ubersplat          bj_lastCreatedUbersplat     = null
+    // 最后创建的小地图图标
     minimapicon        bj_lastCreatedMinimapIcon   = null
+    // 最后创建的按钮特效
 	commandbuttoneffect bj_lastCreatedCommandButtonEffect = null
 
     // Filter function vars
@@ -3611,7 +3829,7 @@ function ChooseRandomItemBJ takes integer level returns integer
 endfunction
 
 
-// 随机物品-有类别
+// 随机物品-指定类别
 function ChooseRandomItemExBJ takes integer level, itemtype whichType returns integer
     return ChooseRandomItemEx(whichType, level)
 endfunction
@@ -4293,19 +4511,19 @@ function SetUnitAcquireRangeBJ takes unit whichUnit, real acquireRange returns n
 endfunction
 
 
-// 设置单位睡眠(之在晚上)
+// 设置单位睡觉(在晚上)
 function UnitSetCanSleepBJ takes unit whichUnit, boolean canSleep returns nothing
     call UnitAddSleep(whichUnit, canSleep)
 endfunction
 
 
-// 单位晚上睡觉
+// 单位晚上是否睡觉
 function UnitCanSleepBJ takes unit whichUnit returns boolean
     return UnitCanSleep(whichUnit)
 endfunction
 
 
-// 设置单位醒来
+// 唤醒单位
 function UnitWakeUpBJ takes unit whichUnit returns nothing
     call UnitWakeUp(whichUnit)
 endfunction
@@ -4316,7 +4534,7 @@ function UnitIsSleepingBJ takes unit whichUnit returns boolean
     return UnitIsSleeping(whichUnit)
 endfunction
 
-
+// 唤醒单位
 function WakePlayerUnitsEnum takes nothing returns nothing
     call UnitWakeUp(GetEnumUnit())
 endfunction
@@ -4353,13 +4571,13 @@ function DoesUnitGenerateAlarms takes unit whichUnit returns boolean
 endfunction
 
 
-// Pause all units 
+// 暂停所有单位 Pause all units 
 function PauseAllUnitsBJEnum takes nothing returns nothing
     call PauseUnit( GetEnumUnit(), bj_pauseAllUnitsFlag )
 endfunction
 
 
-// Pause all units 
+// 暂停/恢复 所有单位 Pause all units 
 function PauseAllUnitsBJ takes boolean pause returns nothing
     local integer index
     local player  indexPlayer
@@ -4418,7 +4636,7 @@ function UnitShareVisionBJ takes boolean share, unit whichUnit, player whichPlay
 endfunction
 
 
-// 删除 持续状态
+// 删除 持续状态（BUFF）
 function UnitRemoveBuffsBJ takes integer buffType, unit whichUnit returns nothing
     if (buffType == bj_REMOVEBUFFS_POSITIVE) then
         call UnitRemoveBuffs(whichUnit, true, false)

--- a/static/blizzard.j
+++ b/static/blizzard.j
@@ -92,7 +92,7 @@ globals
     // 最大物品等级，默认10级
     constant integer   bj_MAX_ITEM_LEVEL                =  10
     
-    // Auto Save constants  最大保存点数量，默认5
+    // Auto Save constants  最大自动保存次数，默认5
     constant integer   bj_MAX_CHECKPOINTS               =  5
 
     // Ideally these would be looked up from Units/MiscData.txt,
@@ -134,9 +134,9 @@ globals
     constant real      bj_MELEE_CRIPPLE_TIMEOUT         = 120.00
     // 失去全部基地，暴露倒计时结束，玩家依旧没有造基地，显示玩家位置的持续时间，默认20.00
     constant real      bj_MELEE_CRIPPLE_MSG_DURATION    = 20.00
-    // 英雄初始物品要给予的次数，默认3次，即前3个获得的英雄都会给（V0表示混乱之治）
+    // 英雄初始物品给予次数，默认3次，即前3发英雄都给（V0表示混乱之治）
     constant integer   bj_MELEE_MAX_TWINKED_HEROES_V0   = 3
-    // 英雄初始物品要给予的次数，默认1次，即只给第1个获得的英雄（V1表示冰封王座）
+    // 英雄初始物品给予次数，默认1次，即只给首发英雄（V1表示冰封王座）
     constant integer   bj_MELEE_MAX_TWINKED_HEROES_V1   = 1
 
     // Delay between a creep's death and the time it may drop an item.
@@ -522,7 +522,7 @@ globals
     // Keyboard Event Keys
     // 键盘按键事件 方向键（左）
     constant integer   bj_KEYEVENTKEY_LEFT         = 0
-    // 方键盘按键事件 方向键（右）
+    // 键盘按键事件 方向键（右）
     constant integer   bj_KEYEVENTKEY_RIGHT        = 1
     // 键盘按键事件 方向键（上）
     constant integer   bj_KEYEVENTKEY_DOWN         = 2
@@ -598,39 +598,39 @@ globals
     constant integer   bj_SORTTYPE_SORTBYLABEL     = 2
 
     // Cinematic fade filter methods
-    // 电影类型-淡入
+    // 电影淡化-淡入
     constant integer   bj_CINEFADETYPE_FADEIN      = 0
-    // 电影类型-淡出
+    // 电影淡化-淡出
     constant integer   bj_CINEFADETYPE_FADEOUT     = 1
-    // 电影类型-淡出并淡入（一并使用）
+    // 电影淡化-淡出并淡入（一并使用）
     constant integer   bj_CINEFADETYPE_FADEOUTIN   = 2
 
     // Buff removal methods
-    // BUFF 属性 - 按类别删除BUFF 肯定（正面BUFF）
+    // BUFF属性 - 按类别删除BUFF 肯定（正面BUFF）
     constant integer   bj_REMOVEBUFFS_POSITIVE     = 0
-    // BUFF 属性 - 按类别删除BUFF 否定（负面BUFF）
+    // BUFF属性 - 按类别删除BUFF 否定（负面BUFF）
     constant integer   bj_REMOVEBUFFS_NEGATIVE     = 1
-    // BUFF 属性 - 按类别删除BUFF 全部（正面BUFF 和 负面BUFF）
+    // BUFF属性 - 按类别删除BUFF 全部（正面BUFF 和 负面BUFF）
     constant integer   bj_REMOVEBUFFS_ALL          = 2
-    // BUFF 属性 - 按类别删除BUFF 除终止计时器外的全部
+    // BUFF属性 - 按类别删除BUFF 除终止计时器外的全部
     constant integer   bj_REMOVEBUFFS_NONTLIFE     = 3
 
     // Buff properties - polarity
-    // BUFF 属性 - 极性 肯定（正面BUFF）
+    // BUFF属性 - 极性 肯定（正面BUFF）
     constant integer   bj_BUFF_POLARITY_POSITIVE   = 0
-    // BUFF 属性 - 极性 否定（负面BUFF）
+    // BUFF属性 - 极性 否定（负面BUFF）
     constant integer   bj_BUFF_POLARITY_NEGATIVE   = 1
-    // BUFF 属性 - 极性 肯定 或 否定（正面BUFF 或 负面BUFF）
+    // BUFF属性 - 极性 肯定 或 否定（正面BUFF 或 负面BUFF）
     constant integer   bj_BUFF_POLARITY_EITHER     = 2
 
     // Buff properties - resist type
-    // BUFF 属性 魔法BUFF
+    // BUFF属性 魔法BUFF
     constant integer   bj_BUFF_RESIST_MAGIC        = 0
-    // BUFF 属性 物理BUFF
+    // BUFF属性 物理BUFF
     constant integer   bj_BUFF_RESIST_PHYSICAL     = 1
-    // BUFF 属性 物理BUFF 或 魔法BUFF
+    // BUFF属性 物理BUFF 或 魔法BUFF
     constant integer   bj_BUFF_RESIST_EITHER       = 2
-    // BUFF 属性 物理BUFF 和 魔法BUFF
+    // BUFF属性 物理BUFF 和 魔法BUFF
     constant integer   bj_BUFF_RESIST_BOTH         = 3
 
     // Hero stats
@@ -822,15 +822,25 @@ globals
     boolean            bj_isSinglePlayer           = false
 
     // Day/Night Cycle vars
+    // 昼夜参数 白天声音触发器
     trigger            bj_dncSoundsDay             = null
+    // 昼夜参数 夜晚声音触发器
     trigger            bj_dncSoundsNight           = null
+    // 昼夜参数 白天环境声效
     sound              bj_dayAmbientSound          = null
+    // 昼夜参数 夜晚环境声效
     sound              bj_nightAmbientSound        = null
+    // 昼夜参数 黎明声音触发器
     trigger            bj_dncSoundsDawn            = null
+    // 昼夜参数 黄昏声音触发器
     trigger            bj_dncSoundsDusk            = null
+    // 昼夜参数 黎明声效
     sound              bj_dawnSound                = null
+    // 昼夜参数 黄昏声效
     sound              bj_duskSound                = null
+    // 昼夜参数 是否启用黎明/黄昏声效
     boolean            bj_useDawnDuskSounds        = true
+    // 昼夜参数 是否启用昼夜交替
     boolean            bj_dncIsDaytime             = false
 
     // Triggered sounds
@@ -936,21 +946,35 @@ globals
     trigger            bj_cineSceneBeingSkipped    = null
 
     // Cinematic mode vars
+    // 电影模式设置 默认速度
     gamespeed          bj_cineModePriorSpeed       = MAP_SPEED_NORMAL
+    // 电影模式设置 战争迷雾状态（启用或禁用）
     boolean            bj_cineModePriorFogSetting  = false
+    // 电影模式设置 黑色阴影状态（启用或禁用）
     boolean            bj_cineModePriorMaskSetting = false
+    // 电影模式设置 电影准备状态（完成或未完成）
     boolean            bj_cineModeAlreadyIn        = false
+    // 电影模式设置 黎明/昏黄状态（启用或禁用）
     boolean            bj_cineModePriorDawnDusk    = false
+    // 电影模式设置 保存速度，默认值0，游戏初始化后取随机数0~1000000
     integer            bj_cineModeSavedSeed        = 0
 
     // Cinematic fade vars
+    // 电影淡入淡出滤镜 淡化计时器
     timer              bj_cineFadeFinishTimer      = null
+    // 电影淡入淡出滤镜 继续淡化计时器
     timer              bj_cineFadeContinueTimer    = null
+    // 电影淡入淡出滤镜 继续淡化（红）
     real               bj_cineFadeContinueRed      = 0
+    // 电影淡入淡出滤镜 继续淡化（绿）
     real               bj_cineFadeContinueGreen    = 0
+    // 电影淡入淡出滤镜 继续淡化（蓝）
     real               bj_cineFadeContinueBlue     = 0
+    // 电影淡入淡出滤镜 透明度
     real               bj_cineFadeContinueTrans    = 0
+    // 电影淡入淡出滤镜 转化时间
     real               bj_cineFadeContinueDuration = 0
+    // 电影淡入淡出滤镜 使用图片（图片路径）
     string             bj_cineFadeContinueTex      = ""
 
     // QueuedTriggerExecute vars
@@ -966,7 +990,9 @@ globals
     trigger            bj_queuedExecTimeout        = null
 
     // Helper vars (for Filter and Enum funcs)
+    // 可破坏物死亡事件 统计死亡的可破坏物数量
     integer            bj_destInRegionDiesCount    = 0
+    // 可破坏物死亡事件 死亡的可破坏物动作的触发器
     trigger            bj_destInRegionDiesTrig     = null
     // 单位组内单位数量
     integer            bj_groupCountUnits          = 0
@@ -982,6 +1008,7 @@ globals
     group              bj_groupRemoveGroupDest     = null
     integer            bj_groupRandomConsidered    = 0
     unit               bj_groupRandomCurrentPick   = null
+    //最后创建且需要摧毁的单位组
     group              bj_groupLastCreatedDest     = null
     group              bj_randomSubGroupGroup      = null
     integer            bj_randomSubGroupWant       = 0
@@ -989,17 +1016,25 @@ globals
     real               bj_randomSubGroupChance     = 0
     integer            bj_destRandomConsidered     = 0
     destructable       bj_destRandomCurrentPick    = null
+    // 可破坏物 升降机路径阻断器
     destructable       bj_elevatorWallBlocker      = null
+    // 可破坏物 相邻的升降机
     destructable       bj_elevatorNeighbor         = null
     integer            bj_itemRandomConsidered     = 0
     item               bj_itemRandomCurrentPick    = null
     integer            bj_forceRandomConsidered    = 0
     player             bj_forceRandomCurrentPick   = null
+    // 可营救单位
     unit               bj_makeUnitRescuableUnit    = null
+    // 可营救单位是否已被营救
     boolean            bj_makeUnitRescuableFlag    = true
+    // 暂停/恢复所有单位
     boolean            bj_pauseAllUnitsFlag        = true
+    // 可破坏物中心店
     location           bj_enumDestructableCenter   = null
+    // 可破坏物半径（范围）
     real               bj_enumDestructableRadius   = 0
+    // 设置玩家颜色
     playercolor        bj_setPlayerTargetColor     = null
     boolean            bj_isUnitGroupDeadResult    = true
     boolean            bj_isUnitGroupEmptyResult   = true
@@ -2503,7 +2538,7 @@ function TriggerRegisterGameSavedEventBJ takes trigger trig returns event
 endfunction
 
 
-// 注册可破坏物在区域内死亡(矩形区域)
+// 可破坏物在区域内死亡动作(矩形区域)
 function RegisterDestDeathInRegionEnum takes nothing returns nothing
     set bj_destInRegionDiesCount = bj_destInRegionDiesCount + 1
     if (bj_destInRegionDiesCount <= bj_MAX_DEST_IN_REGION_EVENTS) then
@@ -3360,7 +3395,7 @@ function EnableDawnDusk takes boolean flag returns nothing
 endfunction
 
 
-// 是否启用了黎明和黄昏
+// 是否启用了黎明/黄昏
 function IsDawnDuskEnabled takes nothing returns boolean
     return bj_useDawnDuskSounds
 endfunction
@@ -4154,12 +4189,12 @@ function CreateNUnitsAtLocFacingLocBJ takes integer count, integer unitId, playe
 endfunction
 
 
-// 最后创建的单位组
+// 添加选取的单位到最后创建的单位组
 function GetLastCreatedGroupEnum takes nothing returns nothing
     call GroupAddUnit(bj_groupLastCreatedDest, GetEnumUnit())
 endfunction
 
-
+// 创建单位组并添加选取单位
 function GetLastCreatedGroup takes nothing returns group
     set bj_groupLastCreatedDest = CreateGroup()
     call ForGroup(bj_lastCreatedGroup, function GetLastCreatedGroupEnum)
@@ -8049,7 +8084,7 @@ function AbortCinematicFadeBJ takes nothing returns nothing
 endfunction
 
 
-// 淡化的过滤器
+// 淡入淡出滤镜
 function CinematicFadeBJ takes integer fadetype, real duration, string tex, real red, real green, real blue, real trans returns nothing
     if (fadetype == bj_CINEFADETYPE_FADEOUT) then
         // Fade out to the requested color.
@@ -10198,7 +10233,8 @@ endfunction
 //*
 //***************************************************************************
 
-
+// 选择对战AI
+// @params1~s3 不同的AI文件，系统默认只有s1，当s2或s3不为null时，非新手电脑有几率（随机）使用AI
 function PickMeleeAI takes player num, string s1, string s2, string s3 returns nothing
     local integer pick
 
@@ -10262,7 +10298,7 @@ function MeleeStartingAI takes nothing returns nothing
     endloop
 endfunction
 
-// 锁定的防守职责
+// 锁定单位防守职责
 function LockGuardPosition takes unit targ returns nothing
     call SetUnitCreepGuard(targ,true)
 endfunction

--- a/static/blizzard.j
+++ b/static/blizzard.j
@@ -73,7 +73,7 @@ globals
     // 轮询跳过阈值（游戏时间），默认2
     constant real      bj_POLLED_WAIT_SKIP_THRESHOLD    =  2.00
 
-    // Game constants  最大库存
+    // Game constants  最大库存，默认6
     constant integer   bj_MAX_INVENTORY                 =  6
     // 最大玩家数（包含12或24位玩家和中立敌对玩家，共13/25位）
     constant integer   bj_MAX_PLAYERS                   =  GetBJMaxPlayers()
@@ -807,7 +807,7 @@ endfunction
 //***************************************************************************
 
 
-// 最小值
+// 对比实数，取最小值
 function RMinBJ takes real a, real b returns real
     if (a < b) then
         return a
@@ -817,7 +817,7 @@ function RMinBJ takes real a, real b returns real
 endfunction
 
 
-// 最大值
+// 对比实数，取最大值
 function RMaxBJ takes real a, real b returns real
     if (a < b) then
         return b
@@ -827,7 +827,7 @@ function RMaxBJ takes real a, real b returns real
 endfunction
 
 
-// 绝对值Abs
+// 取实数的绝对值
 function RAbsBJ takes real a returns real
     if (a >= 0) then
         return a
@@ -837,7 +837,7 @@ function RAbsBJ takes real a returns real
 endfunction
 
 
-// 标记
+// 取实数正负标记，输入数值大于等于0返回 1.0，小于0返回 -1.0
 function RSignBJ takes real a returns real
     if (a >= 0.0) then
         return 1.0
@@ -847,7 +847,7 @@ function RSignBJ takes real a returns real
 endfunction
 
 
-// 取最小值
+// 对比整数，取最小值
 function IMinBJ takes integer a, integer b returns integer
     if (a < b) then
         return a
@@ -857,7 +857,7 @@ function IMinBJ takes integer a, integer b returns integer
 endfunction
 
 
-// 取最大值
+// 对比整数，取最大值
 function IMaxBJ takes integer a, integer b returns integer
     if (a < b) then
         return b
@@ -867,7 +867,7 @@ function IMaxBJ takes integer a, integer b returns integer
 endfunction
 
 
-// 绝对值Abs
+// 取整数的绝对值
 function IAbsBJ takes integer a returns integer
     if (a >= 0) then
         return a
@@ -877,7 +877,7 @@ function IAbsBJ takes integer a returns integer
 endfunction
 
 
-// 标记
+// 取整数正负标记，输入数值大于等于0返回 1，小于0返回 -1
 function ISignBJ takes integer a returns integer
     if (a >= 0) then
         return 1
@@ -917,25 +917,25 @@ function AcosBJ takes real degrees returns real
 endfunction
 
 
-// 反正切 (From Angle)
+// 2象限反正切 (From Angle)
 function AtanBJ takes real degrees returns real
     return Atan(degrees) * bj_RADTODEG
 endfunction
 
 
-// 和正半轴角度
+// 4象限反正切
 function Atan2BJ takes real y, real x returns real
     return Atan2(y, x) * bj_RADTODEG
 endfunction
 
 
-// 两个坐标之间的角度
+// 两点之间的角度
 function AngleBetweenPoints takes location locA, location locB returns real
     return bj_RADTODEG * Atan2(GetLocationY(locB) - GetLocationY(locA), GetLocationX(locB) - GetLocationX(locA))
 endfunction
 
 
-// 坐标之间的距离
+// 两点之间的距离
 function DistanceBetweenPoints takes location locA, location locB returns real
     local real dx = GetLocationX(locB) - GetLocationX(locA)
     local real dy = GetLocationY(locB) - GetLocationY(locA)
@@ -943,7 +943,7 @@ function DistanceBetweenPoints takes location locA, location locB returns real
 endfunction
 
 
-// 点向方向 位移 
+// 点向指定方向 位移指定距离 
 function PolarProjectionBJ takes location source, real dist, real angle returns location
     local real x = GetLocationX(source) + dist * Cos(angle * bj_DEGTORAD)
     local real y = GetLocationY(source) + dist * Sin(angle * bj_DEGTORAD)
@@ -951,19 +951,19 @@ function PolarProjectionBJ takes location source, real dist, real angle returns 
 endfunction
 
 
-// 随机角度
+// 取随机角度
 function GetRandomDirectionDeg takes nothing returns real
     return GetRandomReal(0, 360)
 endfunction
 
 
-// 随机百分数
+// 取随机百分数
 function GetRandomPercentageBJ takes nothing returns real
     return GetRandomReal(0, 100)
 endfunction
 
 
-// 区域内的随机地点
+// 取区域内的随机地点
 function GetRandomLocInRect takes rect whichRect returns location
     return Location(GetRandomReal(GetRectMinX(whichRect), GetRectMaxX(whichRect)), GetRandomReal(GetRectMinY(whichRect), GetRectMaxY(whichRect)))
 endfunction
@@ -1005,7 +1005,7 @@ function ModuloReal takes real dividend, real divisor returns real
 endfunction
 
 
-// 点的坐标位移
+// 点位移
 function OffsetLocation takes location loc, real dx, real dy returns location
     return Location(GetLocationX(loc) + dx, GetLocationY(loc) + dy)
 endfunction
@@ -1040,13 +1040,13 @@ function RectContainsLoc takes rect r, location loc returns boolean
 endfunction
 
 
-// 单位在区域
+// 单位是否在区域内
 function RectContainsUnit takes rect r, unit whichUnit returns boolean
     return RectContainsCoords(r, GetUnitX(whichUnit), GetUnitY(whichUnit))
 endfunction
 
 
-// 物品在区域
+// 物品是否在区域内
 function RectContainsItem takes item whichItem, rect r returns boolean
     if (whichItem == null) then
         return false
@@ -1070,7 +1070,7 @@ endfunction
 
 // Runs the trigger's actions if the trigger's conditions evaluate to true.
 //
-// 运行触发器 (检查条件)
+// 运行触发器 (无视条件)
 function ConditionalTriggerExecute takes trigger trig returns nothing
     if TriggerEvaluate(trig) then
         call TriggerExecute(trig)
@@ -1080,7 +1080,7 @@ endfunction
 
 // Runs the trigger's actions if the trigger's conditions evaluate to true.
 //
-// 运行触发器
+// 运行触发器(检查条件)
 function TriggerExecuteBJ takes trigger trig, boolean checkConditions returns boolean
     if checkConditions then
         if not (TriggerEvaluate(trig)) then
@@ -1096,7 +1096,7 @@ endfunction
 // trigger is not interrupted as is the case with a TriggerExecute call.
 // Since the trigger executes normally, its conditions are still evaluated.
 //
-// 执行触发器
+// 执行触发器动作
 function PostTriggerExecuteBJ takes trigger trig, boolean checkConditions returns boolean
     if checkConditions then
         if not (TriggerEvaluate(trig)) then

--- a/static/blizzard.j
+++ b/static/blizzard.j
@@ -232,10 +232,10 @@ globals
     constant real      bj_SPEECH_VOLUME_FIRE            = 0.60
 
     // Smart pan settings
-    // 必要时平移镜头动作的距离限制，默认500
+    // 必要时平移镜头的距离限制，默认500
     // 超过该值但不超过 bj_SMARTPAN_TRESHOLD_SNAP 时，使用限定的时间平移，低于该值时不平移
     constant real      bj_SMARTPAN_TRESHOLD_PAN         = 500
-    // 必要时平移镜头动作的距离限制，默认3500
+    // 必要时平移镜头的距离限制，默认3500
     // 平移距离超过该值时，立即完成平移（限定的时间被替换为0秒）
     constant real      bj_SMARTPAN_TRESHOLD_SNAP        = 3500
 
@@ -804,9 +804,9 @@ globals
     integer            bj_forLoopBIndexEnd         = 0
     // 玩家检查是否完成，自动检查，检查完成后自动变为真，用于开局系统自动检查所有玩家槽是电脑（不论是否具备AI）还是真人
     boolean            bj_slotControlReady         = false
-    // 玩家是真人，数组，每位玩家都有标识，系统在开局时自动设置
+    // 玩家槽是否可用，每位玩家配一个，系统在开局时自动设置
     boolean array      bj_slotControlUsed
-    // 控制类型，标识当前插槽的玩家是电脑还是真人
+    // 标识当前插槽的玩家是电脑还是真人，每位玩家配一个
     mapcontrol array   bj_slotControl
 
     // Game started detection vars
@@ -869,7 +869,7 @@ globals
     sound              bj_defeatDialogSound        = null
 
     // Marketplace vars
-    // 市场相关变量 任意物品被购买触发
+    // 市场相关变量 任意物品被购买触发器
     trigger            bj_stockItemPurchased       = null
     // 市场相关变量 物品更新计时器
     timer              bj_stockUpdateTimer         = null
@@ -990,9 +990,9 @@ globals
     trigger            bj_queuedExecTimeout        = null
 
     // Helper vars (for Filter and Enum funcs)
-    // 可破坏物死亡事件 统计死亡的可破坏物数量
+    // 可破坏物死亡/毁坏事件触发器 统计死亡/毁坏的可破坏物数量
     integer            bj_destInRegionDiesCount    = 0
-    // 可破坏物死亡事件 死亡的可破坏物的触发器
+    // 可破坏物死亡/毁坏事件触发器 选取区域内的死亡/毁坏的可破坏物
     trigger            bj_destInRegionDiesTrig     = null
     // 单位组内单位数量
     integer            bj_groupCountUnits          = 0
@@ -1000,7 +1000,7 @@ globals
     integer            bj_forceCountPlayers        = 0
     // 获取单位组中指定类型的单位，指定的单位类型
     integer            bj_groupEnumTypeId          = 0
-    // 获取玩家在指定方形区域中的单位，指定的玩家
+    // 获取玩家在指定矩形区域中的单位，指定的玩家
     player             bj_groupEnumOwningPlayer    = null
     // 指代往 A单位组 添加 B单位组 单位完成后，需要摧毁的单位组
     group              bj_groupAddGroupDest        = null
@@ -1021,9 +1021,9 @@ globals
     // 随机选取单位组中的单位，指定的单位数量 与 原单位组的单位数量 的比例
     // bj_randomSubGroupChance = I2R(bj_randomSubGroupWant) / I2R(bj_randomSubGroupTotal)
     real               bj_randomSubGroupChance     = 0
-    // 随机选取方形区域的可破坏物，区域内的可破坏物数量
+    // 随机选取矩形区域的可破坏物，区域内的可破坏物数量
     integer            bj_destRandomConsidered     = 0
-    // 随机选取方形区域的可破坏物，选取的可破坏物
+    // 随机选取矩形区域的可破坏物，选取的可破坏物
     destructable       bj_destRandomCurrentPick    = null
     // 可破坏物 升降机路径阻断器
     destructable       bj_elevatorWallBlocker      = null
@@ -1091,7 +1091,7 @@ globals
     unit               bj_lastCreatedUnit          = null
     // 最后创建的物品
     item               bj_lastCreatedItem          = null
-    // 最后删除的物品
+    // 最后丢弃的物品
     item               bj_lastRemovedItem          = null
     // 最后创建的闹鬼金矿
     unit               bj_lastHauntedGoldMine      = null
@@ -1513,7 +1513,7 @@ endfunction
 
 // Debug - Display the contents of the trigger queue (as either null or "x"
 // for each entry).
-// 队列触发器检查
+// 触发器队列检查
 function QueuedTriggerCheck takes nothing returns nothing
     local string s = "TrigQueue Check "
     local integer i
@@ -1582,7 +1582,7 @@ endfunction
 // it and execute the next one.  Continue this cycle until a trigger runs,
 // or until the queue is empty.
 //
-// 队列中尝试执行触发器
+// 尝试执行队列中的触发器
 function QueuedTriggerAttemptExec takes nothing returns boolean
     loop
         exitwhen bj_queuedExecTotal == 0
@@ -1625,7 +1625,7 @@ endfunction
 // Denotes the end of a queued trigger. Be sure to call this only once per
 // queued trigger, or risk stepping on the toes of other queued triggers.
 //
-// 清除触发器队列
+// 从队列中清除触发器
 function QueuedTriggerRemoveBJ takes trigger trig returns nothing
     local integer index
     local integer trigIndex
@@ -1651,7 +1651,7 @@ endfunction
 // Denotes the end of a queued trigger. Be sure to call this only once per
 // queued trigger, lest you step on the toes of other queued triggers.
 //
-// 触发器队列完成
+// 完成触发器队列
 function QueuedTriggerDoneBJ takes nothing returns nothing
     local integer index
 
@@ -1671,7 +1671,7 @@ endfunction
 
 // Empty the trigger queue.
 //
-// 清除触发器所有队列
+// 清除所有触发器队列
 function QueuedTriggerClearBJ takes nothing returns nothing
     call PauseTimer(bj_queuedExecTimeoutTimer)
     set bj_queuedExecTotal = 0
@@ -1686,13 +1686,13 @@ function QueuedTriggerClearInactiveBJ takes nothing returns nothing
 endfunction
 
 
-// 触发器队列中触发器的数量
+// 统计触发器队列中触发器的数量
 function QueuedTriggerCountBJ takes nothing returns integer
     return bj_queuedExecTotal
 endfunction
 
 
-// 触发器队列是空的
+// 触发器队列是否为空
 function IsTriggerQueueEmptyBJ takes nothing returns boolean
     return bj_queuedExecTotal <= 0
 endfunction
@@ -1784,7 +1784,7 @@ endfunction
 // this function will serve as a stub.
 //
 // 此函数不起任何作用
-// WorldEdit会忽略此函数,因为此函数在脚本生成期间触发
+// WorldEdit会忽略此函数,因为此函数中不生成触发
 function CommentString takes string commentString returns nothing
 endfunction
 
@@ -1797,7 +1797,7 @@ function StringIdentity takes string theString returns string
 endfunction
 
 // 与运算
-// valueA && valueB
+// valueA && valueB 判断是否同时满足两个条件
 // @param valueA 条件A
 // @param valueB 条件B
 function GetBooleanAnd takes boolean valueA, boolean valueB returns boolean
@@ -1805,7 +1805,7 @@ function GetBooleanAnd takes boolean valueA, boolean valueB returns boolean
 endfunction
 
 // 或运算
-// valueA || valueB
+// valueA || valueB 判断是否满足任一条件
 // @param valueA 条件A
 // @param valueB 条件B
 function GetBooleanOr takes boolean valueA, boolean valueB returns boolean
@@ -1840,7 +1840,7 @@ function PercentTo255 takes real percentage returns integer
 endfunction
 
 
-// 游戏当前的时间
+// 获取游戏当前的时间
 function GetTimeOfDay takes nothing returns real
     return GetFloatGameState(GAME_STATE_TIME_OF_DAY)
 endfunction
@@ -1858,7 +1858,7 @@ function SetTimeOfDayScalePercentBJ takes real scalePercent returns nothing
 endfunction
 
 
-// 游戏时间的速度
+// 获取游戏时间流逝速度
 function GetTimeOfDayScalePercentBJ takes nothing returns real
     return GetTimeOfDayScale() * 100
 endfunction
@@ -2583,7 +2583,7 @@ function TriggerRegisterGameSavedEventBJ takes trigger trig returns event
 endfunction
 
 
-// 让指定区域内的可破坏物死亡(毁坏的)触发器(矩形区域)
+// 选取指定矩形区域内可破坏物(毁坏的)触发器动作
 function RegisterDestDeathInRegionEnum takes nothing returns nothing
     set bj_destInRegionDiesCount = bj_destInRegionDiesCount + 1
     if (bj_destInRegionDiesCount <= bj_MAX_DEST_IN_REGION_EVENTS) then
@@ -2592,7 +2592,7 @@ function RegisterDestDeathInRegionEnum takes nothing returns nothing
 endfunction
 
 
-// 让指定区域的可毁坏物死亡(毁坏的)
+// 选取指定区域内可毁坏物(毁坏的)
 function TriggerRegisterDestDeathInRegionEvent takes trigger trig, rect r returns nothing
     set bj_destInRegionDiesTrig = trig
     set bj_destInRegionDiesCount = 0
@@ -2810,7 +2810,7 @@ function CreateFogModifierRectSimple takes player whichPlayer, fogstate whichFog
 endfunction
 
 
-// 创建可见度修正器(圆范围)
+// 创建可见度修正器(圆形区域)
 function CreateFogModifierRadiusLocSimple takes player whichPlayer, fogstate whichFogState, location center, real radius, boolean afterUnits returns fogmodifier
     set bj_lastCreatedFogModifier = CreateFogModifierRadiusLoc(whichPlayer, whichFogState, center, radius, true, afterUnits)
     return bj_lastCreatedFogModifier
@@ -2821,7 +2821,7 @@ endfunction
 // gives the option of immediately enabling the modifier, so that triggers
 // can default to modifiers that are immediately enabled.
 //
-// 创造 区域 可见度修正器
+// 启用可见度修正器(矩形区域)
 function CreateFogModifierRectBJ takes boolean enabled, player whichPlayer, fogstate whichFogState, rect r returns fogmodifier
     set bj_lastCreatedFogModifier = CreateFogModifierRect(whichPlayer, whichFogState, r, true, false)
     if enabled then
@@ -2835,7 +2835,7 @@ endfunction
 // gives the option of immediately enabling the modifier, so that triggers
 // can default to modifiers that are immediately enabled.
 //
-// 创造 圆周 可见度修正器
+// 启用可见度修正器(圆形区域)
 function CreateFogModifierRadiusLocBJ takes boolean enabled, player whichPlayer, fogstate whichFogState, location center, real radius returns fogmodifier
     set bj_lastCreatedFogModifier = CreateFogModifierRadiusLoc(whichPlayer, whichFogState, center, radius, true, false)
     if enabled then
@@ -2857,7 +2857,7 @@ function FogEnableOn takes nothing returns nothing
 endfunction
 
 
-// 禁止战争迷雾
+// 禁用战争迷雾
 function FogEnableOff takes nothing returns nothing
     call FogEnable(false)
 endfunction
@@ -2869,13 +2869,13 @@ function FogMaskEnableOn takes nothing returns nothing
 endfunction
 
 
-// 禁止黑色阴影
+// 禁用黑色阴影
 function FogMaskEnableOff takes nothing returns nothing
     call FogMaskEnable(false)
 endfunction
 
 
-// 打开/关闭日夜循环
+// 打开/关闭 昼夜循环
 function UseTimeOfDayBJ takes boolean flag returns nothing
     call SuspendTimeOfDay(not flag)
 endfunction
@@ -2893,13 +2893,13 @@ function ResetTerrainFogBJ takes nothing returns nothing
 endfunction
 
 
-// 播放圆周内地形装饰物的触发器
+// 播放圆形区域内地形装饰物动画
 function SetDoodadAnimationBJ takes string animName, integer doodadID, real radius, location center returns nothing
     call SetDoodadAnimation(GetLocationX(center), GetLocationY(center), radius, doodadID, false, animName, false)
 endfunction
 
 
-// 播放区域内地形装饰物的触发器
+// 播放矩形区域内地形装饰物动画
 function SetDoodadAnimationRectBJ takes string animName, integer doodadID, rect r returns nothing
     call SetDoodadAnimationRect(r, doodadID, animName, false)
 endfunction
@@ -2956,35 +2956,35 @@ function ShowUbersplatBJ takes boolean flag, ubersplat whichSplat returns nothin
 endfunction
 
 
-// 最后创建的地面纹理
+// 获取最后创建的地面纹理
 function GetLastCreatedUbersplat takes nothing returns ubersplat
     return bj_lastCreatedUbersplat
 endfunction
 
-
+// 获取最后创建的小地图图标
 function GetLastCreatedMinimapIcon takes nothing returns minimapicon
     return bj_lastCreatedMinimapIcon
 endfunction
 
-
+// 创建小地图图标（指定单位）
 function CreateMinimapIconOnUnitBJ takes unit whichUnit, integer red, integer green, integer blue, string pingPath, fogstate fogVisibility returns minimapicon
     set bj_lastCreatedMinimapIcon = CreateMinimapIconOnUnit(whichUnit, red, green, blue, pingPath, fogVisibility)
     return bj_lastCreatedMinimapIcon
 endfunction
 
-
+// 创建小地图图标（指定点）
 function CreateMinimapIconAtLocBJ takes location where, integer red, integer green, integer blue, string pingPath, fogstate fogVisibility returns minimapicon
     set bj_lastCreatedMinimapIcon = CreateMinimapIconAtLoc(where, red, green, blue, pingPath, fogVisibility)
     return bj_lastCreatedMinimapIcon
 endfunction
 
-
+// 创建小地图图标（指定坐标）
 function CreateMinimapIconBJ takes real x, real y, integer red, integer green, integer blue, string pingPath, fogstate fogVisibility returns minimapicon
     set bj_lastCreatedMinimapIcon = CreateMinimapIcon(x, y, red, green, blue, pingPath, fogVisibility)
     return bj_lastCreatedMinimapIcon
 endfunction
 
-
+// 创建小地图图标（指定单位和图标样式）
 function CampaignMinimapIconUnitBJ takes unit whichUnit, integer style returns nothing
 	local integer	red
 	local integer 	green
@@ -3050,7 +3050,7 @@ function CampaignMinimapIconUnitBJ takes unit whichUnit, integer style returns n
 endfunction
 
 
-
+// 创建小地图图标（指定点和图标样式）
 function CampaignMinimapIconLocBJ takes location where, integer style returns nothing
 	local integer	red
 	local integer 	green
@@ -3172,19 +3172,19 @@ function AttachSoundToUnitBJ takes sound soundHandle, unit whichUnit returns not
     call AttachSoundToUnit(soundHandle, whichUnit)
 endfunction
 
-
+// 设置3D音效音锥角度
 function SetSoundConeAnglesBJ takes sound soundHandle, real inside, real outside, real outsideVolumePercent returns nothing
     call SetSoundConeAngles(soundHandle, inside, outside, PercentToInt(outsideVolumePercent, 127))
 endfunction
 
 
-// 破坏声音
+// 终止声音
 function KillSoundWhenDoneBJ takes sound soundHandle returns nothing
     call KillSoundWhenDone(soundHandle)
 endfunction
 
 
-// 播放声音在点
+// 在指定点播放声音（音源位置）
 function PlaySoundAtPointBJ takes sound soundHandle, real volumePercent, location loc, real z returns nothing
     call SetSoundPositionLocBJ(soundHandle, loc, z)
     call SetSoundVolumeBJ(soundHandle, volumePercent)
@@ -3192,7 +3192,7 @@ function PlaySoundAtPointBJ takes sound soundHandle, real volumePercent, locatio
 endfunction
 
 
-// 播放声音单位
+// 在指定单位播放声音（音源位置）
 function PlaySoundOnUnitBJ takes sound soundHandle, real volumePercent, unit whichUnit returns nothing
     call AttachSoundToUnitBJ(soundHandle, whichUnit)
     call SetSoundVolumeBJ(soundHandle, volumePercent)
@@ -3215,14 +3215,14 @@ function PlayMusicBJ takes string musicFileName returns nothing
 endfunction
 
 
-// 播放音乐(跳跃)
+// 播放音乐(指定跳到的时间帧)
 function PlayMusicExBJ takes string musicFileName, real startingOffset, real fadeInTime returns nothing
     set bj_lastPlayedMusic = musicFileName
     call PlayMusicEx(musicFileName, R2I(startingOffset * 1000), R2I(fadeInTime * 1000))
 endfunction
 
 
-// 跳越音乐
+// 设置音乐跳到的时间帧
 function SetMusicOffsetBJ takes real newOffset returns nothing
     call SetMusicPlayPosition(R2I(newOffset * 1000))
 endfunction
@@ -3234,7 +3234,7 @@ function PlayThematicMusicBJ takes string musicName returns nothing
 endfunction
 
 
-// 播放主题音乐(跳跃)
+// 播放主题音乐(指定跳到的时间帧)
 function PlayThematicMusicExBJ takes string musicName, real startingOffset returns nothing
     call PlayThematicMusicEx(musicName, R2I(startingOffset * 1000))
 endfunction
@@ -3269,7 +3269,7 @@ function SetMusicVolumeBJ takes real volumePercent returns nothing
     call SetMusicVolume(PercentToInt(volumePercent, 127))
 endfunction
 
-
+// 设置主题音乐音量
 function SetThematicMusicVolumeBJ takes real volumePercent returns nothing
     call SetThematicMusicVolume(PercentToInt(volumePercent, 127))
 endfunction
@@ -3555,37 +3555,37 @@ endfunction
 //*
 //***************************************************************************
 
-
+// 创建技能命令特效按钮
 function CreateCommandButtonEffectBJ takes integer abilityId, string order returns commandbuttoneffect
     set bj_lastCreatedCommandButtonEffect = CreateCommandButtonEffect(abilityId, order)
     return bj_lastCreatedCommandButtonEffect
 endfunction
 
-
+// 创建技能特效按钮（'Aque'）
 function CreateTrainCommandButtonEffectBJ takes integer unitId returns commandbuttoneffect
     set bj_lastCreatedCommandButtonEffect = CreateCommandButtonEffect('Aque', UnitId2String(unitId))
     return bj_lastCreatedCommandButtonEffect
 endfunction
 
-
+// 创建科技特效按钮
 function CreateUpgradeCommandButtonEffectBJ takes integer techId returns commandbuttoneffect
     set bj_lastCreatedCommandButtonEffect = CreateUpgradeCommandButtonEffect(techId)
     return bj_lastCreatedCommandButtonEffect
 endfunction
 
-
+// 创建命令特效按钮
 function CreateCommonCommandButtonEffectBJ takes string order returns commandbuttoneffect
     set bj_lastCreatedCommandButtonEffect = CreateCommandButtonEffect(0, order)
     return bj_lastCreatedCommandButtonEffect
 endfunction
 
-
+// 创建学习技能特效按钮
 function CreateLearnCommandButtonEffectBJ takes integer abilityId returns commandbuttoneffect
     set bj_lastCreatedCommandButtonEffect = CreateLearnCommandButtonEffect(abilityId)
     return bj_lastCreatedCommandButtonEffect
 endfunction
 
-
+// 创建建造/训练单位特效按钮
 function CreateBuildCommandButtonEffectBJ takes integer unitId returns commandbuttoneffect
 	local race r = GetPlayerRace(GetLocalPlayer())
 	local integer abilityId
@@ -3604,7 +3604,7 @@ function CreateBuildCommandButtonEffectBJ takes integer unitId returns commandbu
     return bj_lastCreatedCommandButtonEffect
 endfunction
 
-
+// 获取最后创建的特效按钮
 function GetLastCreatedCommandButtonEffectBJ takes nothing returns commandbuttoneffect
     return bj_lastCreatedCommandButtonEffect
 endfunction
@@ -3624,13 +3624,13 @@ function GetItemLoc takes item whichItem returns location
 endfunction
 
 
-// 物品生命
+// 获取物品生命
 function GetItemLifeBJ takes widget whichWidget returns real
     return GetWidgetLife(whichWidget)
 endfunction
 
 
-// 设置生命(物品)
+// 设置物品生命值
 function SetItemLifeBJ takes widget whichWidget, real life returns nothing
     call SetWidgetLife(whichWidget, life)
 endfunction
@@ -3674,25 +3674,25 @@ function SetUnitAbilityLevelSwapped takes integer abilcode, unit whichUnit, inte
 endfunction
 
 
-// 单位的技能等级
+// 获取单位技能等级
 function GetUnitAbilityLevelSwapped takes integer abilcode, unit whichUnit returns integer
     return GetUnitAbilityLevel(whichUnit, abilcode)
 endfunction
 
 
-// 单位存在 魔法特效
+// 单位拥有 魔法特效（Buff）
 function UnitHasBuffBJ takes unit whichUnit, integer buffcode returns boolean
     return (GetUnitAbilityLevel(whichUnit, buffcode) > 0)
 endfunction
 
 
-// 删除 持续状态 (指定的)
+// 删除 魔法特效（Buff） (指定Buff)
 function UnitRemoveBuffBJ takes integer buffcode, unit whichUnit returns boolean
     return UnitRemoveAbility(whichUnit, buffcode)
 endfunction
 
 
-// 移动物品给英雄
+// 给英雄添加物品
 function UnitAddItemSwapped takes item whichItem, unit whichHero returns boolean
     return UnitAddItem(whichHero, whichItem)
 endfunction
@@ -3709,7 +3709,7 @@ function UnitAddItemByIdSwapped takes integer itemId, unit whichHero returns ite
 endfunction
 
 
-// 掉落英雄的一个物品
+// 英雄丢弃物品
 function UnitRemoveItemSwapped takes item whichItem, unit whichHero returns nothing
     set bj_lastRemovedItem = whichItem
     call UnitRemoveItem(whichHero, whichItem)
@@ -3718,33 +3718,33 @@ endfunction
 
 // Translates 0-based slot indices to 1-based slot indices.
 //
-// 从英雄的物品栏位置中掉落物品
+// 英雄丢弃物品（指定物品栏位置）
 function UnitRemoveItemFromSlotSwapped takes integer itemSlot, unit whichHero returns item
     set bj_lastRemovedItem = UnitRemoveItemFromSlot(whichHero, itemSlot-1)
     return bj_lastRemovedItem
 endfunction
 
 
-// 创造物品
+// 创建物品
 function CreateItemLoc takes integer itemId, location loc returns item
     set bj_lastCreatedItem = CreateItem(itemId, GetLocationX(loc), GetLocationY(loc))
     return bj_lastCreatedItem
 endfunction
 
 
-// 最后创造的物品
+// 获取最后创建的物品
 function GetLastCreatedItem takes nothing returns item
     return bj_lastCreatedItem
 endfunction
 
 
-// 最后掉落的物品
+// 获取最后丢弃的物品
 function GetLastRemovedItem takes nothing returns item
     return bj_lastRemovedItem
 endfunction
 
 
-// 移动物品 (立刻)
+// 移动物品到点 (立刻)
 function SetItemPositionLoc takes item whichItem, location loc returns nothing
     call SetItemPosition(whichItem, GetLocationX(loc), GetLocationY(loc))
 endfunction
@@ -3761,34 +3761,34 @@ function SuspendHeroXPBJ takes boolean flag, unit whichHero returns nothing
     call SuspendHeroXP(whichHero, not flag)
 endfunction
 
-
+// 设置玩家损伤障碍
 function SetPlayerHandicapDamageBJ takes player whichPlayer, real handicapPercent returns nothing
     call SetPlayerHandicapDamage(whichPlayer, handicapPercent * 0.01)
 endfunction
 
-
+// 获取玩家损伤障碍
 function GetPlayerHandicapDamageBJ takes player whichPlayer returns real
     return GetPlayerHandicapDamage(whichPlayer) * 100
 endfunction
 
-
+// 设置玩家障碍恢复时间
 function SetPlayerHandicapReviveTimeBJ takes player whichPlayer, real handicapPercent returns nothing
     call SetPlayerHandicapReviveTime(whichPlayer, handicapPercent * 0.01)
 endfunction
 
-
+// 获取玩家障碍恢复时间
 function GetPlayerHandicapReviveTimeBJ takes player whichPlayer returns real
     return GetPlayerHandicapReviveTime(whichPlayer) * 100
 endfunction
 
 
-// 设置玩家英雄经验值预先获得
+// 设置玩家英雄经验获得率
 function SetPlayerHandicapXPBJ takes player whichPlayer, real handicapPercent returns nothing
     call SetPlayerHandicapXP(whichPlayer, handicapPercent * 0.01)
 endfunction
 
 
-// 经验值比率
+// 获取玩家经验获得率
 function GetPlayerHandicapXPBJ takes player whichPlayer returns real
     return GetPlayerHandicapXP(whichPlayer) * 100
 endfunction
@@ -3800,13 +3800,13 @@ function SetPlayerHandicapBJ takes player whichPlayer, real handicapPercent retu
 endfunction
 
 
-// 经验值上限
+// 获取玩家经验值上限
 function GetPlayerHandicapBJ takes player whichPlayer returns real
     return GetPlayerHandicap(whichPlayer) * 100
 endfunction
 
 
-// 英雄的属性
+// 获取英雄属性值
 function GetHeroStatBJ takes integer whichStat, unit whichHero, boolean includeBonuses returns integer
     if (whichStat == bj_HEROSTAT_STR) then
         return GetHeroStr(whichHero, includeBonuses)
@@ -3821,7 +3821,7 @@ function GetHeroStatBJ takes integer whichStat, unit whichHero, boolean includeB
 endfunction
 
 
-// 修改英雄属性
+// 设置英雄属性值
 function SetHeroStat takes unit whichHero, integer whichStat, integer value returns nothing
     // Ignore requests for negative hero stats.
     if (value <= 0) then
@@ -3840,7 +3840,7 @@ function SetHeroStat takes unit whichHero, integer whichStat, integer value retu
 endfunction
 
 
-// 改变英雄属性
+// 修改英雄属性
 function ModifyHeroStat takes integer whichStat, unit whichHero, integer modifyMethod, integer value returns nothing
     if (modifyMethod == bj_MODIFYMETHOD_ADD) then
         call SetHeroStat(whichHero, whichStat, GetHeroStatBJ(whichStat, whichHero, false) + value)
@@ -3854,7 +3854,7 @@ function ModifyHeroStat takes integer whichStat, unit whichHero, integer modifyM
 endfunction
 
 
-// 改变英雄技能点数
+// 修改英雄技能点数
 function ModifyHeroSkillPoints takes unit whichHero, integer modifyMethod, integer value returns boolean
     if (modifyMethod == bj_MODIFYMETHOD_ADD) then
         return UnitModifySkillPoints(whichHero, value)
@@ -3869,7 +3869,7 @@ function ModifyHeroSkillPoints takes unit whichHero, integer modifyMethod, integ
 endfunction
 
 
-// 单位掉落的物品
+// 单位丢弃物品
 function UnitDropItemPointBJ takes unit whichUnit, item whichItem, real x, real y returns boolean
     return UnitDropItemPoint(whichUnit, whichItem, x, y)
 endfunction
@@ -3902,7 +3902,7 @@ function UnitUseItemDestructable takes unit whichUnit, item whichItem, widget ta
 endfunction
 
 
-// 对 点 使用物品
+// 使用物品（制订单）
 function UnitUseItemPointLoc takes unit whichUnit, item whichItem, location loc returns boolean
     return UnitUseItemPoint(whichUnit, whichItem, GetLocationX(loc), GetLocationY(loc))
 endfunction
@@ -3910,7 +3910,7 @@ endfunction
 
 // Translates 0-based slot indices to 1-based slot indices.
 //
-// 英雄携带的物品
+// 英雄携带的物品（指定物品格）
 function UnitItemInSlotBJ takes unit whichUnit, integer itemSlot returns item
     return UnitItemInSlot(whichUnit, itemSlot-1)
 endfunction
@@ -3937,7 +3937,7 @@ function GetInventoryIndexOfItemTypeBJ takes unit whichUnit, integer itemId retu
 endfunction
 
 
-// 英雄携带的物品类型
+// 获取英雄携带物品的类型
 function GetItemOfTypeFromUnitBJ takes unit whichUnit, integer itemId returns item
     local integer index = GetInventoryIndexOfItemTypeBJ(whichUnit, itemId)
 
@@ -3949,13 +3949,14 @@ function GetItemOfTypeFromUnitBJ takes unit whichUnit, integer itemId returns it
 endfunction
 
 
-// 英雄已有 物品 - 类型
+// 英雄是否已有物品（指定物品类型）
 function UnitHasItemOfTypeBJ takes unit whichUnit, integer itemId returns boolean
     return GetInventoryIndexOfItemTypeBJ(whichUnit, itemId) > 0
 endfunction
 
 
-// 单位物品的数量
+// 单位拥有物品的数量
+// 只判断所有物品格是否被占，不统计物品堆叠，即只返回0~6
 function UnitInventoryCount takes unit whichUnit returns integer
     local integer index = 0
     local integer count = 0
@@ -3973,7 +3974,7 @@ function UnitInventoryCount takes unit whichUnit returns integer
 endfunction
 
 
-// 物品栏容量
+// 物品栏格数
 function UnitInventorySizeBJ takes unit whichUnit returns integer
     return UnitInventorySize(whichUnit)
 endfunction
@@ -3985,7 +3986,7 @@ function SetItemInvulnerableBJ takes item whichItem, boolean flag returns nothin
 endfunction
 
 
-// 设置英雄死亡后能否物品掉落
+// 设置英雄死亡后物品是否掉落
 function SetItemDropOnDeathBJ takes item whichItem, boolean flag returns nothing
     call SetItemDropOnDeath(whichItem, flag)
 endfunction
@@ -4027,19 +4028,19 @@ function ChooseRandomItemExBJ takes integer level, itemtype whichType returns in
 endfunction
 
 
-// 随机的中立建筑物类型
+// 获取随机=中立建筑物类型
 function ChooseRandomNPBuildingBJ takes nothing returns integer
     return ChooseRandomNPBuilding()
 endfunction
 
 
-// 随机的野生单位单位类型(有等级)
+// 获取随机中立敌对单位类型(指定单位等级)
 function ChooseRandomCreepBJ takes integer level returns integer
     return ChooseRandomCreep(level)
 endfunction
 
 
-// 选取所有物品在 区域 做动作(单个动作)
+// 选取指定区域内所有物品做动作(单个动作)
 function EnumItemsInRectBJ takes rect r, code actionFunc returns nothing
     call EnumItemsInRect(r, null, actionFunc)
 endfunction
@@ -4047,7 +4048,7 @@ endfunction
 
 // See GroupPickRandomUnitEnum for the details of this algorithm.
 //
-// 随机选取指定区域的物品触发器
+// 随机选取指定区域的物品触发器动作
 function RandomItemInRectBJEnum takes nothing returns nothing
     set bj_itemRandomConsidered = bj_itemRandomConsidered + 1
     if (GetRandomInt(1, bj_itemRandomConsidered) == 1) then
@@ -4186,19 +4187,19 @@ function OrderId2StringBJ takes integer orderId returns string
 endfunction
 
 
-// 发出的命令
+// 获取发出的命令
 function GetIssuedOrderIdBJ takes nothing returns integer
     return GetIssuedOrderId()
 endfunction
 
 
-// 凶手单位
+// 获取凶手单位
 function GetKillingUnitBJ takes nothing returns unit
     return GetKillingUnit()
 endfunction
 
 
-// 新建单位(指定点)
+// 创建单位(指定点)
 function CreateUnitAtLocSaveLast takes player id, integer unitid, location loc, real face returns unit
     if (unitid == 'ugol') then
         set bj_lastCreatedUnit = CreateBlightedGoldmine(id, GetLocationX(loc), GetLocationY(loc), face)
@@ -4216,7 +4217,7 @@ function GetLastCreatedUnit takes nothing returns unit
 endfunction
 
 
-// 创造单位面对角度
+// 创建单位（指定面向角度）
 function CreateNUnitsAtLoc takes integer count, integer unitId, player whichPlayer, location loc, real face returns group
     call GroupClear(bj_lastCreatedGroup)
     loop
@@ -4229,7 +4230,7 @@ function CreateNUnitsAtLoc takes integer count, integer unitId, player whichPlay
 endfunction
 
 
-// 创造单位面对点
+// 创建单位（指定面向点）
 function CreateNUnitsAtLocFacingLocBJ takes integer count, integer unitId, player whichPlayer, location loc, location lookAt returns group
     return CreateNUnitsAtLoc(count, unitId, whichPlayer, loc, AngleBetweenPoints(loc, lookAt))
 endfunction
@@ -4248,7 +4249,7 @@ function GetLastCreatedGroup takes nothing returns group
 endfunction
 
 
-// 创造尸体
+// 创建尸体
 function CreateCorpseLocBJ takes integer unitid, player whichPlayer, location loc returns unit
     set bj_lastCreatedUnit = CreateCorpse(whichPlayer, unitid, GetLocationX(loc), GetLocationY(loc), GetRandomReal(0, 360))
     return bj_lastCreatedUnit
@@ -4285,7 +4286,7 @@ endfunction
 // Game code explicitly sets the animation back to "decay bone" after the
 // initial corpse fades away, so we reset it now.  It's best not to show
 // off corpses thus created until after this grace period has passed.
-//
+// 设置尸体腐烂状态及动画触发器动作
 function DelayedSuspendDecayFleshEnum takes nothing returns nothing
     local unit enumUnit = GetEnumUnit()
 
@@ -4299,7 +4300,7 @@ endfunction
 
 // Waits a short period of time to ensure that the corpse is decaying, and
 // then suspend the animation and corpse decay.
-//
+// 设置尸体腐烂状态及动画触发器条件
 function DelayedSuspendDecay takes nothing returns nothing
     local group boneGroup
     local group fleshGroup
@@ -4326,7 +4327,7 @@ function DelayedSuspendDecay takes nothing returns nothing
     call DestroyGroup(fleshGroup)
 endfunction
 
-
+// 创建尸体腐烂状态及动画触发器
 function DelayedSuspendDecayCreate takes nothing returns nothing
     set bj_delayedSuspendDecayTrig = CreateTrigger()
     call TriggerRegisterTimerExpireEvent(bj_delayedSuspendDecayTrig, bj_delayedSuspendDecayTimer)
@@ -4334,7 +4335,7 @@ function DelayedSuspendDecayCreate takes nothing returns nothing
 endfunction
 
 
-// 创造永久的尸体
+// 创建尸体（永久的）
 function CreatePermanentCorpseLocBJ takes integer style, integer unitid, player whichPlayer, location loc, real facing returns unit
     set bj_lastCreatedUnit = CreateCorpse(whichPlayer, unitid, GetLocationX(loc), GetLocationY(loc), facing)
     call SetUnitBlendTime(bj_lastCreatedUnit, 0)
@@ -4356,7 +4357,7 @@ function CreatePermanentCorpseLocBJ takes integer style, integer unitid, player 
 endfunction
 
 
-// 单位属性
+// 获取单位属性
 function GetUnitStateSwap takes unitstate whichState, unit whichUnit returns real
     return GetUnitState(whichUnit, whichState)
 endfunction
@@ -4375,13 +4376,13 @@ function GetUnitStatePercent takes unit whichUnit, unitstate whichState, unitsta
 endfunction
 
 
-// 生命值百分比
+// 获取指定单位的生命值百分比
 function GetUnitLifePercent takes unit whichUnit returns real
     return GetUnitStatePercent(whichUnit, UNIT_STATE_LIFE, UNIT_STATE_MAX_LIFE)
 endfunction
 
 
-// 魔法值百分比
+// 获取指定单位的魔法值百分比
 function GetUnitManaPercent takes unit whichUnit returns real
     return GetUnitStatePercent(whichUnit, UNIT_STATE_MANA, UNIT_STATE_MAX_MANA)
 endfunction
@@ -4399,7 +4400,7 @@ function SelectGroupBJEnum takes nothing returns nothing
     call SelectUnit( GetEnumUnit(), true )
 endfunction
 
-
+// 选择单位组
 function SelectGroupBJ takes group g returns nothing
     call ClearSelection()
     call ForGroup( g, function SelectGroupBJEnum )
@@ -4501,7 +4502,7 @@ function IsUnitAliveBJ takes unit whichUnit returns boolean
 endfunction
 
 
-// 单位组的单位是否已死亡触发器
+// 单位组的单位是否已死亡触发器动作
 function IsUnitGroupDeadBJEnum takes nothing returns nothing
     if not IsUnitDeadBJ(GetEnumUnit()) then
         set bj_isUnitGroupDeadResult = false
@@ -4528,7 +4529,7 @@ function IsUnitGroupDeadBJ takes group g returns boolean
 endfunction
 
 
-// 单位组是空的
+// 单位组是否为空触发器动作
 function IsUnitGroupEmptyBJEnum takes nothing returns nothing
     set bj_isUnitGroupEmptyResult = false
 endfunction
@@ -4553,7 +4554,7 @@ function IsUnitGroupEmptyBJ takes group g returns boolean
 endfunction
 
 
-// 单位组的单位在区域
+// 单位组的单位在区域触发器动作
 function IsUnitGroupInRectBJEnum takes nothing returns nothing
     if not RectContainsUnit(bj_isUnitGroupInRectRect, GetEnumUnit()) then
         set bj_isUnitGroupInRectResult = false
@@ -4562,7 +4563,7 @@ endfunction
 
 
 // Returns true if every unit of the group is within the given rect.
-//
+// 单位组的单位在区域
 function IsUnitGroupInRectBJ takes group g, rect r returns boolean
     set bj_isUnitGroupInRectResult = true
     set bj_isUnitGroupInRectRect = r
@@ -4571,7 +4572,7 @@ function IsUnitGroupInRectBJ takes group g, rect r returns boolean
 endfunction
 
 
-// 单位被隐藏
+// 隐藏单位触发器动作
 function IsUnitHiddenBJ takes unit whichUnit returns boolean
     return IsUnitHidden(whichUnit)
 endfunction
@@ -4593,12 +4594,12 @@ function ShowUnitShow takes unit whichUnit returns nothing
     call ShowUnit(whichUnit, true)
 endfunction
 
-
+// 发送建造闹鬼金矿命令（指定农民及金矿）触发器条件（匹配金矿）
 function IssueHauntOrderAtLocBJFilter takes nothing returns boolean
     return GetUnitTypeId(GetFilterUnit()) == 'ngol'
 endfunction
 
-
+// 发送建造闹鬼金矿命令（指定农民及金矿）
 function IssueHauntOrderAtLocBJ takes unit whichPeon, location loc returns boolean
     local group g = null
     local unit goldMine = null
@@ -4647,25 +4648,25 @@ function IssueUpgradeOrderByIdBJ takes unit whichUnit, integer techId returns bo
 endfunction
 
 
-// 被攻击的单位
+// 获取被攻击的单位
 function GetAttackedUnitBJ takes nothing returns unit
     return GetTriggerUnit()
 endfunction
 
 
-// 改变单位飞行高度
+// 设置单位飞行高度
 function SetUnitFlyHeightBJ takes unit whichUnit, real newHeight, real rate returns nothing
     call SetUnitFlyHeight(whichUnit, newHeight, rate)
 endfunction
 
 
-// 改变单位转向速度
+// 设置单位转向速度
 function SetUnitTurnSpeedBJ takes unit whichUnit, real turnSpeed returns nothing
     call SetUnitTurnSpeed(whichUnit, turnSpeed)
 endfunction
 
 
-// 改变单位头像视窗角度
+// 设置单位头像视窗角度
 function SetUnitPropWindowBJ takes unit whichUnit, real propWindow returns nothing
     local real angle = propWindow
     if (angle <= 0) then
@@ -4679,19 +4680,19 @@ function SetUnitPropWindowBJ takes unit whichUnit, real propWindow returns nothi
 endfunction
 
 
-// 单位在头像窗口的角度 (当前)
+// 获取单位在头像窗口的角度 (当前)
 function GetUnitPropWindowBJ takes unit whichUnit returns real
     return GetUnitPropWindow(whichUnit) * bj_RADTODEG
 endfunction
 
 
-// 单位在头像窗口的角度 (默认)
+// 获取单位在头像窗口的角度 (默认)
 function GetUnitDefaultPropWindowBJ takes unit whichUnit returns real
     return GetUnitDefaultPropWindow(whichUnit)
 endfunction
 
 
-// 改变单位混合时间
+// 设置单位混合时间
 function SetUnitBlendTimeBJ takes unit whichUnit, real blendTime returns nothing
     call SetUnitBlendTime(whichUnit, blendTime)
 endfunction
@@ -4731,7 +4732,7 @@ function WakePlayerUnitsEnum takes nothing returns nothing
     call UnitWakeUp(GetEnumUnit())
 endfunction
 
-
+// 唤醒指定玩家的单位
 function WakePlayerUnits takes player whichPlayer returns nothing
     local group g = CreateGroup()
     call GroupEnumUnitsOfPlayer(g, whichPlayer, null)
@@ -4804,7 +4805,7 @@ function PauseUnitBJ takes boolean pause, unit whichUnit returns nothing
 endfunction
 
 
-// 单位被暂停
+// 暂停单位触发器动作
 function IsUnitPausedBJ takes unit whichUnit returns boolean
     return IsUnitPaused(whichUnit)
 endfunction
@@ -4844,7 +4845,7 @@ function UnitRemoveBuffsBJ takes integer buffType, unit whichUnit returns nothin
 endfunction
 
 
-// 删除 持续状态 (按类型)
+// 删除单位拥有的 魔法效果 (按类型)
 function UnitRemoveBuffsExBJ takes integer polarity, integer resist, unit whichUnit, boolean bTLife, boolean bAura returns nothing
     local boolean bPos   = (polarity == bj_BUFF_POLARITY_EITHER) or (polarity == bj_BUFF_POLARITY_POSITIVE)
     local boolean bNeg   = (polarity == bj_BUFF_POLARITY_EITHER) or (polarity == bj_BUFF_POLARITY_NEGATIVE)
@@ -4855,7 +4856,7 @@ function UnitRemoveBuffsExBJ takes integer polarity, integer resist, unit whichU
 endfunction
 
 
-// 魔法效果/特殊效果 的数量
+// 获取单位拥有的 魔法效果 的数量
 function UnitCountBuffsExBJ takes integer polarity, integer resist, unit whichUnit, boolean bTLife, boolean bAura returns integer
     local boolean bPos   = (polarity == bj_BUFF_POLARITY_EITHER) or (polarity == bj_BUFF_POLARITY_POSITIVE)
     local boolean bNeg   = (polarity == bj_BUFF_POLARITY_EITHER) or (polarity == bj_BUFF_POLARITY_NEGATIVE)
@@ -4889,7 +4890,7 @@ function UnitAddTypeBJ takes unittype whichType, unit whichUnit returns boolean
     return UnitAddType(whichUnit, whichType)
 endfunction
 
-
+// 设置单位技能的永久性
 function UnitMakeAbilityPermanentBJ takes boolean permanent, integer abilityId, unit whichUnit returns boolean
     return UnitMakeAbilityPermanent(whichUnit, permanent, abilityId)
 endfunction
@@ -4908,13 +4909,13 @@ function ExplodeUnitBJ takes unit whichUnit returns nothing
 endfunction
 
 
-// 传送单位
+// 获取传送单位
 function GetTransportUnitBJ takes nothing returns unit
     return GetTransportUnit()
 endfunction
 
 
-// 装载单位
+// 获取装载单位
 function GetLoadedUnitBJ takes nothing returns unit
     return GetLoadedUnit()
 endfunction
@@ -5147,7 +5148,7 @@ function GetDestructableLoc takes destructable whichDestructable returns locatio
 endfunction
 
 
-// 选取指定方形区域所有可毁坏物做动作(单个动作)
+// 选取指定矩形区域所有可毁坏物做动作(单个动作)
 function EnumDestructablesInRectAll takes rect r, code actionFunc returns nothing
     call EnumDestructablesInRect(r, null, actionFunc)
 endfunction
@@ -5178,7 +5179,7 @@ endfunction
 
 // See GroupPickRandomUnitEnum for the details of this algorithm.
 //
-// 随机选取方形区域的可毁坏物触发器
+// 随机选取矩形区域的可毁坏物触发器
 function RandomDestructableInRectBJEnum takes nothing returns nothing
     set bj_destRandomConsidered = bj_destRandomConsidered + 1
     if (GetRandomInt(1,bj_destRandomConsidered) == 1) then
@@ -5188,7 +5189,7 @@ endfunction
 
 
 // Picks a random destructable from within a rect, matching a condition
-// 随机选取方形区域满足过滤的可毁坏物
+// 随机选取矩形区域满足过滤的可毁坏物
 function RandomDestructableInRectBJ takes rect r, boolexpr filter returns destructable
     set bj_destRandomConsidered = 0
     set bj_destRandomCurrentPick = null
@@ -5200,7 +5201,7 @@ endfunction
 
 // Picks a random destructable from within a rect
 //
-// 随机选取方形区域的可毁坏物
+// 随机选取矩形区域的可毁坏物
 function RandomDestructableInRectSimpleBJ takes rect r returns destructable
     return RandomDestructableInRectBJ(r, null)
 endfunction
@@ -5331,14 +5332,14 @@ endfunction
 
 // Grab the unit and throw his own coords in his face, forcing him to push
 // and shove until he finds a spot where noone will bother him.
-//
+// 移动选取单位
 function NudgeUnitsInRectEnum takes nothing returns nothing
     local unit nudgee = GetEnumUnit()
 
     call SetUnitPosition(nudgee, GetUnitX(nudgee), GetUnitY(nudgee))
 endfunction
 
-
+// 移动选取物品
 function NudgeItemsInRectEnum takes nothing returns nothing
     local item nudgee = GetEnumItem()
 
@@ -5349,7 +5350,7 @@ endfunction
 // Nudge the items and units within a given rect ever so gently, so as to
 // encourage them to find locations where they can peacefully coexist with
 // pathing restrictions and live happy, fruitful lives.
-//
+// 移动单位和物品到指定矩形区域
 function NudgeObjectsInRect takes rect nudgeArea returns nothing
     local group        g
 
@@ -5361,7 +5362,7 @@ function NudgeObjectsInRect takes rect nudgeArea returns nothing
     call EnumItemsInRect(nudgeArea, null, function NudgeItemsInRectEnum)
 endfunction
 
-
+// 获取附近的升降机
 function NearbyElevatorExistsEnum takes nothing returns nothing
     local destructable d     = GetEnumDestructable()
     local integer      dType = GetDestructableTypeId(d)
@@ -5371,7 +5372,7 @@ function NearbyElevatorExistsEnum takes nothing returns nothing
     endif
 endfunction
 
-
+// 附近是否存在升降机
 function NearbyElevatorExists takes real x, real y returns boolean
     local real findThreshold = 32
     local rect r
@@ -5385,7 +5386,7 @@ function NearbyElevatorExists takes real x, real y returns boolean
     return bj_elevatorNeighbor != null
 endfunction
 
-
+// 获取升降机路径阻断器
 function FindElevatorWallBlockerEnum takes nothing returns nothing
     set bj_elevatorWallBlocker = GetEnumDestructable()
 endfunction
@@ -5512,7 +5513,7 @@ function WaygateGetDestinationLocBJ takes unit waygate returns location
 endfunction
 
 
-// 设置单位的小地图图标
+// 启用/禁用 单位的小地图图标
 function UnitSetUsesAltIconBJ takes boolean flag, unit whichUnit returns nothing
     call UnitSetUsesAltIcon(whichUnit, flag)
 endfunction
@@ -5552,6 +5553,7 @@ endfunction
 //***************************************************************************
 
 // 选取单位组做指定动作
+// 最多12个单位响应
 function ForGroupBJ takes group whichGroup, code callback returns nothing
     // If the user wants the group destroyed, remember that fact and clear
     // the flag, in case it is used again in the callback.
@@ -5579,7 +5581,7 @@ function GroupRemoveUnitSimple takes unit whichUnit, group whichGroup returns no
 endfunction
 
 
-// 增加单位组到单位组触发器
+// 增加单位组到单位组触发器动作
 function GroupAddGroupEnum takes nothing returns nothing
     call GroupAddUnit(bj_groupAddGroupDest, GetEnumUnit())
 endfunction
@@ -5601,7 +5603,7 @@ function GroupAddGroup takes group sourceGroup, group destGroup returns nothing
 endfunction
 
 
-// 清除单位组从单位组触发器
+// 清除单位组从单位组触发器动作
 function GroupRemoveGroupEnum takes nothing returns nothing
     call GroupRemoveUnit(bj_groupRemoveGroupDest, GetEnumUnit())
 endfunction
@@ -5641,7 +5643,7 @@ endfunction
 // The chance of picking a given unit over the "current pick" is 1/N, where N is
 // the number of units considered thusfar (including the current consideration).
 //
-// 随机选取单位组中的单位触发器
+// 随机选取单位组中的单位触发器动作
 function GroupPickRandomUnitEnum takes nothing returns nothing
     set bj_groupRandomConsidered = bj_groupRandomConsidered + 1
     if (GetRandomInt(1,bj_groupRandomConsidered) == 1) then
@@ -5672,7 +5674,7 @@ endfunction
 
 // See GroupPickRandomUnitEnum for the details of this algorithm.
 //
-// 随机选择玩家组中的玩家触发器
+// 随机选择玩家组中的玩家触发器动作
 function ForcePickRandomPlayerEnum takes nothing returns nothing
     set bj_forceRandomConsidered = bj_forceRandomConsidered + 1
     if (GetRandomInt(1,bj_forceRandomConsidered) == 1) then
@@ -5690,7 +5692,7 @@ function ForcePickRandomPlayer takes force whichForce returns player
     return bj_forceRandomCurrentPick
 endfunction
 
-// 选取区域中的所有单位触发器
+// 选取区域内所有单位触发器动作
 function EnumUnitsSelected takes player whichPlayer, boolexpr enumFilter, code enumAction returns nothing
     local group g = CreateGroup()
     call SyncSelections()
@@ -5701,7 +5703,7 @@ function EnumUnitsSelected takes player whichPlayer, boolexpr enumFilter, code e
 endfunction
 
 
-// 选取区域中的所有单位（过滤）
+// 选取区域内所有单位（过滤）
 function GetUnitsInRectMatching takes rect r, boolexpr filter returns group
     local group g = CreateGroup()
     call GroupEnumUnitsInRect(g, r, filter)
@@ -5710,18 +5712,18 @@ function GetUnitsInRectMatching takes rect r, boolexpr filter returns group
 endfunction
 
 
-// 选取区域中的所有单位
+// 选取区域内所有单位
 function GetUnitsInRectAll takes rect r returns group
     return GetUnitsInRectMatching(r, null)
 endfunction
 
 
-// 获取玩家在指定方形区域中的单位触发器
+// 选取玩家在指定矩形区域内单位触发器动作
 function GetUnitsInRectOfPlayerFilter takes nothing returns boolean
     return GetOwningPlayer(GetFilterUnit()) == bj_groupEnumOwningPlayer
 endfunction
 
-// 获取玩家在指定方形区域中的单位
+// 选取玩家在指定矩形区域内单位
 function GetUnitsInRectOfPlayer takes rect r, player whichPlayer returns group
     local group g = CreateGroup()
     set bj_groupEnumOwningPlayer = whichPlayer
@@ -5730,7 +5732,7 @@ function GetUnitsInRectOfPlayer takes rect r, player whichPlayer returns group
 endfunction
 
 
-// 获取玩家在指定圆形区域中的单位
+// 选取玩家在指定圆形区域内单位
 function GetUnitsInRangeOfLocMatching takes real radius, location whichLocation, boolexpr filter returns group
     local group g = CreateGroup()
     call GroupEnumUnitsInRangeOfLoc(g, whichLocation, radius, filter)
@@ -5739,7 +5741,7 @@ function GetUnitsInRangeOfLocMatching takes real radius, location whichLocation,
 endfunction
 
 
-// 圆形区域内的所有单位（指定圆心及半径）
+// 选取圆形区域内所有单位（指定圆心及半径）
 function GetUnitsInRangeOfLocAll takes real radius, location whichLocation returns group
     return GetUnitsInRangeOfLocMatching(radius, whichLocation, null)
 endfunction
@@ -5793,7 +5795,7 @@ function GetUnitsOfPlayerAndTypeIdFilter takes nothing returns boolean
     return GetUnitTypeId(GetFilterUnit()) == bj_groupEnumTypeId
 endfunction
 
-// 获取玩家的指定类型单位组
+// 选取玩家的指定类型单位组
 function GetUnitsOfPlayerAndTypeId takes player whichPlayer, integer unitid returns group
     local group g = CreateGroup()
     set bj_groupEnumTypeId = unitid
@@ -5819,7 +5821,7 @@ function GetForceOfPlayer takes player whichPlayer returns force
 endfunction
 
 
-// 所有玩家
+// 获取所有玩家（返回玩家组）
 function GetPlayersAll takes nothing returns force
     return bj_FORCE_ALL_PLAYERS
 endfunction
@@ -5846,7 +5848,7 @@ function GetPlayersByMapControl takes mapcontrol whichControl returns force
 endfunction
 
 
-// 玩家联盟
+// 获取玩家联盟的玩家组
 function GetPlayersAllies takes player whichPlayer returns force
     local force f = CreateForce()
     call ForceEnumAllies(f, whichPlayer, null)
@@ -5854,7 +5856,7 @@ function GetPlayersAllies takes player whichPlayer returns force
 endfunction
 
 
-// 玩家的敌人
+// 获取玩家敌对的玩家组
 function GetPlayersEnemies takes player whichPlayer returns force
     local force f = CreateForce()
     call ForceEnumEnemies(f, whichPlayer, null)
@@ -5862,7 +5864,7 @@ function GetPlayersEnemies takes player whichPlayer returns force
 endfunction
 
 
-// 匹配所有玩家（过滤）
+// 获取选取玩家匹配的玩家组（过滤）
 function GetPlayersMatching takes boolexpr filter returns force
     local force f = CreateForce()
     call ForceEnumPlayers(f, filter)
@@ -5871,7 +5873,7 @@ function GetPlayersMatching takes boolexpr filter returns force
 endfunction
 
 
-// 单位组的单位数量
+// 单位组的单位数
 function CountUnitsInGroupEnum takes nothing returns nothing
     set bj_groupCountUnits = bj_groupCountUnits + 1
 endfunction
@@ -5893,13 +5895,13 @@ function CountUnitsInGroup takes group g returns integer
     return bj_groupCountUnits
 endfunction
 
-// 
+// 玩家组中的玩家数
 function CountPlayersInForceEnum takes nothing returns nothing
     set bj_forceCountPlayers = bj_forceCountPlayers + 1
 endfunction
 
 
-// 玩家组中的玩家数量
+// 获取玩家组中的玩家数
 function CountPlayersInForceBJ takes force f returns integer
     set bj_forceCountPlayers = 0
     call ForForce(f, function CountPlayersInForceEnum)
@@ -5968,13 +5970,13 @@ endfunction
 //***************************************************************************
 
 
-// 重置单位触发器
+// 重置单位动画为 "stand"
 function ResetUnitAnimation takes unit whichUnit returns nothing
     call SetUnitAnimation(whichUnit, "stand")
 endfunction
 
 
-// 改变单位动作速度
+// 改变单位动画速度
 function SetUnitTimeScalePercent takes unit whichUnit, real percentScale returns nothing
     call SetUnitTimeScale(whichUnit, percentScale * 0.01)
 endfunction
@@ -6036,25 +6038,25 @@ function SetUnitFacingToFaceUnitTimed takes unit whichUnit, unit target, real du
 endfunction
 
 
-// 队列单位触发器
+// 队列单位动画
 function QueueUnitAnimationBJ takes unit whichUnit, string whichAnimation returns nothing
     call QueueUnitAnimation(whichUnit, whichAnimation)
 endfunction
 
 
-// 播放可毁坏物的触发器
+// 设置可毁坏物动画
 function SetDestructableAnimationBJ takes destructable d, string whichAnimation returns nothing
     call SetDestructableAnimation(d, whichAnimation)
 endfunction
 
 
-// 排列可毁坏物的触发器
+// 队列可毁坏物动画
 function QueueDestructableAnimationBJ takes destructable d, string whichAnimation returns nothing
     call QueueDestructableAnimation(d, whichAnimation)
 endfunction
 
 
-// 改变可毁坏物动作速度
+// 改变可毁坏物动画速度
 function SetDestAnimationSpeedPercent takes destructable d, real percentScale returns nothing
     call SetDestructableAnimationSpeed(d, percentScale * 0.01)
 endfunction
@@ -6137,7 +6139,8 @@ endfunction
 
 
 // Set all flags used by the in-game "Ally" checkbox.
-//
+// 设置两位指定的玩家是否联盟
+// 同时设置被动联盟（互不侵略）、帮助请求、响应帮助请求、共享经验值、盟友魔法锁定
 function SetPlayerAllianceStateAllyBJ takes player sourcePlayer, player otherPlayer, boolean flag returns nothing
     call SetPlayerAlliance(sourcePlayer, otherPlayer, ALLIANCE_PASSIVE,       flag)
     call SetPlayerAlliance(sourcePlayer, otherPlayer, ALLIANCE_HELP_REQUEST,  flag)
@@ -6148,14 +6151,14 @@ endfunction
 
 
 // Set all flags used by the in-game "Shared Vision" checkbox.
-//
+// 设置两位指定的玩家是否共享视野
 function SetPlayerAllianceStateVisionBJ takes player sourcePlayer, player otherPlayer, boolean flag returns nothing
     call SetPlayerAlliance(sourcePlayer, otherPlayer, ALLIANCE_SHARED_VISION, flag)
 endfunction
 
 
 // Set all flags used by the in-game "Shared Units" checkbox.
-//
+// 设置两位指定的玩家是否共享单位控制（非完全共享单位控制）
 function SetPlayerAllianceStateControlBJ takes player sourcePlayer, player otherPlayer, boolean flag returns nothing
     call SetPlayerAlliance(sourcePlayer, otherPlayer, ALLIANCE_SHARED_CONTROL, flag)
 endfunction
@@ -6163,7 +6166,7 @@ endfunction
 
 // Set all flags used by the in-game "Shared Units" checkbox with the Full
 // Shared Unit Control feature enabled.
-//
+// 设置两位指定的玩家是否完全共享单位控制
 function SetPlayerAllianceStateFullControlBJ takes player sourcePlayer, player otherPlayer, boolean flag returns nothing
     call SetPlayerAlliance(sourcePlayer, otherPlayer, ALLIANCE_SHARED_ADVANCED_CONTROL, flag)
 endfunction
@@ -6253,7 +6256,7 @@ endfunction
 
 
 // Test to see if two players are co-allied (allied with each other).
-//
+// 玩家组是否联盟
 function PlayersAreCoAllied takes player playerA, player playerB returns boolean
     // Players are considered to be allied with themselves.
     if (playerA == playerB) then
@@ -6296,7 +6299,8 @@ endfunction
 
 
 // Force (whichPlayer) to share vision and advanced unit control with all of his/her allies.
-//
+// 设置玩家组内共享状态
+// 会同时共享视野、共享单位控制、完全共享单位控制
 function ShareEverythingWithTeam takes player whichPlayer returns nothing
     local integer playerIndex
     local player  indexPlayer
@@ -6353,7 +6357,7 @@ endfunction
 
 
 // Change ownership for every unit of (whichPlayer)'s team to neutral passive.
-//
+// 创建中立被动玩家单位
 function MakeUnitsPassiveForPlayer takes player whichPlayer returns nothing
     local group   playerUnits = CreateGroup()
     call CachePlayerHeroData(whichPlayer)
@@ -6364,7 +6368,7 @@ endfunction
 
 
 // Change ownership for every unit of (whichPlayer)'s team to neutral passive.
-//
+// 创建中立被动玩家队伍
 function MakeUnitsPassiveForTeam takes player whichPlayer returns nothing
     local integer playerIndex
     local player  indexPlayer
@@ -6383,7 +6387,7 @@ endfunction
 
 
 // Determine whether or not victory/defeat is disabled via cheat codes.
-//
+// 允许胜利和失败（使用普通对战胜败判定）
 function AllowVictoryDefeat takes playergameresult gameResult returns boolean
     if (gameResult == PLAYER_GAME_RESULT_VICTORY) then
         return not IsNoVictoryCheat()
@@ -6397,12 +6401,12 @@ function AllowVictoryDefeat takes playergameresult gameResult returns boolean
     return true
 endfunction
 
-//退出游戏
+// 退出游戏
 function EndGameBJ takes nothing returns nothing
     call EndGame( true )
 endfunction
 
-
+// 对战胜利对话框
 function MeleeVictoryDialogBJ takes player whichPlayer, boolean leftGame returns nothing
     local trigger t = CreateTrigger()
     local dialog  d = DialogCreate()
@@ -6427,7 +6431,7 @@ function MeleeVictoryDialogBJ takes player whichPlayer, boolean leftGame returns
     call StartSoundForPlayerBJ( whichPlayer, bj_victoryDialogSound )
 endfunction
 
-
+// 对战失败对话框
 function MeleeDefeatDialogBJ takes player whichPlayer, boolean leftGame returns nothing
     local trigger t = CreateTrigger()
     local dialog  d = DialogCreate()
@@ -6591,13 +6595,13 @@ function CustomVictoryBJ takes player whichPlayer, boolean showDialog, boolean s
     endif
 endfunction
 
-//游戏失败对话框按钮事件，重新开始
+// 游戏失败对话框按钮事件，重新开始
 function CustomDefeatRestartBJ takes nothing returns nothing
     call PauseGame( false )
     call RestartGame( true )
 endfunction
 
-//游戏失败对话框按钮事件，选择难度并重新开始
+// 游戏失败对话框按钮事件，选择难度并重新开始
 function CustomDefeatReduceDifficultyBJ takes nothing returns nothing
     local gamedifficulty diff = GetGameDifficulty()
 
@@ -6617,13 +6621,13 @@ function CustomDefeatReduceDifficultyBJ takes nothing returns nothing
     call RestartGame( true )
 endfunction
 
-//游戏失败对话框按钮事件，选择存档
+// 游戏失败对话框按钮事件，选择存档
 function CustomDefeatLoadBJ takes nothing returns nothing
     call PauseGame( false )
     call DisplayLoadDialog()
 endfunction
 
-//游戏失败对话框按钮事件，退出游戏
+// 游戏失败对话框按钮事件，退出游戏
 function CustomDefeatQuitBJ takes nothing returns nothing
     if bj_isSinglePlayer then
         call PauseGame( false )
@@ -8212,7 +8216,7 @@ endfunction
 // Attempt to init triggers for default rescue behavior.  For performance
 // reasons, this should only be attempted if a player is set to Rescuable,
 // or if a specific unit is thus flagged.
-// 初始化营救触发
+// 初始化可营救玩家单位
 function TryInitRescuableTriggersBJ takes nothing returns nothing
     local integer index
 
@@ -8261,7 +8265,7 @@ function MakeUnitRescuableToForceBJ takes unit whichUnit, boolean isRescuable, f
     call ForForce(whichForce, function MakeUnitRescuableToForceBJEnum)
 endfunction
 
-// 初始化可营救触发
+// 初始化可营救玩家
 function InitRescuableBehaviorBJ takes nothing returns nothing
     local integer index
 
@@ -9504,7 +9508,7 @@ function SaveDyingWidget takes nothing returns nothing
 endfunction
 
 
-// 创造/删除 荒芜地表（不死族）在指定方形区域
+// 创造/删除 荒芜地表（不死族）在指定矩形区域
 function SetBlightRectBJ takes boolean addBlight, player whichPlayer, rect r returns nothing
     call SetBlightRect(whichPlayer, r, addBlight)
 endfunction
@@ -9725,7 +9729,7 @@ endfunction
 //*
 //***************************************************************************
 
-// 删除当前开始点多余单位触发器
+// 删除当前开始点多余单位
 // 多余单位是指中立敌对玩家的单位 或 中立被动玩家的非建筑类单位
 function MeleeClearExcessUnit takes nothing returns nothing
     local unit    theUnit = GetEnumUnit()
@@ -9785,7 +9789,7 @@ endfunction
 //*
 //***************************************************************************
 
-// 寻找玩家开始点附近的金矿触发器
+// 寻找玩家开始点附近的金矿
 function MeleeEnumFindNearestMine takes nothing returns nothing
     local unit enumUnit = GetEnumUnit()
     local real dist
@@ -10443,7 +10447,7 @@ endfunction
 
 
 // Count allies, excluding dead players and the player themself.
-//
+// 获取盟友数量（指定玩家）
 function MeleeGetAllyCount takes player whichPlayer returns integer
     local integer playerIndex
     local integer playerCount
@@ -10550,7 +10554,7 @@ endfunction
 
 
 // Remove all observers
-// 
+// 游戏结束时移除裁判
 function MeleeRemoveObservers takes nothing returns nothing
     local integer    playerIndex
     local player     indexPlayer
@@ -10574,7 +10578,7 @@ endfunction
 // remaining (read: undefeated) players need to be co-allied with all other
 // remaining players.  If even one player is not allied towards another,
 // everyone must be denied victory.
-//
+// 胜利检查
 function MeleeCheckForVictors takes nothing returns force
     local integer    playerIndex
     local integer    opponentIndex
@@ -10615,7 +10619,7 @@ endfunction
 
 
 // Test each player to determine if anyone has been defeated.
-//
+// 检查所有玩家的游戏结果（胜利/失败）
 function MeleeCheckForLosersAndVictors takes nothing returns nothing
     local integer    playerIndex
     local player     indexPlayer
@@ -10676,7 +10680,8 @@ endfunction
 
 
 // Returns a race-specific "build X or be revealed" message.
-//
+// 暴露建造默认提示文本
+// 失去全部基地时，系统会提示要在限定时间建造一个一本基地，否则将会暴露，这里控制要建造的单位类型提示文本
 function MeleeGetCrippledWarningMessage takes player whichPlayer returns string
     local race r = GetPlayerRace(whichPlayer)
 
@@ -10696,8 +10701,8 @@ endfunction
 
 
 // Returns a race-specific "build X" label for cripple timers.
-// 建造默认提示文本
-// 失去全部基地时，系统会提示要在限定时间建造一个一本基地，否则将会暴露，这里控制具体的提示文本
+// 暴露建造计时器默认提示文本
+// 失去全部基地时，系统会提示要在限定时间建造一个一本基地，否则将会暴露，这里控制计时器的提示文本
 function MeleeGetCrippledTimerMessage takes player whichPlayer returns string
     local race r = GetPlayerRace(whichPlayer)
 
@@ -10819,7 +10824,8 @@ function MeleeCrippledPlayerTimeout takes nothing returns nothing
     call MeleeExposePlayer(exposedPlayer, true)
 endfunction
 
-
+// 玩家是否没有基地
+// 用于对战胜负判断和暴露提示
 function MeleePlayerIsCrippled takes player whichPlayer returns boolean
     local integer playerStructures  = GetPlayerStructureCount(whichPlayer, true)
     local integer playerKeyStructures = BlzGetPlayerTownHallCount(whichPlayer)
@@ -10830,7 +10836,7 @@ endfunction
 
 
 // Test each player to determine if anyone has become crippled.
-//
+// 检查玩家残余单位
 function MeleeCheckForCrippledPlayers takes nothing returns nothing
     local integer    playerIndex
     local player     indexPlayer
@@ -10899,7 +10905,7 @@ endfunction
 
 
 // Determine if the lost unit should result in any defeats or victories.
-//
+// 检查残余单位
 function MeleeCheckLostUnit takes unit lostUnit returns nothing
     local player lostUnitOwner = GetOwningPlayer(lostUnit)
 
@@ -10916,7 +10922,8 @@ endfunction
 
 // Determine if the gained unit should result in any defeats, victories,
 // or cripple-status changes.
-//
+// 检查是否需要添加残余单位
+// 残余单位：判断玩家当前是否有任意单位存活
 function MeleeCheckAddedUnit takes unit addedUnit returns nothing
     local player addedUnitOwner = GetOwningPlayer(addedUnit)
 
@@ -10926,24 +10933,24 @@ function MeleeCheckAddedUnit takes unit addedUnit returns nothing
     endif
 endfunction
 
-
+// 检查是否需要添加残余单位（取消建筑建造触发）
 function MeleeTriggerActionConstructCancel takes nothing returns nothing
     call MeleeCheckLostUnit(GetCancelledStructure())
 endfunction
 
-
+// 检查是否需要添加残余单位（单位死亡触发）
 function MeleeTriggerActionUnitDeath takes nothing returns nothing
     if (IsUnitType(GetDyingUnit(), UNIT_TYPE_STRUCTURE)) then
         call MeleeCheckLostUnit(GetDyingUnit())
     endif
 endfunction
 
-
+// 检查是否需要添加残余单位（建造建筑触发）
 function MeleeTriggerActionUnitConstructionStart takes nothing returns nothing
     call MeleeCheckAddedUnit(GetConstructingStructure())
 endfunction
 
-
+// 游戏结束时玩家失败触发器
 function MeleeTriggerActionPlayerDefeated takes nothing returns nothing
     local player thePlayer = GetTriggerPlayer()
     call CachePlayerHeroData(thePlayer)
@@ -10966,7 +10973,7 @@ function MeleeTriggerActionPlayerDefeated takes nothing returns nothing
     call MeleeCheckForLosersAndVictors()
 endfunction
 
-
+// 游戏结束时玩家存活触发器
 function MeleeTriggerActionPlayerLeft takes nothing returns nothing
     local player thePlayer = GetTriggerPlayer()
 
@@ -10995,13 +11002,13 @@ function MeleeTriggerActionPlayerLeft takes nothing returns nothing
     call MeleeCheckForLosersAndVictors()
 endfunction
 
-
+// 改变联盟状态触发器动作
 function MeleeTriggerActionAllianceChange takes nothing returns nothing
     call MeleeCheckForLosersAndVictors()
     call MeleeCheckForCrippledPlayers()
 endfunction
 
-
+// 对战比赛即将结束（暴露提示）
 function MeleeTriggerTournamentFinishSoon takes nothing returns nothing
     // Note: We may get this trigger multiple times
     local integer    playerIndex
@@ -11042,7 +11049,7 @@ function MeleeTriggerTournamentFinishSoon takes nothing returns nothing
 endfunction
 
 
-
+// 玩家是否真人
 function MeleeWasUserPlayer takes player whichPlayer returns boolean
     local playerslotstate slotState
 
@@ -11055,7 +11062,7 @@ function MeleeWasUserPlayer takes player whichPlayer returns boolean
     return (slotState == PLAYER_SLOT_STATE_PLAYING or slotState == PLAYER_SLOT_STATE_LEFT)
 endfunction
 
-
+// 判断对战比赛的结束规则
 function MeleeTournamentFinishNowRuleA takes integer multiplier returns nothing
     local integer array playerScore
     local integer array teamScore
@@ -11182,7 +11189,7 @@ function MeleeTournamentFinishNowRuleA takes integer multiplier returns nothing
 
 endfunction
 
-
+// 对战比赛结束
 function MeleeTriggerTournamentFinishNow takes nothing returns nothing
     local integer rule = GetTournamentFinishNowRule()
 
@@ -11302,7 +11309,7 @@ endfunction
 //*
 //***************************************************************************
 
-
+// 检查玩家槽可用性
 function CheckInitPlayerSlotAvailability takes nothing returns nothing
     local integer index
 
@@ -11318,7 +11325,7 @@ function CheckInitPlayerSlotAvailability takes nothing returns nothing
     endif
 endfunction
 
-
+// 设置玩家槽可用性
 function SetPlayerSlotAvailable takes player whichPlayer, mapcontrol control returns nothing
     local integer playerIndex = GetPlayerId(whichPlayer)
 
@@ -11335,7 +11342,7 @@ endfunction
 //*
 //***************************************************************************
 
-
+// 设置玩家队伍（指定队伍数量）
 function TeamInitPlayerSlots takes integer teamCount returns nothing
     local integer index
     local player  indexPlayer
@@ -11361,17 +11368,17 @@ function TeamInitPlayerSlots takes integer teamCount returns nothing
     endloop
 endfunction
 
-
+// 玩家队伍 混战
 function MeleeInitPlayerSlots takes nothing returns nothing
     call TeamInitPlayerSlots(bj_MAX_PLAYERS)
 endfunction
 
-
+// 玩家队伍 FFA
 function FFAInitPlayerSlots takes nothing returns nothing
     call TeamInitPlayerSlots(bj_MAX_PLAYERS)
 endfunction
 
-
+// 玩家队伍 1V1
 function OneOnOneInitPlayerSlots takes nothing returns nothing
     // Limit the game to 2 players.
     call SetTeams(2)
@@ -11379,7 +11386,8 @@ function OneOnOneInitPlayerSlots takes nothing returns nothing
     call TeamInitPlayerSlots(2)
 endfunction
 
-
+// 初始化玩家队伍（按游戏类型）
+// 包含1V1、2支队伍、3支队伍、4支队伍、FFA、混战
 function InitGenericPlayerSlots takes nothing returns nothing
     local gametype gType = GetGameTypeSelected()
 
@@ -11410,21 +11418,21 @@ endfunction
 //*
 //***************************************************************************
 
-
+// 设置黎明声音
 function SetDNCSoundsDawn takes nothing returns nothing
     if bj_useDawnDuskSounds then
         call StartSound(bj_dawnSound)
     endif
 endfunction
 
-
+// 设置黄昏声音
 function SetDNCSoundsDusk takes nothing returns nothing
     if bj_useDawnDuskSounds then
         call StartSound(bj_duskSound)
     endif
 endfunction
 
-
+// 设置白天声音
 function SetDNCSoundsDay takes nothing returns nothing
     local real ToD = GetTimeOfDay()
 
@@ -11437,7 +11445,7 @@ function SetDNCSoundsDay takes nothing returns nothing
     endif
 endfunction
 
-
+// 设置夜晚声音
 function SetDNCSoundsNight takes nothing returns nothing
     local real ToD = GetTimeOfDay()
 
@@ -11450,7 +11458,7 @@ function SetDNCSoundsNight takes nothing returns nothing
     endif
 endfunction
 
-
+// 初始化声音设置
 function InitDNCSounds takes nothing returns nothing
     // Create sounds to be played at dawn and dusk.
     set bj_dawnSound = CreateSoundFromLabel("RoosterSound", false, false, false, 10000, 10000)
@@ -11477,7 +11485,7 @@ function InitDNCSounds takes nothing returns nothing
     call TriggerAddAction(bj_dncSoundsNight, function SetDNCSoundsNight)
 endfunction
 
-// 初始blizzard.j全局变量
+// 初始化blizzard.j全局变量
 function InitBlizzardGlobals takes nothing returns nothing
     local integer index
     local integer userControlledPlayers
@@ -11599,7 +11607,7 @@ endfunction
 
 
 // Update the per-class stock limits.
-//
+// 更新市场物品可用性限制
 function UpdateStockAvailability takes item whichItem returns nothing
     local itemtype iType  = GetItemType(whichItem)
     local integer  iLevel = GetItemLevel(whichItem)
@@ -11618,7 +11626,7 @@ endfunction
 
 
 // Find a sellable item of the given type and level, and then add it.
-//
+// 更新商店物品库存触发器条件
 function UpdateEachStockBuildingEnum takes nothing returns nothing
     local integer iteration = 0
     local integer pickedItemId
@@ -11637,7 +11645,7 @@ function UpdateEachStockBuildingEnum takes nothing returns nothing
     call AddItemToStock(GetEnumUnit(), pickedItemId, 1, 1)
 endfunction
 
-
+// 更新商店物品库存触发器动作
 function UpdateEachStockBuilding takes itemtype iType, integer iLevel returns nothing
     local group g
 
@@ -11652,7 +11660,7 @@ endfunction
 
 
 // Update stock inventory.
-// 更新商店物品库存
+// 更新商店物品库存触发器
 function PerformStockUpdates takes nothing returns nothing
     local integer  pickedItemId
     local itemtype pickedItemType
@@ -11699,18 +11707,18 @@ endfunction
 
 
 // Perform the first update, and then arrange future updates.
-//
+// 开始更新市场库存
 function StartStockUpdates takes nothing returns nothing
     call PerformStockUpdates()
     call TimerStart(bj_stockUpdateTimer, bj_STOCK_RESTOCK_INTERVAL, true, function PerformStockUpdates)
 endfunction
 
-
+// 删除购买物品
 function RemovePurchasedItem takes nothing returns nothing
     call RemoveItemFromStock(GetSellingUnit(), GetItemTypeId(GetSoldItem()))
 endfunction
 
-
+// 初始化中立建筑
 function InitNeutralBuildings takes nothing returns nothing
     local integer iLevel
 
@@ -11750,7 +11758,7 @@ function DetectGameStarted takes nothing returns nothing
     call TimerStart(bj_gameStartedTimer, bj_GAME_STARTED_THRESHOLD, false, function MarkGameStarted)
 endfunction
 
-
+// 初始化
 function InitBlizzard takes nothing returns nothing
     // Set up the Neutral Victim player slot, to torture the abandoned units
     // of defeated players.  Since some triggers expect this player slot to

--- a/static/blizzard.j
+++ b/static/blizzard.j
@@ -546,9 +546,9 @@ globals
     constant integer   bj_TIMETYPE_SUB             = 2
 
     // Camera bounds adjustment methods
-    // 镜头界限调整 - 增加
+    // 镜头界限调整 - 扩展
     constant integer   bj_CAMERABOUNDS_ADJUST_ADD  = 0
-    // 镜头界限调整 - 减少
+    // 镜头界限调整 - 收缩
     constant integer   bj_CAMERABOUNDS_ADJUST_SUB  = 1
 
     // Quest creation states
@@ -598,11 +598,11 @@ globals
     constant integer   bj_SORTTYPE_SORTBYLABEL     = 2
 
     // Cinematic fade filter methods
-    // 电影淡化-淡入
+    // 电影淡化 - 淡入
     constant integer   bj_CINEFADETYPE_FADEIN      = 0
-    // 电影淡化-淡出
+    // 电影淡化 - 淡出
     constant integer   bj_CINEFADETYPE_FADEOUT     = 1
-    // 电影淡化-淡出并淡入（一并使用）
+    // 电影淡化 - 淡出并淡入（一并使用）
     constant integer   bj_CINEFADETYPE_FADEOUTIN   = 2
 
     // Buff removal methods
@@ -908,10 +908,10 @@ globals
     boolean array      bj_meleeVictoried
     unit array         bj_ghoul
     // 玩家即将暴露计时器
-    // 失去所有基地时，系统会提示要在限定内造一个基地，否则会暴露，这就是计时器
+    // 失去所有基地时，系统会提示要在限定内造一个基地，否则会暴露，这是提示的计时器
     timer array        bj_crippledTimer
     // 玩家即将暴露计时器计时窗口
-    // 失去所有基地时，系统会提示要在限定内造一个基地，否则会暴露，这就是计时窗口
+    // 失去所有基地时，系统会提示要在限定内造一个基地，否则会暴露，这是提示的计时窗口
     timerdialog array  bj_crippledTimerWindows
     // 玩家即将暴露判断布尔值数组，每位玩家配一个
     // 失去所有基地时，系统会提示要在限定内造一个基地，失去所有基地会变为真
@@ -920,10 +920,10 @@ globals
     // 失去所有基地时，系统会提示要在限定内造一个基地，如果计时完成没有造，变为真
     boolean array      bj_playerIsExposed
     // 玩家暴露计时器
-    // 失去所有基地时，系统会提示要在限定内造一个基地，如果没造，这就是暴露时间的计时器
+    // 失去所有基地时，系统会提示要在限定内造一个基地，如果没造，这是暴露时间的计时器
     boolean            bj_finishSoonAllExposed     = false
     // 玩家即将暴露计时器计时窗口
-    // 失去所有基地时，系统会提示要在限定内造一个基地，如果没造，这就是暴露时间的计时窗口
+    // 失去所有基地时，系统会提示要在限定内造一个基地，如果没造，这是暴露时间的计时窗口
     timerdialog        bj_finishSoonTimerDialog    = null
     // 首发英雄初始物品创建数量数组，每位玩家配一个
     // 用于记录已经给首发创建了多少个初始物品
@@ -978,29 +978,29 @@ globals
     string             bj_cineFadeContinueTex      = ""
 
     // QueuedTriggerExecute vars
-    // 动作队列执行次数统计
+    // 触发器队列执行次数统计
     integer            bj_queuedExecTotal          = 0
-    // 动作队列执行触发器数组
+    // 触发器队列执行触发器数组
     trigger array      bj_queuedExecTriggers
-    // 动作队列执行布尔值数组 用于登记当前动作是否使用了条件
+    // 触发器队列执行布尔值数组 用于登记当前触发器是否使用了条件
     boolean array      bj_queuedExecUseConds
-    // 动作队列执行计时器
+    // 触发器队列执行计时器
     timer              bj_queuedExecTimeoutTimer   = CreateTimer()
-    // 动作队列执行超时触发器
+    // 触发器队列执行超时触发器
     trigger            bj_queuedExecTimeout        = null
 
     // Helper vars (for Filter and Enum funcs)
     // 可破坏物死亡事件 统计死亡的可破坏物数量
     integer            bj_destInRegionDiesCount    = 0
-    // 可破坏物死亡事件 死亡的可破坏物动作的触发器
+    // 可破坏物死亡事件 死亡的可破坏物的触发器
     trigger            bj_destInRegionDiesTrig     = null
     // 单位组内单位数量
     integer            bj_groupCountUnits          = 0
     // 玩家组内的玩家数量
     integer            bj_forceCountPlayers        = 0
-    // 执行单位组动作时，选取的单位类型
+    // 获取单位组中指定类型的单位，指定的单位类型
     integer            bj_groupEnumTypeId          = 0
-    // 执行玩家区域单位组动作是，选取的玩家
+    // 获取玩家在指定方形区域中的单位，指定的玩家
     player             bj_groupEnumOwningPlayer    = null
     // 指代往 A单位组 添加 B单位组 单位完成后，需要摧毁的单位组
     group              bj_groupAddGroupDest        = null
@@ -1010,21 +1010,32 @@ globals
     integer            bj_groupRandomConsidered    = 0
     // 获取单位组随机单位返回的单位
     unit               bj_groupRandomCurrentPick   = null
-    //最后创建且需要摧毁的单位组
+    // 最后创建且需要摧毁的单位组
     group              bj_groupLastCreatedDest     = null
+    // 随机选取单位组中的单位，返回的新单位组
     group              bj_randomSubGroupGroup      = null
+    // 随机选取单位组中的单位，指定的单位数量
     integer            bj_randomSubGroupWant       = 0
+    // 随机选取单位组中的单位，原单位组的单位数量
     integer            bj_randomSubGroupTotal      = 0
+    // 随机选取单位组中的单位，指定的单位数量 与 原单位组的单位数量 的比例
+    // bj_randomSubGroupChance = I2R(bj_randomSubGroupWant) / I2R(bj_randomSubGroupTotal)
     real               bj_randomSubGroupChance     = 0
+    // 随机选取方形区域的可破坏物，区域内的可破坏物数量
     integer            bj_destRandomConsidered     = 0
+    // 随机选取方形区域的可破坏物，选取的可破坏物
     destructable       bj_destRandomCurrentPick    = null
     // 可破坏物 升降机路径阻断器
     destructable       bj_elevatorWallBlocker      = null
     // 可破坏物 相邻的升降机
     destructable       bj_elevatorNeighbor         = null
+    // 随机选取的区域中的物品，区域内的物品数量
     integer            bj_itemRandomConsidered     = 0
+    // 随机选取的区域中的物品，选取的物品
     item               bj_itemRandomCurrentPick    = null
+    // 随机获取玩家组中的玩家，玩家组的玩家数量
     integer            bj_forceRandomConsidered    = 0
+    // 随机获取玩家组中的玩家，选取的玩家
     player             bj_forceRandomCurrentPick   = null
     // 可营救单位
     unit               bj_makeUnitRescuableUnit    = null
@@ -1140,21 +1151,21 @@ globals
 	commandbuttoneffect bj_lastCreatedCommandButtonEffect = null
 
     // Filter function vars
-    // 初始化条件 单位类型为金矿（中立金矿）的单位，默认值为空
+    // 初始化过滤 单位类型为金矿（中立金矿）的单位，默认值为空
     boolexpr           filterIssueHauntOrderAtLocBJ      = null
-    // 初始化条件 匹配的可破坏物是否离指定点小于某距离，默认值为空
+    // 初始化过滤 匹配的可破坏物是否离指定点小于某距离，默认值为空
     boolexpr           filterEnumDestructablesInCircleBJ = null
-    // 初始化条件 匹配指定玩家在指定区域的单位，默认值为空
+    // 初始化过滤 匹配指定玩家在指定区域的单位，默认值为空
     boolexpr           filterGetUnitsInRectOfPlayer      = null
-    // 初始化条件 匹配的单位类型，默认值为空
+    // 初始化过滤 匹配的单位类型，默认值为空
     boolexpr           filterGetUnitsOfTypeIdAll         = null
-    // 初始化条件 匹配玩家拥有的单位类型，默认值为空
+    // 初始化过滤 匹配玩家拥有的单位类型，默认值为空
     // 用于对战初始化
     boolexpr           filterGetUnitsOfPlayerAndTypeId   = null
-    // 初始化条件 匹配的英雄单位，默认值为空
+    // 初始化过滤 匹配的英雄单位，默认值为空
     // 用于对战初始化
     boolexpr           filterMeleeTrainedUnitIsHeroBJ    = null
-    // 初始化条件 匹配玩家拥有且存活的单位类型，默认值为空
+    // 初始化过滤 匹配玩家拥有且存活的单位类型，默认值为空
     // 用于对战初始化
     boolexpr           filterLivingPlayerUnitsOfTypeId   = null
 
@@ -1485,7 +1496,7 @@ endfunction
 // trigger is not interrupted as is the case with a TriggerExecute call.
 // Since the trigger executes normally, its conditions are still evaluated.
 //
-// 执行触发器动作
+// 执行触发器
 function PostTriggerExecuteBJ takes trigger trig, boolean checkConditions returns boolean
     if checkConditions then
         if not (TriggerEvaluate(trig)) then
@@ -1888,7 +1899,7 @@ endfunction
 //***************************************************************************
 
 
-// 当前的视角
+// 获取当前镜头设置
 function GetCurrentCameraSetup takes nothing returns camerasetup
     local camerasetup theCam = CreateCameraSetup()
     local real duration = 0
@@ -1915,7 +1926,7 @@ function CameraSetupApplyForPlayer takes boolean doPan, camerasetup whichSetup, 
     endif
 endfunction
 
-
+// 设置镜头平滑持续时间
 function CameraSetupApplyForPlayerSmooth takes boolean doPan, camerasetup whichSetup, player whichPlayer, real forcedDuration, real easeInDuration, real easeOutDuration, real smoothFactor returns nothing
     if (GetLocalPlayer() == whichPlayer) then
         // Use only local code (no net traffic) within this block to avoid desyncs.
@@ -1924,7 +1935,7 @@ function CameraSetupApplyForPlayerSmooth takes boolean doPan, camerasetup whichS
 endfunction
 
 
-// 镜头的数值
+// 获取指定镜头的指定属性
 function CameraSetupGetFieldSwap takes camerafield whichField, camerasetup whichSetup returns real
     return CameraSetupGetField(whichSetup, whichField)
 endfunction
@@ -1948,7 +1959,7 @@ function SetCameraTargetControllerNoZForPlayer takes player whichPlayer, unit wh
 endfunction
 
 
-// 设置玩家的镜头位置
+// 设置玩家的镜头位置（指定坐标）
 function SetCameraPositionForPlayer takes player whichPlayer, real x, real y returns nothing
     if (GetLocalPlayer() == whichPlayer) then
         // Use only local code (no net traffic) within this block to avoid desyncs.
@@ -1957,7 +1968,7 @@ function SetCameraPositionForPlayer takes player whichPlayer, real x, real y ret
 endfunction
 
 
-// 设置玩家的镜头位置
+// 设置玩家的镜头位置（指定点）
 function SetCameraPositionLocForPlayer takes player whichPlayer, location loc returns nothing
     if (GetLocalPlayer() == whichPlayer) then
         // Use only local code (no net traffic) within this block to avoid desyncs.
@@ -1975,7 +1986,7 @@ function RotateCameraAroundLocBJ takes real degrees, location loc, player whichP
 endfunction
 
 
-// 平移镜头
+// 平移镜头（指定坐标）
 function PanCameraToForPlayer takes player whichPlayer, real x, real y returns nothing
     if (GetLocalPlayer() == whichPlayer) then
         // Use only local code (no net traffic) within this block to avoid desyncs.
@@ -1984,7 +1995,7 @@ function PanCameraToForPlayer takes player whichPlayer, real x, real y returns n
 endfunction
 
 
-// 平移镜头
+// 平移镜头（指定点）
 function PanCameraToLocForPlayer takes player whichPlayer, location loc returns nothing
     if (GetLocalPlayer() == whichPlayer) then
         // Use only local code (no net traffic) within this block to avoid desyncs.
@@ -1993,7 +2004,7 @@ function PanCameraToLocForPlayer takes player whichPlayer, location loc returns 
 endfunction
 
 
-// 平移镜头 定时
+// 平移镜头（定时）
 function PanCameraToTimedForPlayer takes player whichPlayer, real x, real y, real duration returns nothing
     if (GetLocalPlayer() == whichPlayer) then
         // Use only local code (no net traffic) within this block to avoid desyncs.
@@ -2060,7 +2071,9 @@ function ResetToGameCameraForPlayer takes player whichPlayer, real duration retu
 endfunction
 
 
-// 摇摆镜头来源
+// 摇晃镜头源
+// @param magnitude摇晃幅度
+// @param velocity摇晃速率
 function CameraSetSourceNoiseForPlayer takes player whichPlayer, real magnitude, real velocity returns nothing
     if (GetLocalPlayer() == whichPlayer) then
         // Use only local code (no net traffic) within this block to avoid desyncs.
@@ -2069,7 +2082,9 @@ function CameraSetSourceNoiseForPlayer takes player whichPlayer, real magnitude,
 endfunction
 
 
-// 摇摆镜头目标
+// 摇晃镜头目标
+// @param magnitude摇晃幅度
+// @param velocity摇晃速率
 function CameraSetTargetNoiseForPlayer takes player whichPlayer, real magnitude, real velocity returns nothing
     if (GetLocalPlayer() == whichPlayer) then
         // Use only local code (no net traffic) within this block to avoid desyncs.
@@ -2078,7 +2093,8 @@ function CameraSetTargetNoiseForPlayer takes player whichPlayer, real magnitude,
 endfunction
 
 
-// 摇动镜头
+// 震动镜头
+// @param magnitude摇晃幅度
 function CameraSetEQNoiseForPlayer takes player whichPlayer, real magnitude returns nothing
     local real richter = magnitude
     if (richter > 5.0) then
@@ -2095,7 +2111,7 @@ function CameraSetEQNoiseForPlayer takes player whichPlayer, real magnitude retu
 endfunction
 
 
-// 停止 摇摆/摇动 镜头
+// 停止 摇摆/摇晃 镜头
 function CameraClearNoiseForPlayer takes player whichPlayer returns nothing
     if (GetLocalPlayer() == whichPlayer) then
         // Use only local code (no net traffic) within this block to avoid desyncs.
@@ -2107,7 +2123,7 @@ endfunction
 
 // Query the current camera bounds.
 //
-// 当前的摄象机范围
+// 获取当前镜头范围
 function GetCurrentCameraBoundsMapRectBJ takes nothing returns rect
     return Rect(GetCameraBoundMinX(), GetCameraBoundMinY(), GetCameraBoundMaxX(), GetCameraBoundMaxY())
 endfunction
@@ -2115,7 +2131,7 @@ endfunction
 
 // Query the initial camera bounds, as defined at map init.
 //
-// 初始游戏时的摄象机范围
+// 获取初始游戏时的镜头范围
 function GetCameraBoundsMapRect takes nothing returns rect
     return bj_mapInitialCameraBounds
 endfunction
@@ -2123,7 +2139,7 @@ endfunction
 
 // Query the playable map area, as defined at map init.
 //
-// 可玩的地图区域
+// 获取可玩的地图区域
 function GetPlayableMapRect takes nothing returns rect
     return bj_mapInitialPlayableArea
 endfunction
@@ -2131,7 +2147,7 @@ endfunction
 
 // Query the entire map area, as defined at map init.
 //
-// 全地图
+// 获取全地图可用区域
 function GetEntireMapRect takes nothing returns rect
     return GetWorldBounds()
 endfunction
@@ -2156,7 +2172,7 @@ function SetCameraBoundsToRectForPlayerBJ takes player whichPlayer, rect r retur
 endfunction
 
 
-// 调整相机边界
+// 调整镜头边界
 function AdjustCameraBoundsBJ takes integer adjustMethod, real dxWest, real dxEast, real dyNorth, real dySouth returns nothing
     local real minX = 0
     local real minY = 0
@@ -2194,7 +2210,8 @@ function AdjustCameraBoundsBJ takes integer adjustMethod, real dxWest, real dxEa
 endfunction
 
 
-// 扩展/收缩摄像绑定
+// 扩展/收缩 可用镜头区域（指定玩家）
+// @param adjustMethod扩展/收缩
 function AdjustCameraBoundsForPlayerBJ takes integer adjustMethod, player whichPlayer, real dxWest, real dxEast, real dyNorth, real dySouth returns nothing
     if (GetLocalPlayer() == whichPlayer) then
         // Use only local code (no net traffic) within this block to avoid desyncs.
@@ -2203,7 +2220,7 @@ function AdjustCameraBoundsForPlayerBJ takes integer adjustMethod, player whichP
 endfunction
 
 
-// 设置相机位置 (快速)
+// 设置镜头空格键转向坐标（指定玩家） (快速)
 function SetCameraQuickPositionForPlayer takes player whichPlayer, real x, real y returns nothing
     if (GetLocalPlayer() == whichPlayer) then
         // Use only local code (no net traffic) within this block to avoid desyncs.
@@ -2212,7 +2229,7 @@ function SetCameraQuickPositionForPlayer takes player whichPlayer, real x, real 
 endfunction
 
 
-// 设置相机位置 (快速)
+// 设置镜头空格键转向点（指定玩家） (快速)
 function SetCameraQuickPositionLocForPlayer takes player whichPlayer, location loc returns nothing
     if (GetLocalPlayer() == whichPlayer) then
         // Use only local code (no net traffic) within this block to avoid desyncs.
@@ -2220,13 +2237,13 @@ function SetCameraQuickPositionLocForPlayer takes player whichPlayer, location l
     endif
 endfunction
 
-
+// 设置镜头空格键转向点（指定玩家）
 function SetCameraQuickPositionLoc takes location loc returns nothing
     call SetCameraQuickPosition(GetLocationX(loc), GetLocationY(loc))
 endfunction
 
 
-// 停止镜头
+// 停止播放镜头
 function StopCameraForPlayerBJ takes player whichPlayer returns nothing
     if (GetLocalPlayer() == whichPlayer) then
         // Use only local code (no net traffic) within this block to avoid desyncs.
@@ -2563,7 +2580,7 @@ function TriggerRegisterGameSavedEventBJ takes trigger trig returns event
 endfunction
 
 
-// 可破坏物在区域内死亡动作(矩形区域)
+// 让指定区域内的可破坏物死亡(毁坏的)触发器(矩形区域)
 function RegisterDestDeathInRegionEnum takes nothing returns nothing
     set bj_destInRegionDiesCount = bj_destInRegionDiesCount + 1
     if (bj_destInRegionDiesCount <= bj_MAX_DEST_IN_REGION_EVENTS) then
@@ -2572,7 +2589,7 @@ function RegisterDestDeathInRegionEnum takes nothing returns nothing
 endfunction
 
 
-// 可毁坏物在 区域 死亡
+// 让指定区域的可毁坏物死亡(毁坏的)
 function TriggerRegisterDestDeathInRegionEvent takes trigger trig, rect r returns nothing
     set bj_destInRegionDiesTrig = trig
     set bj_destInRegionDiesCount = 0
@@ -2873,13 +2890,13 @@ function ResetTerrainFogBJ takes nothing returns nothing
 endfunction
 
 
-// 播放圆周内地形装饰物的动作
+// 播放圆周内地形装饰物的触发器
 function SetDoodadAnimationBJ takes string animName, integer doodadID, real radius, location center returns nothing
     call SetDoodadAnimation(GetLocationX(center), GetLocationY(center), radius, doodadID, false, animName, false)
 endfunction
 
 
-// 播放区域内地形装饰物的动作
+// 播放区域内地形装饰物的触发器
 function SetDoodadAnimationRectBJ takes string animName, integer doodadID, rect r returns nothing
     call SetDoodadAnimationRect(r, doodadID, animName, false)
 endfunction
@@ -4018,7 +4035,7 @@ function ChooseRandomCreepBJ takes integer level returns integer
 endfunction
 
 
-// 选取所有物品在 区域 做动作(单一的)
+// 选取所有物品在 区域 做动作(单个动作)
 function EnumItemsInRectBJ takes rect r, code actionFunc returns nothing
     call EnumItemsInRect(r, null, actionFunc)
 endfunction
@@ -4026,7 +4043,7 @@ endfunction
 
 // See GroupPickRandomUnitEnum for the details of this algorithm.
 //
-// 随机物品在区域并匹配条件
+// 随机选取指定区域的物品触发器
 function RandomItemInRectBJEnum takes nothing returns nothing
     set bj_itemRandomConsidered = bj_itemRandomConsidered + 1
     if (GetRandomInt(1, bj_itemRandomConsidered) == 1) then
@@ -4036,7 +4053,7 @@ endfunction
 
 
 // Picks a random item from within a rect, matching a condition
-//
+// 随机选取指定区域的匹配物品（过滤）
 function RandomItemInRectBJ takes rect r, boolexpr filter returns item
     set bj_itemRandomConsidered = 0
     set bj_itemRandomCurrentPick = null
@@ -4048,7 +4065,7 @@ endfunction
 
 // Picks a random item from within a rect
 //
-// 随机物品在区域
+// 随机选取指定区域的物品
 function RandomItemInRectSimpleBJ takes rect r returns item
     return RandomItemInRectBJ(r, null)
 endfunction
@@ -4480,7 +4497,7 @@ function IsUnitAliveBJ takes unit whichUnit returns boolean
 endfunction
 
 
-// 单位组的单位是否已死亡动作
+// 单位组的单位是否已死亡触发器
 function IsUnitGroupDeadBJEnum takes nothing returns nothing
     if not IsUnitDeadBJ(GetEnumUnit()) then
         set bj_isUnitGroupDeadResult = false
@@ -5125,13 +5142,13 @@ function GetDestructableLoc takes destructable whichDestructable returns locatio
 endfunction
 
 
-// 选取指定方形区域所有可毁坏物做动作(单一的)
+// 选取指定方形区域所有可毁坏物做动作(单个动作)
 function EnumDestructablesInRectAll takes rect r, code actionFunc returns nothing
     call EnumDestructablesInRect(r, null, actionFunc)
 endfunction
 
 
-// 选取指定圆形区域所有可毁坏物做动作(单一的)
+// 选取指定圆形区域所有可毁坏物做动作(单个动作)
 function EnumDestructablesInCircleBJFilter takes nothing returns boolean
     local location destLoc = GetDestructableLoc(GetFilterDestructable())
     local boolean result
@@ -5156,7 +5173,7 @@ endfunction
 
 // See GroupPickRandomUnitEnum for the details of this algorithm.
 //
-// 随机选取方形区域满足指定条件的可毁坏物触发器
+// 随机选取方形区域的可毁坏物触发器
 function RandomDestructableInRectBJEnum takes nothing returns nothing
     set bj_destRandomConsidered = bj_destRandomConsidered + 1
     if (GetRandomInt(1,bj_destRandomConsidered) == 1) then
@@ -5166,7 +5183,7 @@ endfunction
 
 
 // Picks a random destructable from within a rect, matching a condition
-// 随机选取方形区域满足指定条件的可毁坏物
+// 随机选取方形区域满足过滤的可毁坏物
 function RandomDestructableInRectBJ takes rect r, boolexpr filter returns destructable
     set bj_destRandomConsidered = 0
     set bj_destRandomCurrentPick = null
@@ -5186,7 +5203,7 @@ endfunction
 
 // Enumerates within a rect, with a filter to narrow the enumeration down
 // objects within a circular area.
-// 随机选取圆形区域满足指定条件的可毁坏物
+// 随机选取圆形区域满足过滤的可毁坏物
 function EnumDestructablesInCircleBJ takes real radius, location loc, code actionFunc returns nothing
     local rect r
 
@@ -5528,7 +5545,7 @@ endfunction
 //*
 //***************************************************************************
 
-
+// 选取单位组做指定动作
 function ForGroupBJ takes group whichGroup, code callback returns nothing
     // If the user wants the group destroyed, remember that fact and clear
     // the flag, in case it is used again in the callback.
@@ -5550,18 +5567,18 @@ function GroupAddUnitSimple takes unit whichUnit, group whichGroup returns nothi
 endfunction
 
 
-// 清除单位从单位组
+// 从单位组清除单位
 function GroupRemoveUnitSimple takes unit whichUnit, group whichGroup returns nothing
     call GroupRemoveUnit(whichGroup, whichUnit)
 endfunction
 
 
-// 增加单位组到单位组
+// 增加单位组到单位组触发器
 function GroupAddGroupEnum takes nothing returns nothing
     call GroupAddUnit(bj_groupAddGroupDest, GetEnumUnit())
 endfunction
 
-
+// 增加 sourceGroup单位组中的单位 到 destGroup单位组
 function GroupAddGroup takes group sourceGroup, group destGroup returns nothing
     // If the user wants the group destroyed, remember that fact and clear
     // the flag, in case it is used again in the callback.
@@ -5578,12 +5595,12 @@ function GroupAddGroup takes group sourceGroup, group destGroup returns nothing
 endfunction
 
 
-// 清除单位组从单位组
+// 清除单位组从单位组触发器
 function GroupRemoveGroupEnum takes nothing returns nothing
     call GroupRemoveUnit(bj_groupRemoveGroupDest, GetEnumUnit())
 endfunction
 
-
+// 将 sourceGroup单位组中的单位 从 destGroup单位组 中清除
 function GroupRemoveGroup takes group sourceGroup, group destGroup returns nothing
     // If the user wants the group destroyed, remember that fact and clear
     // the flag, in case it is used again in the callback.
@@ -5618,7 +5635,7 @@ endfunction
 // The chance of picking a given unit over the "current pick" is 1/N, where N is
 // the number of units considered thusfar (including the current consideration).
 //
-// 单位组里的随机单位
+// 随机选取单位组中的单位触发器
 function GroupPickRandomUnitEnum takes nothing returns nothing
     set bj_groupRandomConsidered = bj_groupRandomConsidered + 1
     if (GetRandomInt(1,bj_groupRandomConsidered) == 1) then
@@ -5628,7 +5645,7 @@ endfunction
 
 
 // Picks a random unit from a group.
-//
+// 随机选取单位组中的单位
 function GroupPickRandomUnit takes group whichGroup returns unit
     // If the user wants the group destroyed, remember that fact and clear
     // the flag, in case it is used again in the callback.
@@ -5649,7 +5666,7 @@ endfunction
 
 // See GroupPickRandomUnitEnum for the details of this algorithm.
 //
-// 玩家组里的随机玩家
+// 随机选择玩家组中的玩家触发器
 function ForcePickRandomPlayerEnum takes nothing returns nothing
     set bj_forceRandomConsidered = bj_forceRandomConsidered + 1
     if (GetRandomInt(1,bj_forceRandomConsidered) == 1) then
@@ -5659,7 +5676,7 @@ endfunction
 
 
 // Picks a random player from a force.
-//
+// 随机选择玩家组中的玩家（指定玩家组）
 function ForcePickRandomPlayer takes force whichForce returns player
     set bj_forceRandomConsidered = 0
     set bj_forceRandomCurrentPick = null
@@ -5667,7 +5684,7 @@ function ForcePickRandomPlayer takes force whichForce returns player
     return bj_forceRandomCurrentPick
 endfunction
 
-
+// 选取区域中的所有单位触发器
 function EnumUnitsSelected takes player whichPlayer, boolexpr enumFilter, code enumAction returns nothing
     local group g = CreateGroup()
     call SyncSelections()
@@ -5678,7 +5695,7 @@ function EnumUnitsSelected takes player whichPlayer, boolexpr enumFilter, code e
 endfunction
 
 
-// 单位在区域中并匹配条件
+// 选取区域中的所有单位（过滤）
 function GetUnitsInRectMatching takes rect r, boolexpr filter returns group
     local group g = CreateGroup()
     call GroupEnumUnitsInRect(g, r, filter)
@@ -5687,13 +5704,13 @@ function GetUnitsInRectMatching takes rect r, boolexpr filter returns group
 endfunction
 
 
-// 匹配区域中的所有单位
+// 选取区域中的所有单位
 function GetUnitsInRectAll takes rect r returns group
     return GetUnitsInRectMatching(r, null)
 endfunction
 
 
-// 获取玩家在指定方形区域中的单位动作
+// 获取玩家在指定方形区域中的单位触发器
 function GetUnitsInRectOfPlayerFilter takes nothing returns boolean
     return GetOwningPlayer(GetFilterUnit()) == bj_groupEnumOwningPlayer
 endfunction
@@ -5750,7 +5767,7 @@ function GetUnitsOfTypeIdAll takes integer unitid returns group
 endfunction
 
 
-// 玩家拥有的单位匹配条件
+// 匹配玩家拥有的单位（过滤）
 function GetUnitsOfPlayerMatching takes player whichPlayer, boolexpr filter returns group
     local group g = CreateGroup()
     call GroupEnumUnitsOfPlayer(g, whichPlayer, filter)
@@ -5770,7 +5787,7 @@ function GetUnitsOfPlayerAndTypeIdFilter takes nothing returns boolean
     return GetUnitTypeId(GetFilterUnit()) == bj_groupEnumTypeId
 endfunction
 
-// 获取玩家的制定类型单位组
+// 获取玩家的指定类型单位组
 function GetUnitsOfPlayerAndTypeId takes player whichPlayer, integer unitid returns group
     local group g = CreateGroup()
     set bj_groupEnumTypeId = unitid
@@ -5839,7 +5856,7 @@ function GetPlayersEnemies takes player whichPlayer returns force
 endfunction
 
 
-// 所有玩家匹配条件
+// 匹配所有玩家（过滤）
 function GetPlayersMatching takes boolexpr filter returns force
     local force f = CreateForce()
     call ForceEnumPlayers(f, filter)
@@ -5884,7 +5901,7 @@ function CountPlayersInForceBJ takes force f returns integer
 endfunction
 
 
-// 随机选 N 个单位在单位组中
+// 在单位组中随机选 N 个单位
 function GetRandomSubGroupEnum takes nothing returns nothing
     if (bj_randomSubGroupWant > 0) then
         if (bj_randomSubGroupWant >= bj_randomSubGroupTotal) or (GetRandomReal(0,1) < bj_randomSubGroupChance) then
@@ -5896,7 +5913,8 @@ function GetRandomSubGroupEnum takes nothing returns nothing
     set bj_randomSubGroupTotal = bj_randomSubGroupTotal - 1
 endfunction
 
-// 获取单位组的随机子单位组
+// 获取单位组的随机单位，并添加在新单位组中，返回新单位组
+// @param 指定获取的单位数量
 // GetRandomSubGroup(2, [unit(8),unit(4),unit(2)]) -> [unit(4),unit(2)]
 function GetRandomSubGroup takes integer count, group sourceGroup returns group
     local group g = CreateGroup()
@@ -5914,14 +5932,14 @@ function GetRandomSubGroup takes integer count, group sourceGroup returns group
     return g
 endfunction
 
-
+// 匹配的单位类型是否存活
 function LivingPlayerUnitsOfTypeIdFilter takes nothing returns boolean
     local unit filterUnit = GetFilterUnit()
     return IsUnitAliveBJ(filterUnit) and GetUnitTypeId(filterUnit) == bj_livingPlayerUnitsTypeId
 endfunction
 
 
-// 玩家活着的某类型单位的数量
+// 玩家存活的指定单位类型的数量
 function CountLivingPlayerUnitsOfTypeId takes integer unitId, player whichPlayer returns integer
     local group g
     local integer matchedCount
@@ -5944,7 +5962,7 @@ endfunction
 //***************************************************************************
 
 
-// 重置单位动作
+// 重置单位触发器
 function ResetUnitAnimation takes unit whichUnit returns nothing
     call SetUnitAnimation(whichUnit, "stand")
 endfunction
@@ -6012,19 +6030,19 @@ function SetUnitFacingToFaceUnitTimed takes unit whichUnit, unit target, real du
 endfunction
 
 
-// 队列单位动作
+// 队列单位触发器
 function QueueUnitAnimationBJ takes unit whichUnit, string whichAnimation returns nothing
     call QueueUnitAnimation(whichUnit, whichAnimation)
 endfunction
 
 
-// 播放可毁坏物的动作
+// 播放可毁坏物的触发器
 function SetDestructableAnimationBJ takes destructable d, string whichAnimation returns nothing
     call SetDestructableAnimation(d, whichAnimation)
 endfunction
 
 
-// 排列可毁坏物的动作
+// 排列可毁坏物的触发器
 function QueueDestructableAnimationBJ takes destructable d, string whichAnimation returns nothing
     call QueueDestructableAnimation(d, whichAnimation)
 endfunction

--- a/static/blizzard.j
+++ b/static/blizzard.j
@@ -171,7 +171,7 @@ globals
     // 镜头默认旋转值（Z 轴旋转角度）（90）
     constant integer   bj_CAMERA_DEFAULT_ROTATION       = 90
 
-    // 救援延时，怀疑是中立可救援单位在被救援后变更队伍的延迟，默认2.00 Rescue
+    // 可营救延时，怀疑是中立可营救单位在被可营救后变更队伍的延迟，默认2.00 Rescue
     constant real      bj_RESCUE_PING_TIME              = 2.00
 
     // Transmission behavior settings
@@ -196,31 +196,53 @@ globals
     constant gamespeed bj_CINEMODE_GAMESPEED            = MAP_SPEED_NORMAL
 
     // Cinematic mode volume levels
+    // 电影模式默认音量 单位移动声音，默认0.40
     constant real      bj_CINEMODE_VOLUME_UNITMOVEMENT  = 0.40
+    // 电影模式默认音量 单位回应声音，默认0.00
     constant real      bj_CINEMODE_VOLUME_UNITSOUNDS    = 0.00
+    // 电影模式默认音量 战斗声音，默认0.40
     constant real      bj_CINEMODE_VOLUME_COMBAT        = 0.40
+    // 电影模式默认音量 动画和法术声音，默认0.40
     constant real      bj_CINEMODE_VOLUME_SPELLS        = 0.40
+    // 电影模式默认音量 用户界面（UI）声音，默认0.00
     constant real      bj_CINEMODE_VOLUME_UI            = 0.00
+    // 电影模式默认音量 音乐，默认0.55
     constant real      bj_CINEMODE_VOLUME_MUSIC         = 0.55
+    // 电影模式默认音量 场景配音，默认1.00
     constant real      bj_CINEMODE_VOLUME_AMBIENTSOUNDS = 1.00
+    // 电影模式默认音量 火焰声音，默认0.60
     constant real      bj_CINEMODE_VOLUME_FIRE          = 0.60
 
     // Speech mode volume levels
+    // 多通道默认音量 单位移动声音，默认0.25
     constant real      bj_SPEECH_VOLUME_UNITMOVEMENT    = 0.25
+    // 多通道默认音量 单位回应声音，默认0.00
     constant real      bj_SPEECH_VOLUME_UNITSOUNDS      = 0.00
+    // 多通道默认音量 战斗声音，默认0.25
     constant real      bj_SPEECH_VOLUME_COMBAT          = 0.25
+    // 多通道默认音量 动画和法术声音，默认0.25
     constant real      bj_SPEECH_VOLUME_SPELLS          = 0.25
+    // 多通道默认音量 用户界面（UI）声音，默认0.00
     constant real      bj_SPEECH_VOLUME_UI              = 0.00
+    // 多通道默认音量 音乐，默认0.55
     constant real      bj_SPEECH_VOLUME_MUSIC           = 0.55
+    // 多通道默认音量 场景配音，默认1.00
     constant real      bj_SPEECH_VOLUME_AMBIENTSOUNDS   = 1.00
+    // 多通道默认音量 火焰声音，默认0.60
     constant real      bj_SPEECH_VOLUME_FIRE            = 0.60
 
     // Smart pan settings
+    // 必要时平移镜头动作的距离限制，默认500
+    // 超过该值但不超过 bj_SMARTPAN_TRESHOLD_SNAP 时，使用限定的时间平移，低于该值时不平移
     constant real      bj_SMARTPAN_TRESHOLD_PAN         = 500
+    // 必要时平移镜头动作的距离限制，默认3500
+    // 平移距离超过该值时，立即完成平移（限定的时间被替换为0秒）
     constant real      bj_SMARTPAN_TRESHOLD_SNAP        = 3500
 
     // QueuedTriggerExecute settings
+    // 最大触发器队列，默认100
     constant integer   bj_MAX_QUEUED_TRIGGERS           = 100
+    // 触发器队列超时时间，默认180.00
     constant real      bj_QUEUED_TRIGGER_TIMEOUT        = 180.00
 
     // Campaign indexing constants
@@ -474,21 +496,21 @@ globals
     constant integer   bj_CINEMATICINDEX_XED      = 10
 
     // Alliance settings
-    // 联盟设置 - 不结盟
+    // 联盟设置 - 相互敌对
     constant integer   bj_ALLIANCE_UNALLIED        = 0
-    // 联盟设置 - 不结盟视野
+    // 联盟设置 - 相互敌对但共享视野
     constant integer   bj_ALLIANCE_UNALLIED_VISION = 1
-    // 联盟设置 - 结盟
+    // 联盟设置 - 相互结盟
     constant integer   bj_ALLIANCE_ALLIED          = 2
-    // 联盟设置 - 结盟视野
+    // 联盟设置 - 相互结盟且共享视野
     constant integer   bj_ALLIANCE_ALLIED_VISION   = 3
-    // 联盟设置 - 结盟单位
+    // 联盟设置 - 相互结盟并共享视野和部分单位
     constant integer   bj_ALLIANCE_ALLIED_UNITS    = 4
-    // 联盟设置 - 高级单位
+    // 联盟设置 - 相互结盟并共享视野和所有单位
     constant integer   bj_ALLIANCE_ALLIED_ADVUNITS = 5
-    // 联盟设置 - 中立
+    // 联盟设置 - 相互中立
     constant integer   bj_ALLIANCE_NEUTRAL         = 6
-    // 联盟设置 - 中立视野
+    // 联盟设置 - 相互中立但共享视野
     constant integer   bj_ALLIANCE_NEUTRAL_VISION  = 7
 
     // Keyboard Event Types
@@ -638,11 +660,11 @@ globals
     constant integer   bj_UNIT_STATE_METHOD_MAXIMUM  = 3
 
     // Gate operations
-    // （操作可破坏物）门 - 关闭
+    // 操作可破坏物 - 关闭门
     constant integer   bj_GATEOPERATION_CLOSE      = 0
-    // （操作可破坏物）门 - 开启
+    // 操作可破坏物 - 开启门
     constant integer   bj_GATEOPERATION_OPEN       = 1
-    // （操作可破坏物）门 - 摧毁
+    // 操作可破坏物 - 摧毁门
     constant integer   bj_GATEOPERATION_DESTROY    = 2
 
 	// Game cache value types
@@ -730,15 +752,26 @@ globals
     constant integer   bj_CORPSETYPE_BONE          = 1
 
     // Elevator pathing-blocker destructable code
+    // 升降机路径阻断器 物编代码 'DTep'
+    // 可在物编的 可破坏物 分类下找到
     constant integer   bj_ELEVATOR_BLOCKER_CODE    = 'DTep'
+    // 升降机1 物编代码 'DTrf'
+    // 可在物编的 可破坏物 分类下找到
     constant integer   bj_ELEVATOR_CODE01          = 'DTrf'
+    // 升降机2 物编代码 'DTrx'
+    // 可在物编的 可破坏物 分类下找到
     constant integer   bj_ELEVATOR_CODE02          = 'DTrx'
 
     // Elevator wall codes
+    // 升降机墙壁 所有墙
     constant integer   bj_ELEVATOR_WALL_TYPE_ALL        = 0
+    // 升降机墙壁 东墙
     constant integer   bj_ELEVATOR_WALL_TYPE_EAST       = 1
+    // 升降机墙壁 北墙
     constant integer   bj_ELEVATOR_WALL_TYPE_NORTH      = 2
+    // 升降机墙壁 南墙
     constant integer   bj_ELEVATOR_WALL_TYPE_SOUTH      = 3
+    // 升降机墙壁 西墙
     constant integer   bj_ELEVATOR_WALL_TYPE_WEST       = 4
 
     //-----------------------------------------------------------------------
@@ -750,7 +783,8 @@ globals
     force              bj_FORCE_ALL_PLAYERS        = null
     // 玩家组
     force array        bj_FORCE_PLAYER
-    // 英雄初始物品要给予的次数，游戏初始化时会根据游戏版本自动设置
+    // 给予首发英雄初始物品的数量
+    // 游戏初始化时会根据游戏版本自动设置
     integer            bj_MELEE_MAX_TWINKED_HEROES = 0
 
     // Map area rects
@@ -778,10 +812,13 @@ globals
     // Game started detection vars
     // 开局计时器
     timer              bj_gameStartedTimer         = null
+    // 游戏是否已经开始
     boolean            bj_gameStarted              = false
+    // 开局音量控制计时器
     timer              bj_volumeGroupsTimer        = CreateTimer()
 
     // Singleplayer check
+    // 是否单机（只有一位人类玩家），默认为假
     boolean            bj_isSinglePlayer           = false
 
     // Day/Night Cycle vars
@@ -798,7 +835,7 @@ globals
 
     // Triggered sounds
     //sound              bj_pingMinimapSound         = null
-    // 音效 救援音效
+    // 音效 可营救音效
     sound              bj_rescueSound              = null
     // 音效 发现任务音效
     sound              bj_questDiscoveredSound     = null
@@ -841,27 +878,53 @@ globals
     itemtype           bj_stockPickedItemType
 
     // Melee vars
+    // 可见性触发器
     trigger            bj_meleeVisibilityTrained   = null
+    // 可见性
     boolean            bj_meleeVisibilityIsDay     = true
+    // 是否给予首发英雄初始物品
     boolean            bj_meleeGrantHeroItems      = false
+    // 距离玩家开始点最近的金矿所在的点
     location           bj_meleeNearestMineToLoc    = null
+    // 距离玩家开始点最近的金矿
     unit               bj_meleeNearestMine         = null
+    // 距离玩家开始点最近的金矿的距离，默认值0.00
     real               bj_meleeNearestMineDist     = 0.00
+    // 游戏是否结束
     boolean            bj_meleeGameOver            = false
+    // 游戏失败判断布尔值数组，每位玩家配一个
     boolean array      bj_meleeDefeated
+    // 游戏胜利判断布尔值数组，每位玩家配一个
     boolean array      bj_meleeVictoried
     unit array         bj_ghoul
+    // 玩家即将暴露计时器
+    // 失去所有基地时，系统会提示要在限定内造一个基地，否则会暴露，这就是计时器
     timer array        bj_crippledTimer
+    // 玩家即将暴露计时器计时窗口
+    // 失去所有基地时，系统会提示要在限定内造一个基地，否则会暴露，这就是计时窗口
     timerdialog array  bj_crippledTimerWindows
+    // 玩家即将暴露判断布尔值数组，每位玩家配一个
+    // 失去所有基地时，系统会提示要在限定内造一个基地，失去所有基地会变为真
     boolean array      bj_playerIsCrippled
+    // 玩家暴露判断布尔值数组，每位玩家配一个
+    // 失去所有基地时，系统会提示要在限定内造一个基地，如果计时完成没有造，变为真
     boolean array      bj_playerIsExposed
+    // 玩家暴露计时器
+    // 失去所有基地时，系统会提示要在限定内造一个基地，如果没造，这就是暴露时间的计时器
     boolean            bj_finishSoonAllExposed     = false
+    // 玩家即将暴露计时器计时窗口
+    // 失去所有基地时，系统会提示要在限定内造一个基地，如果没造，这就是暴露时间的计时窗口
     timerdialog        bj_finishSoonTimerDialog    = null
+    // 首发英雄初始物品创建数量数组，每位玩家配一个
+    // 用于记录已经给首发创建了多少个初始物品
     integer array      bj_meleeTwinkedHeroes
 
     // Rescue behavior vars
+    // 营救触发器
     trigger            bj_rescueUnitBehavior       = null
+    // 是否允许可营救单位的颜色在被救援后改变
     boolean            bj_rescueChangeColorUnit    = true
+    // 是否允许可营救建筑的颜色在被救援后改变
     boolean            bj_rescueChangeColorBldg    = true
 
     // Transmission vars
@@ -905,11 +968,17 @@ globals
     // Helper vars (for Filter and Enum funcs)
     integer            bj_destInRegionDiesCount    = 0
     trigger            bj_destInRegionDiesTrig     = null
+    // 单位组内单位数量
     integer            bj_groupCountUnits          = 0
+    // 玩家组内的玩家数量
     integer            bj_forceCountPlayers        = 0
+    // 执行单位组动作时，选取的单位类型
     integer            bj_groupEnumTypeId          = 0
+    // 执行玩家区域单位组动作是，选取的玩家
     player             bj_groupEnumOwningPlayer    = null
+    // 指代往 A单位组 添加 B单位组 单位完成后，需要摧毁的单位组
     group              bj_groupAddGroupDest        = null
+    // 指代 A单位组 移除 B单位组 单位完成后，需要摧毁的单位组
     group              bj_groupRemoveGroupDest     = null
     integer            bj_groupRandomConsidered    = 0
     unit               bj_groupRandomCurrentPick   = null
@@ -936,13 +1005,16 @@ globals
     boolean            bj_isUnitGroupEmptyResult   = true
     boolean            bj_isUnitGroupInRectResult  = true
     rect               bj_isUnitGroupInRectRect    = null
+    // 游戏结束时是否展示游戏得分
     boolean            bj_changeLevelShowScores    = false
+    // 下一张地图的名字（用于战役）
     string             bj_changeLevelMapName       = null
     group              bj_suspendDecayFleshGroup   = CreateGroup()
     group              bj_suspendDecayBoneGroup    = CreateGroup()
     timer              bj_delayedSuspendDecayTimer = CreateTimer()
     trigger            bj_delayedSuspendDecayTrig  = null
     integer            bj_livingPlayerUnitsTypeId  = 0
+    // 最后死亡的目标
     widget             bj_lastDyingWidget          = null
 
     // Random distribution vars
@@ -1775,7 +1847,7 @@ function GetCurrentCameraSetup takes nothing returns camerasetup
 endfunction
 
 
-// 应用摄像机 (限时)
+// 应用镜头 (限时)
 function CameraSetupApplyForPlayer takes boolean doPan, camerasetup whichSetup, player whichPlayer, real duration returns nothing
     if (GetLocalPlayer() == whichPlayer) then
         // Use only local code (no net traffic) within this block to avoid desyncs.
@@ -1792,13 +1864,13 @@ function CameraSetupApplyForPlayerSmooth takes boolean doPan, camerasetup whichS
 endfunction
 
 
-// 摄像机的数值
+// 镜头的数值
 function CameraSetupGetFieldSwap takes camerafield whichField, camerasetup whichSetup returns real
     return CameraSetupGetField(whichSetup, whichField)
 endfunction
 
 
-// 设定摄像机属性 (限时)
+// 设定镜头属性 (限时)
 function SetCameraFieldForPlayer takes player whichPlayer, camerafield whichField, real value, real duration returns nothing
     if (GetLocalPlayer() == whichPlayer) then
         // Use only local code (no net traffic) within this block to avoid desyncs.
@@ -1807,7 +1879,7 @@ function SetCameraFieldForPlayer takes player whichPlayer, camerafield whichFiel
 endfunction
 
 
-// 锁定摄像机目标到单位
+// 锁定镜头目标到单位
 function SetCameraTargetControllerNoZForPlayer takes player whichPlayer, unit whichUnit, real xoffset, real yoffset, boolean inheritOrientation returns nothing
     if (GetLocalPlayer() == whichPlayer) then
         // Use only local code (no net traffic) within this block to avoid desyncs.
@@ -1834,7 +1906,7 @@ function SetCameraPositionLocForPlayer takes player whichPlayer, location loc re
 endfunction
 
 
-// 旋转摄像机 (限时)
+// 旋转镜头 (限时)
 function RotateCameraAroundLocBJ takes real degrees, location loc, player whichPlayer, real duration returns nothing
     if (GetLocalPlayer() == whichPlayer) then
         // Use only local code (no net traffic) within this block to avoid desyncs.
@@ -1843,7 +1915,7 @@ function RotateCameraAroundLocBJ takes real degrees, location loc, player whichP
 endfunction
 
 
-// 平移摄像机
+// 平移镜头
 function PanCameraToForPlayer takes player whichPlayer, real x, real y returns nothing
     if (GetLocalPlayer() == whichPlayer) then
         // Use only local code (no net traffic) within this block to avoid desyncs.
@@ -1852,7 +1924,7 @@ function PanCameraToForPlayer takes player whichPlayer, real x, real y returns n
 endfunction
 
 
-// 平移摄像机
+// 平移镜头
 function PanCameraToLocForPlayer takes player whichPlayer, location loc returns nothing
     if (GetLocalPlayer() == whichPlayer) then
         // Use only local code (no net traffic) within this block to avoid desyncs.
@@ -1861,7 +1933,7 @@ function PanCameraToLocForPlayer takes player whichPlayer, location loc returns 
 endfunction
 
 
-// 平移摄像机 定时
+// 平移镜头 定时
 function PanCameraToTimedForPlayer takes player whichPlayer, real x, real y, real duration returns nothing
     if (GetLocalPlayer() == whichPlayer) then
         // Use only local code (no net traffic) within this block to avoid desyncs.
@@ -1870,7 +1942,7 @@ function PanCameraToTimedForPlayer takes player whichPlayer, real x, real y, rea
 endfunction
 
 
-// 平移摄像机 (限时)
+// 平移镜头 (限时)
 function PanCameraToTimedLocForPlayer takes player whichPlayer, location loc, real duration returns nothing
     if (GetLocalPlayer() == whichPlayer) then
         // Use only local code (no net traffic) within this block to avoid desyncs.
@@ -1879,7 +1951,7 @@ function PanCameraToTimedLocForPlayer takes player whichPlayer, location loc, re
 endfunction
 
 
-// 在指定高度平移摄像机 (限时)
+// 在指定高度平移镜头 (限时)
 function PanCameraToTimedLocWithZForPlayer takes player whichPlayer, location loc, real zOffset, real duration returns nothing
     if (GetLocalPlayer() == whichPlayer) then
         // Use only local code (no net traffic) within this block to avoid desyncs.
@@ -1888,7 +1960,7 @@ function PanCameraToTimedLocWithZForPlayer takes player whichPlayer, location lo
 endfunction
 
 
-// 必要时平移摄像机 (限时)
+// 必要时平移镜头 (限时)
 function SmartCameraPanBJ takes player whichPlayer, location loc, real duration returns nothing
     local real dist
 	local location cameraLoc = GetCameraTargetPositionLoc()
@@ -1910,7 +1982,7 @@ function SmartCameraPanBJ takes player whichPlayer, location loc, real duration 
 endfunction
 
 
-// 播放动画摄像机
+// 播放动画镜头
 function SetCinematicCameraForPlayer takes player whichPlayer, string cameraModelFile returns nothing
     if (GetLocalPlayer() == whichPlayer) then
         // Use only local code (no net traffic) within this block to avoid desyncs.
@@ -1919,7 +1991,7 @@ function SetCinematicCameraForPlayer takes player whichPlayer, string cameraMode
 endfunction
 
 
-// 重置游戏摄像机
+// 重置游戏镜头
 function ResetToGameCameraForPlayer takes player whichPlayer, real duration returns nothing
     if (GetLocalPlayer() == whichPlayer) then
         // Use only local code (no net traffic) within this block to avoid desyncs.
@@ -1928,7 +2000,7 @@ function ResetToGameCameraForPlayer takes player whichPlayer, real duration retu
 endfunction
 
 
-// 摇摆摄像机来源
+// 摇摆镜头来源
 function CameraSetSourceNoiseForPlayer takes player whichPlayer, real magnitude, real velocity returns nothing
     if (GetLocalPlayer() == whichPlayer) then
         // Use only local code (no net traffic) within this block to avoid desyncs.
@@ -1937,7 +2009,7 @@ function CameraSetSourceNoiseForPlayer takes player whichPlayer, real magnitude,
 endfunction
 
 
-// 摇摆摄像机目标
+// 摇摆镜头目标
 function CameraSetTargetNoiseForPlayer takes player whichPlayer, real magnitude, real velocity returns nothing
     if (GetLocalPlayer() == whichPlayer) then
         // Use only local code (no net traffic) within this block to avoid desyncs.
@@ -1946,7 +2018,7 @@ function CameraSetTargetNoiseForPlayer takes player whichPlayer, real magnitude,
 endfunction
 
 
-// 摇动摄像机
+// 摇动镜头
 function CameraSetEQNoiseForPlayer takes player whichPlayer, real magnitude returns nothing
     local real richter = magnitude
     if (richter > 5.0) then
@@ -1963,7 +2035,7 @@ function CameraSetEQNoiseForPlayer takes player whichPlayer, real magnitude retu
 endfunction
 
 
-// 停止 摇摆/摇动 摄像机
+// 停止 摇摆/摇动 镜头
 function CameraClearNoiseForPlayer takes player whichPlayer returns nothing
     if (GetLocalPlayer() == whichPlayer) then
         // Use only local code (no net traffic) within this block to avoid desyncs.
@@ -2005,7 +2077,7 @@ function GetEntireMapRect takes nothing returns rect
 endfunction
 
 
-// 设置摄像机边界
+// 设置镜头边界
 function SetCameraBoundsToRect takes rect r returns nothing
     local real minX = GetRectMinX(r)
     local real minY = GetRectMinY(r)
@@ -2094,7 +2166,7 @@ function SetCameraQuickPositionLoc takes location loc returns nothing
 endfunction
 
 
-// 停止摄像机
+// 停止镜头
 function StopCameraForPlayerBJ takes player whichPlayer returns nothing
     if (GetLocalPlayer() == whichPlayer) then
         // Use only local code (no net traffic) within this block to avoid desyncs.
@@ -2103,7 +2175,7 @@ function StopCameraForPlayerBJ takes player whichPlayer returns nothing
 endfunction
 
 
-// 锁定摄像机方向到单位
+// 锁定镜头方向到单位
 function SetCameraOrientControllerForPlayerBJ takes player whichPlayer, unit whichUnit, real xoffset, real yoffset returns nothing
     if (GetLocalPlayer() == whichPlayer) then
         // Use only local code (no net traffic) within this block to avoid desyncs.
@@ -2112,13 +2184,13 @@ function SetCameraOrientControllerForPlayerBJ takes player whichPlayer, unit whi
 endfunction
 
 
-// 改变摄像机平滑参数
+// 改变镜头平滑参数
 function CameraSetSmoothingFactorBJ takes real factor returns nothing
     call CameraSetSmoothingFactor(factor)
 endfunction
 
 
-// 重置摄像机平滑参数
+// 重置镜头平滑参数
 function CameraResetSmoothingFactorBJ takes nothing returns nothing
     call CameraSetSmoothingFactor(0)
 endfunction
@@ -3170,7 +3242,7 @@ function SetCineModeVolumeGroupsImmediateBJ takes nothing returns nothing
 endfunction
 
 
-// 将所有音量设置为动画
+// 设置多通道音量为电影模式
 function SetCineModeVolumeGroupsBJ takes nothing returns nothing
     // Delay the request if it occurs at map init.
     if bj_gameStarted then
@@ -3181,7 +3253,7 @@ function SetCineModeVolumeGroupsBJ takes nothing returns nothing
 endfunction
 
 
-// 设置语音多通道音量环境(立即)
+// 设置语音多通道音量环境为默认值(立即)
 function SetSpeechVolumeGroupsImmediateBJ takes nothing returns nothing
     call VolumeGroupSetVolume(SOUND_VOLUMEGROUP_UNITMOVEMENT,  bj_SPEECH_VOLUME_UNITMOVEMENT)
     call VolumeGroupSetVolume(SOUND_VOLUMEGROUP_UNITSOUNDS,    bj_SPEECH_VOLUME_UNITSOUNDS)
@@ -3194,7 +3266,7 @@ function SetSpeechVolumeGroupsImmediateBJ takes nothing returns nothing
 endfunction
 
 
-// 将所有音量设置为说话
+// 设置多通道音量为语音模式
 function SetSpeechVolumeGroupsBJ takes nothing returns nothing
     // Delay the request if it occurs at map init.
     if bj_gameStarted then
@@ -3211,7 +3283,7 @@ function VolumeGroupResetImmediateBJ takes nothing returns nothing
 endfunction
 
 
-// 重置所有音量
+// 重置所有通道音量为预设值
 function VolumeGroupResetBJ takes nothing returns nothing
     // Delay the request if it occurs at map init.
     if bj_gameStarted then
@@ -7825,6 +7897,7 @@ endfunction
 //   - Reset the camera smoothing factor
 //
 // 切换影片模式(时间)
+// @param interfaceFadeTime淡出时间
 function CinematicModeExBJ takes boolean cineMode, force forForce, real interfaceFadeTime returns nothing
     // If the game hasn't started yet, perform interface fades immediately
     if (not bj_gameStarted) then
@@ -8028,7 +8101,7 @@ endfunction
 // including a rescue sound, flashing selection circle, ownership change,
 // and optionally a unit color change.
 //
-// 营救单位
+// 可营救单位
 function RescueUnitBJ takes unit whichUnit, player rescuer, boolean changeColor returns nothing
     if IsUnitDeadBJ(whichUnit) or (GetOwningPlayer(whichUnit) == rescuer) then
         return
@@ -8055,7 +8128,7 @@ endfunction
 // Attempt to init triggers for default rescue behavior.  For performance
 // reasons, this should only be attempted if a player is set to Rescuable,
 // or if a specific unit is thus flagged.
-//
+// 初始化营救触发
 function TryInitRescuableTriggersBJ takes nothing returns nothing
     local integer index
 
@@ -8075,7 +8148,7 @@ endfunction
 // Determines whether or not rescued units automatically change color upon
 // being rescued.
 //
-// 安排营救单位行为
+// 设置可营救单位的颜色
 function SetRescueUnitColorChangeBJ takes boolean changeColor returns nothing
     set bj_rescueChangeColorUnit = changeColor
 endfunction
@@ -8084,19 +8157,19 @@ endfunction
 // Determines whether or not rescued buildings automatically change color
 // upon being rescued.
 //
-// 设置营救颜色(建筑)
+// 设置可营救建筑的颜色
 function SetRescueBuildingColorChangeBJ takes boolean changeColor returns nothing
     set bj_rescueChangeColorBldg = changeColor
 endfunction
 
 
-// 安排营救单位
+// 执行创建可营救单位
 function MakeUnitRescuableToForceBJEnum takes nothing returns nothing
     call TryInitRescuableTriggersBJ()
     call SetUnitRescuable(bj_makeUnitRescuableUnit, GetEnumPlayer(), bj_makeUnitRescuableFlag)
 endfunction
 
-
+// 创建可营救单位
 function MakeUnitRescuableToForceBJ takes unit whichUnit, boolean isRescuable, force whichForce returns nothing
     // Flag the unit as rescuable/unrescuable for the appropriate players.
     set bj_makeUnitRescuableUnit = whichUnit
@@ -8104,7 +8177,7 @@ function MakeUnitRescuableToForceBJ takes unit whichUnit, boolean isRescuable, f
     call ForForce(whichForce, function MakeUnitRescuableToForceBJEnum)
 endfunction
 
-
+// 初始化可营救触发
 function InitRescuableBehaviorBJ takes nothing returns nothing
     local integer index
 
@@ -9203,7 +9276,7 @@ function GetLastHauntedGoldMine takes nothing returns unit
 endfunction
 
 
-// 点是不死族的地表
+// 指定点是否被荒芜地表（不死族）覆盖
 function IsPointBlightedBJ takes location where returns boolean
     return IsPointBlighted(GetLocationX(where), GetLocationY(where))
 endfunction
@@ -9344,13 +9417,13 @@ function SaveDyingWidget takes nothing returns nothing
 endfunction
 
 
-// 创造/删除 不死族地表在区域
+// 创造/删除 荒芜地表（不死族）在指定方形区域
 function SetBlightRectBJ takes boolean addBlight, player whichPlayer, rect r returns nothing
     call SetBlightRect(whichPlayer, r, addBlight)
 endfunction
 
 
-// 创造/删除 不死族地表在圆周
+// 创造/删除 荒芜地表（不死族）在指定圆形区域
 function SetBlightRadiusLocBJ takes boolean addBlight, player whichPlayer, location loc, real radius returns nothing
     call SetBlightLoc(whichPlayer, loc, radius, addBlight)
 endfunction
@@ -9498,7 +9571,7 @@ endfunction
 // The first N heroes trained or hired for each player start off with a
 // standard set of items.  This is currently:
 //   - 1x Scroll of Town Portal
-//
+// 给首发英雄创建初始物品
 function MeleeGrantItemsToHero takes unit whichUnit returns nothing
     local integer owner   = GetPlayerId(GetOwningPlayer(whichUnit))
 
@@ -9520,7 +9593,7 @@ function MeleeGrantItemsToHiredHero takes nothing returns nothing
 endfunction
 
 
-// 英雄初始物品
+// 给予首发英雄初始物品
 function MeleeGrantHeroItems takes nothing returns nothing
     local integer index
     local trigger trig
@@ -9659,7 +9732,7 @@ function MeleeFindNearestMine takes location src, real range returns unit
     return bj_meleeNearestMine
 endfunction
 
-
+// 创建随机英雄（进入游戏前在高级勾选 使用随机英雄）
 function MeleeRandomHeroLoc takes player p, integer id1, integer id2, integer id3, integer id4, location loc returns unit
     local unit    hero = null
     local integer roll
@@ -10517,7 +10590,8 @@ endfunction
 
 
 // Returns a race-specific "build X" label for cripple timers.
-//
+// 建造默认提示文本
+// 失去全部基地时，系统会提示要在限定时间建造一个一本基地，否则将会暴露，这里控制具体的提示文本
 function MeleeGetCrippledTimerMessage takes player whichPlayer returns string
     local race r = GetPlayerRace(whichPlayer)
 
@@ -11377,7 +11451,7 @@ function InitBlizzardGlobals takes nothing returns nothing
     endif
 endfunction
 
-
+// 初始化触发器队列
 function InitQueuedTriggers takes nothing returns nothing
     set bj_queuedExecTimeout = CreateTrigger()
     call TriggerRegisterTimerExpireEvent(bj_queuedExecTimeout, bj_queuedExecTimeoutTimer)
@@ -11390,7 +11464,8 @@ function InitMapRects takes nothing returns nothing
     set bj_mapInitialCameraBounds = GetCurrentCameraBoundsMapRectBJ()
 endfunction
 
-
+// 初始化单位升级类科技等级上限（升级后会改变训练/召唤的单位类型的科技）
+// 默认针对：坦克的火箭弹幕、狂战士升级、骷髅战士
 function InitSummonableCaps takes nothing returns nothing
     local integer index
 

--- a/static/common.ai
+++ b/static/common.ai
@@ -156,11 +156,11 @@ native DebugS               takes string str                            returns 
     native AttackMoveKill       takes unit target                           returns nothing
     // 让攻击指组攻击指定坐标
     native AttackMoveXY         takes integer x, integer y                  returns nothing
-    // 在指定坐标卸载单位，该命令似乎只对卸载（地精飞艇）技能生效，且AI无需任何辅助代码就能自己控制好飞艇的装卸（运输船则不行），建议勿对飞艇类单位发送忽略防守指令，忽略后AI不会自动控制飞艇卸载
+    // 在指定坐标卸载单位，该命令似乎只对卸载（地精飞艇）技能生效，且AI无需任何辅助代码就能自己控制好飞艇的装卸（运输船不行），建议不要对飞艇类单位发送忽略防守指令，忽略后AI不会自动控制飞艇卸载
     native LoadZepWave          takes integer x, integer y                  returns nothing
-    // 检测自杀攻击是否满足指定条件（指定玩家），自杀指令被暴雪用于战役AI
+    // 检测自杀式攻击是否满足指定条件（指定玩家），该指令被暴雪用于战役AI
     native SuicidePlayer        takes player id, boolean check_full         returns boolean
-    // 检测自杀攻击组是否满足指定条件（指定玩家），自杀指令被暴雪用于战役AI
+    // 检测自杀式攻击组是否满足指定条件（指定玩家），该指令被暴雪用于战役AI
     native SuicidePlayerUnits   takes player id, boolean check_full         returns boolean
     // 攻击组是否在战斗
     native CaptainInCombat      takes boolean attack_captain                returns boolean
@@ -222,13 +222,13 @@ native DebugS               takes string str                            returns 
     native CaptainAtGoal        takes nothing                               returns boolean
     // 地图上是否还有中立敌对玩家的单位，即野怪，在1.29及以上版本中，中立敌对玩家为玩家24，在以下版本则为12
     native CreepsOnMap          takes nothing                               returns boolean
-    // 在攻击组添加自杀单位，指定单位类型和数量，自杀指令被暴雪用于战役AI
+    // 在攻击组添加自杀单位，指定单位类型和数量，该指令被暴雪用于战役AI
     native SuicideUnit          takes integer count, integer unitid         returns nothing
-    // 在攻击组添加自杀单位，指定单位类型、数量和玩家，自杀指令被暴雪用于战役AI
+    // 在攻击组添加自杀单位，指定单位类型、数量和玩家，该指令被暴雪用于战役AI
     native SuicideUnitEx        takes integer ct, integer uid, integer pid  returns nothing
-    // 开始进程，AI脚本最多可运行6条进程，最多可有6条进程同时运行（包含默认线程，自行添加之前请检查已调用的默认线程数量），不同进程之间互不干涉（异步），可共用全局变量，但在一条进程运行到读取变量的代码时，可能因变量已在几十秒前被另一个变量改写，造成滞后的假象
+    // 开始进程，AI脚本最多可运行6条进程，最多可有6条进程同时运行（包含默认线程，自行添加之前请检查已调用的默认线程数量），不同进程之间互不干涉（异步，即使一条线程在等待，也不影响其他线程），可共用全局变量，但在一条进程运行到读取变量的代码时，可能因变量已在几十秒前被另一个变量改写，造成滞后的假象
     native StartThread          takes code func                             returns nothing
-    // 等待指定时间，按秒计时（休眠，不执行任何指令）
+    // 等待指定时间，按秒计时（期间不执行任何指令）
     native Sleep                takes real seconds                          returns nothing
     // 单位是否存活
     native UnitAlive            takes unit id                               returns boolean
@@ -1173,7 +1173,7 @@ native DebugS               takes string str                            returns 
         //--------------------------------------------------------------------
         // 当前AI玩家
         player  ai_player
-        // 休眠/等待时间
+        // 等待时间
         integer sleep_seconds
         integer total_gold              = 0
         integer total_wood              = 0
@@ -1197,22 +1197,25 @@ native DebugS               takes string str                            returns 
         integer array skills2
         // 三发英雄技能数组
         integer array skills3
-        // 最大英雄等级，默认为0
+        // 最大英雄等级，默认为0，会在英雄升级后自动调整，上限由平衡常数决定
         integer max_hero_level          = 0
     
         integer array harass_qty
         integer array harass_max
         integer array harass_units
+        // 攻击组数列，当前已记录到攻击组的单位类型，在下次初始化前，AI会使用这些单位类型进行攻击
         integer harass_length           = 0
     
         integer array defense_qty
         integer array defense_units
+        // 防御组数列，当前已记录到防御组的单位类型，在下次初始化前，AI会使用这些单位类型进行防御
         integer defense_length          = 0
     
         integer array build_qty
         integer array build_type
         integer array build_item
         integer array build_town
+        // 建造组数列，当前已记录到建造队列的单位/建筑/科技类型，在下次初始化前，AI会依次训练/建造/研究
         integer build_length            = 0
         // 战役采金工人数量，默认5
         integer campaign_gold_peons     = 5
@@ -1224,9 +1227,11 @@ native DebugS               takes string str                            returns 
         integer min_creeps              = -1
         // （中立敌对玩家）最大野怪等级，默认-1
         integer max_creeps              = -1
-    
+        // 是否允许AI在第一座基地采集黄金/木材
         boolean harvest_town1           = true
+        // 是否允许AI在第二座基地采集黄金/木材
         boolean harvest_town2           = true
+        // 是否允许AI在第三座基地采集黄金/木材
         boolean harvest_town3           = true
         // 战役人口模式
         boolean do_campaign_farms       = true
@@ -1236,6 +1241,7 @@ native DebugS               takes string str                            returns 
         boolean allow_air_creeps        = false
         // 是否开分矿
         boolean take_exp                = false
+        // 多用于退出自杀等待
         boolean allow_signal_abort      = false
         // 是否完成飞艇购买
         boolean ready_for_zeppelin      = true
@@ -1245,9 +1251,11 @@ native DebugS               takes string str                            returns 
         boolean build_campaign_attackers = true
     
         boolean do_debug_cheats         = false
+        // 是否在游戏中显示 Trace 文本（开启后可用于调试，只需要调用对应的 Trace 发送指定文本即可）
         boolean trace_on                = true
         // 是否需要飞艇空投
         boolean zep_next_wave           = false
+        // 是否允许 进攻组组建超时
         boolean form_group_timeouts     = true
     endglobals
     
@@ -1290,7 +1298,7 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //============================================================================
-    // 初始化AI玩家
+    // 初始化AI玩家和等待时间（sleep_seconds）
     function InitAI takes nothing returns nothing
         set ai_player = Player(GetAiPlayer())
         set sleep_seconds = 0
@@ -1298,7 +1306,7 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //============================================================================
-    // 标准AI初始化程序，运行后AI将开始工作，可指定3条线程并使其开始运行
+    // 标准AI初始化程序，运行后AI将已对战模式开始工作，可指定3条线程并使其开始运行，heroes默认用于英雄学习技能，peons和attacks可自定义
     function StandardAI takes code heroes, code peons, code attacks returns nothing
     
         local boolean isNewbie = (MeleeDifficulty() == MELEE_NEWBIE)
@@ -1351,7 +1359,7 @@ native DebugS               takes string str                            returns 
     function SetZepNextWave takes nothing returns nothing
         set zep_next_wave = true
     endfunction
-    // 自杀休眠倒计时，当指定的时间小于等于0时 及 触发器有命令传入时会退出休眠
+    // 自杀倒计时（等待），当指定的时间小于等于0时 及 触发器有命令传入时会结束等待
     function SuicideSleep takes integer seconds returns nothing
         set sleep_seconds = sleep_seconds - seconds
         loop
@@ -1426,7 +1434,7 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //============================================================================
-    // 启用/禁用 组超时设置
+    // 启用/禁用 进攻组组建超时设置
     function SetFormGroupTimeouts takes boolean state returns nothing
         set form_group_timeouts = state
     endfunction
@@ -1488,7 +1496,7 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //============================================================================
-    // 准备自杀（包含初始化攻击组数组、初始化防御组数组、采集（金和木）工人指令4条命令）
+    // 准备自杀（包含初始化攻击组数组、初始化防御组数组、采集（金和木）工人置零4条命令）
     function PrepFullSuicide takes nothing returns nothing
         call InitAssaultGroup()
         call InitDefenseGroup()
@@ -1515,7 +1523,7 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //============================================================================
-    // 设置建造序列，每个建造/训练命令都会被统一引导到此写入建造先后的排序，等待系统循环检索建造/训练，当 build_length 重置时，系统循环重置
+    // 设置建造序列，每个建造/训练命令都会被统一引导到此写入建造先后的排序，等 建造线程 建造/训练/研究，当 build_length 重置时，之前的建造/训练/研究队列清空
     function SetBuildAll takes integer t, integer qty, integer unitid, integer town returns nothing
         if qty > 0 then
             set build_qty[build_length] = qty
@@ -1771,7 +1779,7 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //============================================================================
-    // 等待指定的单位类型（不包含建造/训练中）数量达到指定数量，达到之前保持休眠
+    // 等待指定的单位类型（不包含建造/训练中）数量达到指定数量，达到之前一直循环等待
     function WaitForUnits takes integer unitid, integer qty returns nothing
         loop
             exitwhen TownCountDone(unitid) == qty
@@ -1858,7 +1866,7 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //============================================================================
-    // 等待指定的单位类型（包含建造/训练中）数量大于或等于指定数量，达到之前保持休眠，若休眠120秒后仍未达到，自动退出休眠
+    // 等待指定的单位类型（包含建造/训练中）数量大于或等于指定数量，满足条件前循环等待，若120秒后仍未满足，自动退出
     function WaitForTown takes integer towns, integer townid returns nothing
         local integer i = 0
         loop
@@ -1947,7 +1955,7 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //============================================================================
-    // 错开休眠，休眠 (base + spread * I2R(GetAiPlayer()) / I2R(GetPlayers())) 秒
+    // 错位等待，时间为 (base + spread * I2R(GetAiPlayer()) / I2R(GetPlayers())) 秒
     function StaggerSleep takes real base, real spread returns nothing
         call Sleep(base + spread * I2R(GetAiPlayer()) / I2R(GetPlayers()))
     endfunction
@@ -1964,7 +1972,7 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //============================================================================
-    // 建造线程（建造/训练/升级 分矿、单位和科技）
+    // 开始运行建造线程（建造/训练/升级 分矿、单位和科技）
     function StartBuildLoop takes nothing returns nothing
         call StartThread(function BuildLoop)
     endfunction
@@ -1976,13 +1984,13 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //============================================================================
-    // 在原基础上增加初始波次的休眠时间
+    // 在原基础上增加初始波次的等待时间
     function AddSleepSeconds takes integer seconds returns nothing
         set sleep_seconds = sleep_seconds + seconds
     endfunction
     
     //============================================================================
-    // 永久休眠，使用后不会退出
+    // 永久等待（使用后不会退出，无法执行下一步命令）
     function SleepForever takes nothing returns nothing
         call Trace("going to sleep forever\n") //xxx
         loop
@@ -2039,7 +2047,7 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //============================================================================
-    // 循环交错设置进攻组，会设置各难度AI，e用于简单，m用于中等，h用于困难，1~3分别代表具体的数量（即每个难度都可设置3个档位），u1~u3为单位类型（即每个难度都可设置3种单位类型）
+    // 循环交错设置进攻组，会设置3种难度AI，e用于简单，m用于中等，h用于困难，1~3分别代表具体的数量（即每个难度都可设置3个档位），u1~u3为单位类型（即每个难度都可设置3种单位类型）
     function Interleave3 takes integer e1, integer m1, integer h1, integer u1, integer e2, integer m2, integer h2, integer u2, integer e3, integer m3, integer h3, integer u3 returns nothing
         local integer i1 = 1
         local integer i2 = 1
@@ -2108,7 +2116,7 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //============================================================================
-    // 将指定类型的单位添加到防御组（指定各难度AI的添加数量），默认用于战役
+    // 将指定类型的单位添加到防御组（指定3种难度AI的添加数量），默认用于战役
     function CampaignDefenderEx takes integer easy, integer med, integer hard, integer unitid returns nothing
         if difficulty == EASY then
             call CampaignDefender(EASY,easy,unitid)
@@ -2128,7 +2136,7 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //============================================================================
-    // 将指定类型的单位添加到攻击组（指定各难度AI的添加数量），默认用于战役
+    // 将指定类型的单位添加到攻击组（指定3种难度AI的添加数量），默认用于战役
     function CampaignAttackerEx takes integer easy, integer med, integer hard, integer unitid returns nothing
         if difficulty == EASY then
             call CampaignAttacker(EASY,easy,unitid)
@@ -2140,7 +2148,7 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //============================================================================
-    // 等待攻击组完成组建，用于等待攻击组补充单位（用testReady指定组的准备情况，为真时需要攻击组准备满50，为假时准备0即可，seconds为最长等待时间）
+    // 等待攻击组完成组建，给予AI一定的时间补充兵力（用testReady指定组的准备情况，为真时需要攻击组准备满50，为假时准备0即可，seconds为最长等待时间）
     function FormGroup takes integer seconds, boolean testReady returns nothing
         local integer index
         local integer count
@@ -2206,13 +2214,13 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //============================================================================
-    // 获取指定单位/科技类型的建造/训练/研究时间，该时间默认用于备战（等待该时间已补充兵力）
+    // 获取指定单位/科技类型的建造/训练/研究时间，用于备战（补充兵力）
     function WavePrepare takes integer unitid returns integer
         return GetUnitBuildTime(unitid)
     endfunction
     
     //============================================================================
-    // 获取等待所需时间
+    // 获取当前累计的等待时间（WavePrepare的累计时间），无等待时返回默认值--30秒
     function PrepTime takes nothing returns integer
         local integer unitid
         local integer missing
@@ -2240,7 +2248,7 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //============================================================================
-    // 休眠指定时间（seconds），并在休眠后判断攻击组准备是否完成
+    // 等待指定时间（seconds），并在等待结束后判断攻击组准备是否完成
     function PrepSuicideOnPlayer takes integer seconds returns boolean
         local integer wave_prep   = PrepTime()
         local integer save_length
@@ -2266,7 +2274,7 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //============================================================================
-    // 进军休眠，攻击组撤退、攻击组到达目的地、攻击组回到家、攻击组为空 任意事件返回 是 时，退出休眠
+    // 进军等待，攻击组撤退、攻击组到达目的地、攻击组回到家、攻击组为空 任意事件返回 是 时，结束等待
     function SleepUntilAtGoal takes nothing returns nothing
         loop
             exitwhen CaptainRetreating()
@@ -2278,7 +2286,7 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //============================================================================
-    // 战斗休眠，攻击组脱离战斗 或 攻击组为空 时，退出内层休眠，当内层循环退出8次时，退出外层循环，两层循环都退出时，结束休眠
+    // 战斗等待，攻击组脱离战斗 或 攻击组为空 时，退出内层循环，当内层循环退出8次时，退出外层循环，两层循环都退出时，结束等待
     function SleepInCombat takes nothing returns nothing
         local integer count = 0
         debug call Trace("SleepInCombat\n")
@@ -2365,7 +2373,7 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //--------------------------------------------------------------------------------------------------
-    // 设置各波次进攻，默认用于自杀（战役），启用standard时判断退出条件
+    // 设置各波次进攻，默认用于自杀式攻击，启用standard时判断退出条件
     function CommonSuicideOnPlayer takes boolean standard, boolean bldgs, integer seconds, player p, integer x, integer y returns nothing
         local integer save_peons
     
@@ -2414,19 +2422,19 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //--------------------------------------------------------------------------------------------------
-    // 自杀进攻（指定玩家）
+    // 自杀式攻击（指定玩家）
     function SuicideOnPlayer takes integer seconds, player p returns nothing
         call CommonSuicideOnPlayer(true,true,seconds,p,0,0)
     endfunction
     
     //--------------------------------------------------------------------------------------------------
-    // 自杀进攻（指定玩家）
+    // 自杀式攻击（指定玩家）
     function SuicideOnUnits takes integer seconds, player p returns nothing
         call CommonSuicideOnPlayer(true,false,seconds,p,0,0)
     endfunction
     
     //--------------------------------------------------------------------------------------------------
-    // 自杀进攻（指定坐标）
+    // 自杀式攻击（指定坐标）
     function SuicideOnPoint takes integer seconds, player p, integer x, integer y returns nothing
         call CommonSuicideOnPlayer(false,false,seconds,p,x,y)
     endfunction
@@ -2467,7 +2475,7 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //--------------------------------------------------------------------------------------------------
-    // 添加自杀单位类型到攻击组，指定各种AI难度的数量
+    // 添加自杀单位类型到攻击组，指定3种AI难度的数量
     function SuicideOnce takes integer easy, integer med, integer hard, integer unitid returns nothing
         if difficulty == EASY then
             call SuicideUnit(easy,unitid)
@@ -2517,7 +2525,7 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //--------------------------------------------------------------------------------------------------
-    // 循环添加自杀单位到单位组（指定玩家，指定单位类型，u1~uA），该循环不会退出
+    // 循环添加自杀单位类型到单位组（指定玩家，指定单位类型：u1~uA），该循环不会退出
     function SuicideUnitsEx takes integer playerid, integer u1, integer u2, integer u3, integer u4, integer u5, integer u6, integer u7, integer u8, integer u9, integer uA returns nothing
         call Trace("MASS SUICIDE - this script is now technically done\n") //xxx
     
@@ -2537,7 +2545,7 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //--------------------------------------------------------------------------------------------------
-    // 自杀进攻（指定玩家），指定各难度的等待时间
+    // 自杀式攻击（指定玩家），指定3种难度的等待时间
     function SuicideOnPlayerEx takes integer easy, integer med, integer hard, player p returns nothing
         if difficulty == EASY then
             call SuicideOnPlayer(easy,p)
@@ -2549,7 +2557,7 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //--------------------------------------------------------------------------------------------------
-    // 自杀进攻（指定玩家），指定各难度的等待时间
+    // 自杀式攻击（指定玩家），指定3种难度的等待时间
     function SuicideOnUnitsEx takes integer easy, integer med, integer hard, player p returns nothing
         if difficulty == EASY then
             call SuicideOnUnits(easy,p)
@@ -2561,7 +2569,7 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //--------------------------------------------------------------------------------------------------
-    // 自杀进攻（指定坐标），指定各难度的等待时间
+    // 自杀式攻击（指定坐标），指定3种难度的等待时间
     function SuicideOnPointEx takes integer easy, integer med, integer hard, player p, integer x, integer y returns nothing
         if difficulty == EASY then
             call SuicideOnPoint(easy,p,x,y)
@@ -2573,7 +2581,7 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //============================================================================
-    // 持续自杀进攻（指定玩家）
+    // 持续自杀式攻击（指定玩家）
     function ForeverSuicideOnPlayer takes integer seconds, player p returns nothing
         local integer length = harass_length
         loop
@@ -3019,7 +3027,7 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //============================================================================
-    // 运行战役AI，运行后启用战役基础线程
+    // 运行战役AI，运行后开始运行战役基础线程
     function CampaignAI takes integer farms, code heroes returns nothing
         if GetGameDifficulty() == MAP_DIFFICULTY_EASY then
             set difficulty = EASY
@@ -3135,7 +3143,7 @@ native DebugS               takes string str                            returns 
     //============================================================================
     //  AwaitMeleeHeroes
     //============================================================================
-    // 等待二发英雄，当首发英雄完成训练/复活，且 【take_exp为真 或 二发英雄存在且完成训练/复活时】 退出休眠，否则一直休眠
+    // 等待二发英雄，当首发英雄完成训练/复活，且 【take_exp为真 或 二发英雄存在且完成训练/复活时】 结束等待，否则循环等待
     function AwaitMeleeHeroes takes nothing returns nothing
         if GetUnitCountDone(hero_id2) > 0 then
             set two_heroes = true

--- a/static/common.ai
+++ b/static/common.ai
@@ -1338,7 +1338,7 @@ native DebugS               takes string str                            returns 
     //============================================================================
     //  Utility Functions
     //============================================================================
-    // 获取最小值
+    // 对比整数，取最小值
     function Min takes integer A, integer B returns integer
         if A < B then
             return A
@@ -1346,7 +1346,7 @@ native DebugS               takes string str                            returns 
             return B
         endif
     endfunction
-    // 获取最大值
+    // 对比整数，取最大值
     function Max takes integer A, integer B returns integer
         if A > B then
             return A

--- a/static/common.ai
+++ b/static/common.ai
@@ -25,60 +25,67 @@ native DebugS               takes string str                            returns 
     // 英雄升级技能相关函数 获取英雄等级
     native GetHeroLevelAI       takes nothing                               returns integer
     
-    // 获取AI玩家指定类型单位的数量/科技的等级，含训练/建造/研究中及已训练/建造/研究完成
+    // 获取AI玩家指定的单位类型数量/科技等级，含训练/建造/研究中及已训练/建造/研究完成
     native GetUnitCount         takes integer unitid                        returns integer
-    // 获取指定玩家的该类型单位的数量/科技的等级，含训练/建造/研究中及已训练/建造/研究完成
+    // 获取指定玩家指定的单位类型数量/科技等级，含训练/建造/研究中及已训练/建造/研究完成
     native GetPlayerUnitTypeCount takes player p, integer unitid            returns integer
-    // 获取AI玩家指定类型单位的数量/科技的等级，仅统计已训练/建造/研究完成
+    // 获取AI玩家指定的单位类型数量/科技等级，仅统计已训练/建造/研究完成
     native GetUnitCountDone     takes integer unitid                        returns integer
-    // 指定基地对应类型的单位数，0为第一个基地
+    // 获取指定基地对应类型的单位数
+    // @param tn基地编号，-1为不限
+    // @param dn是否包含训练/建造/研究中的单位/建筑/科技
     native GetTownUnitCount     takes integer id, integer tn, boolean dn    returns integer
-    // 训练/建造/研究指定/研究一个指定类型单位/科技需要消耗的金钱数量
+    // 获取指定单位/建筑/科技类型的单位造价（金钱）
     native GetUnitGoldCost      takes integer unitid                        returns integer
-    // 训练/建造/研究指定/研究一个指定类型单位/科技需要消耗的木材数量
+    // 获取指定单位/建筑/科技类型的单位造价（木材）
     native GetUnitWoodCost      takes integer unitid                        returns integer
-    // 获取指定单位/科技类型的训练/建造/研究时间
+    // 获取指定单位/建筑/科技类型的训练/建造/研究时间
     native GetUnitBuildTime     takes integer unitid                        returns integer
     
-    // 拥有的金矿数，对于亡灵，该函数会检查开始点所有矿，而不是只查闹鬼金矿
+    // 拥有的金矿数，会检查开始点附近所有矿，而不是只查闹鬼金矿
     // 如果AI开始点有多个未被其他玩家占据的矿，可能会导致亡灵无法正常采矿，因为HarvestGold（0，n）指向到的是该函数在指定基地返回的第一座矿，如果返回的非闹鬼金矿，侍僧就无法采矿
     native GetMinesOwned        takes nothing                               returns integer
-    // 拥有的所有金矿的金钱数量，对于亡灵，该函数会检查开始点所有矿，而不是只查闹鬼金矿，并返回第一座矿
+    // 拥有的所有金矿的金钱数量，会检查开始点所有矿，而不是只查闹鬼金矿，并返回第一座矿的金钱数
     // 如果开始点有多个金矿，且金钱数不同，会导致统计值偏差
     native GetGoldOwned         takes nothing                               returns integer
-    // 有金矿的基地编号，如果多个基地都有金矿 则返回最小编号
+    // 有金矿的基地编号，如果多个基地都有金矿，则返回最小编号
     // 配合TownHasMine检查当前哪座基地有矿时，可以直接获取最小编号，并从该编号查起，避免分基地过多时的逐个查询
     native TownWithMine         takes nothing                               returns integer
-    // 指定编号的基地是否有金矿，0为第一个基地
+    // 指定编号的基地是否有金矿
+    // @param townid基地编号，-1为不限
     native TownHasMine          takes integer townid                        returns boolean
-    // 指定编号的基地是有城镇单位（基地），0为第一个基地
+    // 指定编号的基地是否拥有城镇（一、二或三本任意基地）
+    // @param townid基地编号，-1为不限
     native TownHasHall          takes integer townid                        returns boolean
     
     // 指定科技类型当前升级的等级（如攻防默认有3级，大师级科技默认有2级）
     native GetUpgradeLevel      takes integer id                            returns integer
-    // 升级指定科技需要消耗的金钱数量，指定id就是指定科技等级
+    // 升级指定科技需要消耗的金钱数量，指定id就是指定科技类型
     native GetUpgradeGoldCost   takes integer id                            returns integer
-    // 升级指定科技需要消耗的木材数量，指定id就是指定科技等级
+    // 升级指定科技需要消耗的木材数量，指定id就是指定科技类型
     native GetUpgradeWoodCost   takes integer id                            returns integer
     // 获取下一个扩张点
     native GetNextExpansion     takes nothing                               returns integer
     // 获取大型攻击目标
-    // 因运行时暴雪会往攻击组添加默认攻击类型为攻城的单位，故猜测该单位是某种建筑或位于建筑群中
+    // 因暴雪会往进攻大型目标的攻击组添加 默认攻击类型为攻城 的单位类型，故猜测该单位是建筑或位于建筑群中
     native GetMegaTarget        takes nothing                               returns unit
     // 获取指定玩家正在训练/建造的单位
     native GetBuilding          takes player p                              returns unit
-    // 获得敌人攻击组强度
+    // 获取敌人攻击组强度
     native GetEnemyPower        takes nothing                               returns integer
     // 设置盟友当前的攻击目标（仅对AI盟友生效）
     native SetAllianceTarget    takes unit id                               returns nothing
     // 获取盟友当前的攻击目标
     native GetAllianceTarget    takes nothing                               returns unit
-    // 命令训练/建造/研究指定/研究单位/科技(指定数量,单位类型,基地)
+    // 训练/建造/研究指定/研究单位/科技(指定数量,单位类型,基地)
+    // @param town 基地编号，-1为不限
     native SetProduce           takes integer qty, integer id, integer town returns boolean
-    // 取消指定单位，单位正在建造/训练会取消
+    // 取消指定单位，如果单位正在建造/训练，则会被取消
     // 因单词为反召唤，怀疑可用于建造完成时卖建筑（亡灵）
     native Unsummon             takes unit unitid                           returns nothing
-    // 建造扩张点/分基地（指定工人（具体到某个单位）和城镇单位的类型）
+    // 建造扩张点/分基地
+    // @param peon指定工人单位
+    // @param id建造的城镇单位类型
     native SetExpansion         takes unit peon, integer id                 returns boolean
     // 升级指定科技
     native SetUpgrade           takes integer id                            returns boolean
@@ -87,12 +94,17 @@ native DebugS               takes string str                            returns 
     // 是否允许设置新英雄，
     // 意义不明，可能和学习技能有关
     native SetNewHeroes         takes boolean state                         returns nothing
-    // 购买地精飞艇，运行后AI会自动前往地精实验室并自动购买地精飞艇，无需额外命令
+    // 购买地精飞艇
+    // 运行后AI会自动前往地精实验室并自动购买地精飞艇，无需额外命令
     native PurchaseZeppelin     takes nothing                               returns nothing
-    // 训练/建造/研究指定指定数量的合体单位类型（单位类型a,单位类型b,合体成单位类型make）
+    // 训练/建造/研究指定指定数量的合体单位类型
     // 运行后AI会分别训练a和b并合体，直到make数量达标，如角鹰兽和弓箭手合体
+    // @param a单位类型一
+    // @param b单位类型二
+    // @param make一和二合体成的单位类型
     native MergeUnits           takes integer qty, integer a, integer b, integer make returns boolean
-    // 训练/建造/研究指定指定数量的变形单位类型，此变形不是英雄/熊德/鸟德/白牛/猎头/坦克的变身/升级，而是十胜石雕像和毁灭者这种额外付费的个体变形
+    // 训练/建造/研究指定指定数量的变形单位类型
+    // 此变形不是英雄/熊德/鸟德/白牛/猎头/坦克的变身/升级，而是十胜石雕像和毁灭者这种额外付费的个体变形
     // 运行后AI会训练变形前单位并变形，直到数量达标
     native ConvertUnits         takes integer qty, integer id               returns boolean
     
@@ -138,13 +150,16 @@ native DebugS               takes string str                            returns 
     native RemoveSiege          takes nothing                               returns nothing
     // 初始化攻击组
     native InitAssault          takes nothing                               returns nothing
-    // 增加指定数量的指定单位类型到攻击组。未被编入的单位类型不会跟随进攻，只会留在开始点
+    // 增加指定数量的指定单位类型到攻击组
+    // 未被编入的单位类型不会跟随进攻，只会留在开始点
     native AddAssault           takes integer qty, integer id               returns boolean
     // 增加指定数量的指定单位类型到防守组
     native AddDefenders         takes integer qty, integer id               returns boolean
     
-    // 获取指定等级范围内的中立敌对玩家控制的单位，即野怪（ture 为可获取飞行单位，false 为不获取）
+    // 获取指定等级范围内的中立敌对玩家控制的单位
     // 在1.29及以上版本中，中立敌对玩家为玩家24，在以下版本则为12
+    // @param min~max 获取的最小至最高等级，利用数值区间可让AI在不同的发展阶段攻击不同等级的野怪营地
+    // @param flyers_ok 为 ture 时获取飞行单位，为 false 时不获取
     native GetCreepCamp         takes integer min, integer max, boolean flyers_ok returns unit
     // 开始获取敌人主基地
     native StartGetEnemyBase    takes nothing                               returns nothing
@@ -166,25 +181,33 @@ native DebugS               takes string str                            returns 
     native AttackMoveKill       takes unit target                           returns nothing
     // 让攻击指组攻击指定坐标
     native AttackMoveXY         takes integer x, integer y                  returns nothing
-    // 在指定坐标卸载单位，该命令似乎只对卸载（地精飞艇）技能生效，且AI无需任何辅助代码就能自己控制好飞艇的装卸（运输船不行）
+    // 在指定坐标卸载单位
+    // 该命令只对飞艇类单位的 卸载 技能生效，且AI无需任何辅助代码就能自己控制好飞艇的装卸（运输船不行）
     // 建议不要对飞艇类单位发送忽略防守指令，忽略后AI不会自动控制飞艇卸载
     native LoadZepWave          takes integer x, integer y                  returns nothing
-    // 检测自杀式攻击是否满足指定条件（指定玩家），该指令被暴雪用于战役AI
+    // 自杀式攻击指定玩家，返回false时代表未执行
+    // 理论上是一路打到指定玩家的出生点
+    // 该指令被暴雪用于战役AI
     native SuicidePlayer        takes player id, boolean check_full         returns boolean
-    // 检测自杀式攻击组是否满足指定条件（指定玩家），该指令被暴雪用于战役AI
+    // 自杀式攻击指定玩家，返回false时代表未执行
+    // 和SuicidePlayer的区别怀疑是 只要攻击到指定的单位即可，无需一路打到玩家出生点
+    // 该指令被暴雪用于战役AI
     native SuicidePlayerUnits   takes player id, boolean check_full         returns boolean
     // 攻击组是否正在战斗
     native CaptainInCombat      takes boolean attack_captain                returns boolean
     // 指定单位是否有防御塔保护
     native IsTowered            takes unit target                           returns boolean
-    // 清理上一次的AI采集工人分配设置，暴雪在每次运行 HarvestGold 和 HarvestWood 前都进行了清理
+    // 清理上一次的AI采集工人分配设置
+    // 暴雪在每次运行 HarvestGold 和 HarvestWood 前都进行了清理
     // 清理后AI可能会交换多个基地之间的农民，比如让A矿的农民去B矿工作，反之亦然
     native ClearHarvestAI       takes nothing                               returns nothing
     // 分配指定数量的工人在指定基地采集金矿
     // 如果金矿和基地之间最短距离的路线可以游过深水地形到达，两栖工人会优先走最短距离到达金矿，但其采集完成返回时自动会停在岸边，就像它忘记自己可以游泳一样
+    // @param town 0为主基地，大于0则是对应每个分基地
     native HarvestGold          takes integer town, integer peons           returns nothing
     // 分配指定数量的工人在指定基地采集木材
     // 如果树和基地之间最短距离的路线可以游过深水地形到达，两栖工人会优先走最短距离到达树，但其采集完成返回时自动停会在岸边，就像它忘记自己可以游泳一样
+    // @param town 0为主基地，大于0则是对应每个分基地
     native HarvestWood          takes integer town, integer peons           returns nothing
     // 获取开分基地的工人，系统会随机返回一个工人给AI，但可能返回null
     // 如果AI有盟友，返回null的概率似乎会增加，如果是暗夜，建议另行判断工人是否在金矿内（是否运输单位），因为AI不会命令其离开金矿
@@ -201,6 +224,7 @@ native DebugS               takes string str                            returns 
     native CreateCaptains       takes nothing                               returns nothing
     // 设置指定组（攻击组、防守组、两组一起执行）回家后的集结坐标
     // AI默认把单位聚在主基地的采矿路线上，应该就是这个坐标
+    // @param which攻击组、防守组或两组，即 1，2或3
     native SetCaptainHome       takes integer which, real x, real y         returns nothing
     // 命令攻击组复位（回到 SetCaptainHome 的集结点）
     native ResetCaptainLocs     takes nothing                               returns nothing
@@ -243,12 +267,18 @@ native DebugS               takes string str                            returns 
     // 地图上是否还有中立敌对玩家的单位，即野怪 
     // 在1.29及以上版本中，中立敌对玩家为玩家24，在以下版本则为12
     native CreepsOnMap          takes nothing                               returns boolean
-    // 在攻击组添加自杀单位，指定单位类型和数量，该指令被暴雪用于战役AI
+    // 在攻击组添加自杀单位，指定单位类型和数量
+    // 该指令被暴雪用于战役AI
     native SuicideUnit          takes integer count, integer unitid         returns nothing
-    // 在攻击组添加自杀单位，指定单位类型、数量和玩家，该指令被暴雪用于战役AI
+    // 在攻击组添加自杀单位
+    // 该指令被暴雪用于战役AI
+    // @param ct数量
+    // @param uid单位类型
+    // @param pid玩家编号
     native SuicideUnitEx        takes integer ct, integer uid, integer pid  returns nothing
-    // 开始进程，AI脚本最多可运行6条进程，且同时运行（包含默认线程，自行添加之前请检查已调用的默认线程数量）
-    // 可共用全局变量，但在一条进程运行到读取变量的代码时，可能因变量已在几十秒前被另一个变量改写，造成滞后的假象
+    // 开始线程
+    // AI脚本最多可运行6条线程，且同时运行（包含默认线程，自行添加之前请检查已调用的默认线程数量）
+    // 线程之间共享全局变量，但在一条线程运行到读取变量时，变量可能已在几秒前被另一个线程改写，于是造成滞后的假象
     native StartThread          takes code func                             returns nothing
     // 等待指定时间，按秒计时（期间不执行任何指令）
     native Sleep                takes real seconds                          returns nothing
@@ -258,20 +288,24 @@ native DebugS               takes string str                            returns 
     native UnitInvis            takes unit id                               returns boolean
     // 攻击组忽略指定类型单位的数量
     native IgnoredUnits         takes integer unitid                        returns integer
-    // AI的任意基地被攻击，与小地图警报的触发条件相同，但只针对基地
+    // AI的任意基地被攻击
+    // 与小地图警报的触发条件相同，但只针对基地
     native TownThreatened       takes nothing                               returns boolean
     // 是否允许在未到达目的地前（攻击组/防御组移动过程中）战斗
     native DisablePathing       takes nothing                               returns nothing
     // 获得命令队列中的指令条数
     native SetAmphibious        takes nothing                               returns nothing
     
-    // 获取指令类型，可通过BJ发送，未发送时获取的值是0
+    // 获取指令类型
+    // 可通过BJ发送，未发送时获取的值是0
     // 暴雪用该指令打破循环，exitwhen CommandsWaiting() != 0，比如电影结束后，BJ发送1给AI，这就实现了游戏初始化时运行AI，但电影结束前AI不进攻，只发展
     native CommandsWaiting      takes nothing                               returns integer
-    // 获取最新的指令类型，可通过BJ发送，未发送时获取的值是0，指令包含类型和数据
+    // 获取最新的指令类型
+    // 可通过BJ发送，未发送时获取的值是0，指令包含类型和数据
     // 需灵活运用，比如设定1类型为进攻指令，数据0~N代表不同的攻击点，2类型为防守指令，数据0~N代表不同的防御点
     native GetLastCommand       takes nothing                               returns integer
-    // 获取最新指令的数据，可通过BJ发送，未发送时获取的值是0，指令包含类型和数据
+    // 获取最新指令的数据
+    // 可通过BJ发送，未发送时获取的值是0，指令包含类型和数据
     // 需灵活运用，比如设定1类型为进攻指令，数据0~N代表不同的攻击点，2类型为防守指令，数据0~N代表不同的防御点
     native GetLastData          takes nothing                               returns integer
     // 将最新指令踢出队列
@@ -1479,7 +1513,7 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //============================================================================
-     // 获取大型中立敌对玩家的单位（10~100级之间，不含飞行单位）
+     // 获取大型中立敌对玩家的单位（10~100级之间，根据allow_air_creeps当前值确定是否获取飞行单位）
     function GetMajorCreep takes nothing returns unit
         return GetCreepCamp(10,100,allow_air_creeps)
     endfunction
@@ -1549,7 +1583,7 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //============================================================================
-    // 开启指定线程
+    // 运行指定线程
     function StartTownBuilder takes code func returns nothing
         call StartThread(func)
     endfunction
@@ -1613,7 +1647,8 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //============================================================================
-    // 研究/升级指定科技（简单难度AI默认不执行该命令，且只研究/升级1级）
+    // 研究/升级指定科技
+    // 简单难度AI默认不执行该命令
     function SetBuildUpgr takes integer qty, integer unitid returns nothing
         if MeleeDifficulty() != MELEE_NEWBIE or qty == 1 then
             call SetBuildAll(BUILD_UPGRADE,qty,unitid,-1)
@@ -1781,14 +1816,15 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //============================================================================
-    // 统计指定单位类型的数量，不包含建造/训练中，不限基地，默认用于检测城镇类型的单位（基地）
+    // 统计指定单位类型的数量，不包含建造/训练中，不限基地
+    // 默认用于检测城镇类型的单位（基地）
     function TownCount takes integer base returns integer
         return TownCountEx(base,false,-1)
     endfunction
     
     //============================================================================
-    // 开分基地
-    // @param build_it为假时不执行任何操作，当 build_it 和 HallsCompleted(unitid) 都为真时才会开
+    // 建造分基地
+    // @param build_it为假时不执行任何操作，当 build_it 和 HallsCompleted(unitid) 都为真时才会建造
     function BasicExpansion takes boolean build_it, integer unitid returns nothing
         if build_it and HallsCompleted(unitid) then
             call SetBuildExpa( TownCount(unitid)+1, unitid )
@@ -1804,8 +1840,9 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //============================================================================
-    // 统计指定单位类型数量，不否包含建造/训练中，默认用于检测城镇类型的单位（基地）
-    // @param base，指定单位类型
+    // 统计指定单位类型数量，不否包含建造/训练中
+    // 默认用于检测城镇类型的单位（基地）
+    // @param base指定单位类型
     // @param townid基地编号，-1为不限
     function TownCountTown takes integer base, integer townid returns integer
         return TownCountEx(base,false,townid)
@@ -1849,8 +1886,10 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //============================================================================
-    // 开始训练单位/建造建筑
-    // @param town 基地编号，-1为不限
+    // 训练单位/建造建筑
+    // @param ask_qty数量
+    // @param town基地编号，-1为不限
+    // @param unitid单位类型
     function StartUnit takes integer ask_qty, integer unitid, integer town returns boolean
         local integer have_qty
         local integer need_qty
@@ -1929,7 +1968,8 @@ native DebugS               takes string str                            returns 
     
     //============================================================================
     // 等待指定的单位类型（包含建造/训练中）数量大于或等于指定数量，满足条件前循环等待，若120秒后仍未满足，自动退出
-    // @param towns 基地编号，-1为不限
+    // @param towns指定数量
+    // @param townid基地单位类型
     function WaitForTown takes integer towns, integer townid returns nothing
         local integer i = 0
         loop
@@ -1943,7 +1983,7 @@ native DebugS               takes string str                            returns 
     //============================================================================
     // 开始建造分基地
     // @param qty数量
-    // @param hall单位类型
+    // @param hall基地单位类型
     function StartExpansion takes integer qty, integer hall returns boolean
         local integer count
         local integer town
@@ -2459,8 +2499,9 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //--------------------------------------------------------------------------------------------------
-    // 设置各波次进攻，默认用于自杀式攻击
-    // @param standard为真时会判断退出条件
+    // 设置各波次进攻（指定玩家和坐标），默认用于自杀式攻击
+    // @param standard为真时会额外判断退出条件且不进攻指定坐标，为假时会进攻指定坐标
+    // @param bldgs当standard为真时，若bldgs为真，会额外判断退出条件 SuicidePlayer(p,sleep_seconds >= -60)，反之额外判断退出条件 SuicidePlayerUnits(p,sleep_seconds >= -60)
     function CommonSuicideOnPlayer takes boolean standard, boolean bldgs, integer seconds, player p, integer x, integer y returns nothing
         local integer save_peons
     
@@ -2798,7 +2839,7 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //============================================================================
-    // 攻击扩展点
+    // 攻击扩张点（有中立敌对单位的分矿）
     function ExpansionAttack takes nothing returns nothing
         local unit creep = GetExpansionFoe()
         local integer x
@@ -3006,7 +3047,7 @@ native DebugS               takes string str                            returns 
             set get_zeppelin = true
         endif
     endfunction
-    PLAYER_STATE_FOOD_CAP_CEILING
+
     //============================================================================
     // 获取当前AI玩家的已用人口数
     function FoodUsed takes nothing returns integer

--- a/static/common.ai
+++ b/static/common.ai
@@ -24,19 +24,19 @@ native DebugS               takes string str                            returns 
     // 英雄升级技能相关函数 获取英雄等级
     native GetHeroLevelAI       takes nothing                               returns integer
     
-    // 获取AI玩家指定类型单位的数量，统计训练/建造中及已训练/建造完成
+    // 获取AI玩家指定类型单位/科技的数量，统计训练/建造/研究指定/研究中及已训练/建造/研究指定/研究完成
     native GetUnitCount         takes integer unitid                        returns integer
-    // 获取指定玩家的该类型单位的数量，统计训练/建造中及已训练/建造完成
+    // 获取指定玩家的该类型单位的数量，统计训练/建造/研究指定/研究中及已训练/建造/研究指定/研究完成
     native GetPlayerUnitTypeCount takes player p, integer unitid            returns integer
-    // 获取AI玩家指定类型单位的数量，仅统计已训练/建造完成
+    // 获取AI玩家指定类型单位的数量，仅统计已训练/建造/研究指定/研究完成
     native GetUnitCountDone     takes integer unitid                        returns integer
     // 指定基地对应类型的单位数，0为第一个基地
     native GetTownUnitCount     takes integer id, integer tn, boolean dn    returns integer
-    // 训练/建造一个指定类型单位需要消耗的金钱数量
+    // 训练/建造/研究指定/研究一个指定类型单位/科技需要消耗的金钱数量
     native GetUnitGoldCost      takes integer unitid                        returns integer
-    // 训练/建造一个指定类型单位需要消耗的木材数量
+    // 训练/建造/研究指定/研究一个指定类型单位/科技需要消耗的木材数量
     native GetUnitWoodCost      takes integer unitid                        returns integer
-    // 获取指定单位类型的建造/训练时间
+    // 获取指定单位/科技类型的建造/训练/研究时间
     native GetUnitBuildTime     takes integer unitid                        returns integer
     
     // 拥有的金矿数，对于亡灵，该函数会检查开始点所有矿，而不是只查闹鬼金矿，如果AI开始点有多个未被其他玩家占据的矿，可能会导致亡灵无法正常采矿，因为HarvestGold（0，n）指向到的是该函数在指定基地返回的第一座矿，如果返回的非闹鬼金矿，侍僧就无法采矿
@@ -60,7 +60,7 @@ native DebugS               takes string str                            returns 
     native GetNextExpansion     takes nothing                               returns integer
     // 获取大型攻击目标，此时暴雪会往攻击组添加默认攻击类型为攻城的单位，似乎该单位是某种建筑或位于建筑群中
     native GetMegaTarget        takes nothing                               returns unit
-    // 获取指定玩家正在建造的单位
+    // 获取指定玩家正在训练/建造的单位
     native GetBuilding          takes player p                              returns unit
     // 获得敌人进攻组强度
     native GetEnemyPower        takes nothing                               returns integer
@@ -68,9 +68,9 @@ native DebugS               takes string str                            returns 
     native SetAllianceTarget    takes unit id                               returns nothing
     // 获取盟友当前的攻击目标
     native GetAllianceTarget    takes nothing                               returns unit
-    // 命令训练/建造单位(数量,单位类型,基地)
+    // 命令训练/建造/研究指定/研究单位/科技(数量,单位类型,基地)
     native SetProduce           takes integer qty, integer id, integer town returns boolean
-    // 反召唤指定单位（亡灵卖建筑）
+    // 取消/反召唤指定单位（亡灵卖建筑），单位正在建造/训练会取消，建造完成时可能会被卖掉
     native Unsummon             takes unit unitid                           returns nothing
     // 建造扩张点/分基地（指定工人类型和建筑类型）
     native SetExpansion         takes unit peon, integer id                 returns boolean
@@ -82,9 +82,9 @@ native DebugS               takes string str                            returns 
     native SetNewHeroes         takes boolean state                         returns nothing
     // 购买地精飞艇，运行后AI会自动前往地精实验室并自动购买地精飞艇，无需额外命令
     native PurchaseZeppelin     takes nothing                               returns nothing
-    // 训练/建造指定数量的合体单位类型（单位类型a,单位类型b,合体成单位类型make），运行后AI会分别训练a和b并合体，直到make数量达标，如角鹰兽和弓箭手合体
+    // 训练/建造/研究指定指定数量的合体单位类型（单位类型a,单位类型b,合体成单位类型make），运行后AI会分别训练a和b并合体，直到make数量达标，如角鹰兽和弓箭手合体
     native MergeUnits           takes integer qty, integer a, integer b, integer make returns boolean
-    // 训练/建造指定数量的变形单位类型，此变形不是英雄/熊德/鸟德/白牛/猎头/坦克的变身/升级，而是十胜石雕像和毁灭者这种额外付费的个体变形，运行后AI会训练变形前单位并变形，直到数量达标
+    // 训练/建造/研究指定指定数量的变形单位类型，此变形不是英雄/熊德/鸟德/白牛/猎头/坦克的变身/升级，而是十胜石雕像和毁灭者这种额外付费的个体变形，运行后AI会训练变形前单位并变形，直到数量达标
     native ConvertUnits         takes integer qty, integer id               returns boolean
     
     // 启用战役AI
@@ -210,13 +210,13 @@ native DebugS               takes string str                            returns 
     native CaptainIsEmpty       takes nothing                               returns boolean
     // 进攻组规模
     native CaptainGroupSize     takes nothing                               returns integer
-    // 攻击组准备情况
+    // 攻击组准备情况，似乎是百分制，数值越高，准备越充分
     native CaptainReadiness     takes nothing                               returns integer
     // 进攻组是否在撤退
     native CaptainRetreating    takes nothing                               returns boolean
-    // 进攻组整体生命值
+    // 进攻组整体生命值，似乎是百分制且转百分比
     native CaptainReadinessHP   takes nothing                               returns integer
-    // 进攻组整体魔法值
+    // 进攻组整体魔法值，似乎是百分制且转百分比
     native CaptainReadinessMa   takes nothing                               returns integer
     // 进攻组是否到达目的地
     native CaptainAtGoal        takes nothing                               returns boolean
@@ -852,11 +852,13 @@ native DebugS               takes string str                            returns 
     endglobals
     
     //============================================================================
+    // 根据玩家插槽查询玩家，插槽从1开始计算，玩家从0开始计算，玩家数字恒比插槽少1
     function PlayerEx takes integer slot returns player
         return Player(slot-1)
     endfunction
     
     //============================================================================
+    // 显示文本，带1个指定文本
     function Trace takes string message returns nothing
         if trace_on then
             call DisplayText(GetAiPlayer(),message)
@@ -864,6 +866,7 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //============================================================================
+    // 显示文本，带1个指定文本，1个整数
     function TraceI takes string message, integer val returns nothing
         if trace_on then
             call DisplayTextI(GetAiPlayer(),message,val)
@@ -871,6 +874,7 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //============================================================================
+    // 显示文本，带1个指定文本，2个整数
     function TraceII takes string message, integer v1, integer v2 returns nothing
         if trace_on then
             call DisplayTextII(GetAiPlayer(),message,v1,v2)
@@ -878,6 +882,7 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //============================================================================
+    // 显示文本，带1个指定文本，3个整数
     function TraceIII takes string message, integer v1, integer v2, integer v3 returns nothing
         if trace_on then
             call DisplayTextIII(GetAiPlayer(),message,v1,v2,v3)
@@ -926,6 +931,7 @@ native DebugS               takes string str                            returns 
     //============================================================================
     //  Utility Functions
     //============================================================================
+    // 获取最小值
     function Min takes integer A, integer B returns integer
         if A < B then
             return A
@@ -933,7 +939,7 @@ native DebugS               takes string str                            returns 
             return B
         endif
     endfunction
-    
+    // 获取最大值
     function Max takes integer A, integer B returns integer
         if A > B then
             return A
@@ -941,11 +947,11 @@ native DebugS               takes string str                            returns 
             return B
         endif
     endfunction
-    
+    // 设置运输下一波状态开启，用于飞艇空投，但鉴于AI本身会使用飞艇，无需使用该程序
     function SetZepNextWave takes nothing returns nothing
         set zep_next_wave = true
     endfunction
-    // 自杀休眠时间，当指定的时间小于等于0时 及 触发器有命令传入时会退出休眠
+    // 自杀休眠倒计时，当指定的时间小于等于0时 及 触发器有命令传入时会退出休眠
     function SuicideSleep takes integer seconds returns nothing
         set sleep_seconds = sleep_seconds - seconds
         loop
@@ -1109,6 +1115,7 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //============================================================================
+    // 设置建造序列，每个建造/训练命令都会被统一引导到此写入建造先后的排序，等待系统循环检索建造/训练，当 build_length 重置时，系统循环重置
     function SetBuildAll takes integer t, integer qty, integer unitid, integer town returns nothing
         if qty > 0 then
             set build_qty[build_length] = qty
@@ -1120,13 +1127,13 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //============================================================================
-    // 训练/建造指定数量的指定类型单位
+    // 训练/建造/研究指定指定数量的指定类型单位/科技
     function SetBuildUnit takes integer qty, integer unitid returns nothing
         call SetBuildAll(BUILD_UNIT,qty,unitid,-1)
     endfunction
     
     //============================================================================
-    // 继续训练/建造指定类型的单位，如果当前训练/建造中的该类型单位数量大于等于指定数量，则不建造
+    // 继续训练/建造/研究指定指定类型的单位/科技，如果当前训练/建造/研究指定/研究中的该类型单位/科技数量大于等于指定数量，则不建造
     function SetBuildNext takes integer qty, integer unitid returns nothing
         local integer has = GetUnitCount(unitid)
         if has >= qty then
@@ -1136,7 +1143,7 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //============================================================================
-    // 训练/建造指定类型的单位（指定各AI难度的数量）
+    // 训练/建造/研究指定指定类型的单位/科技（指定各AI难度的数量）
     function SetBuildUnitEx takes integer easy, integer med, integer hard, integer unitid returns nothing
         if difficulty == EASY then
             call SetBuildAll(BUILD_UNIT,easy,unitid,-1)
@@ -1148,13 +1155,13 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //============================================================================
-    // 在指定编号的基地建造指定数量的单位
+    // 在指定编号的基地建造指定数量的单位/科技，一般用于在分矿造塔和其他建筑
     function SecondaryTown takes integer town, integer qty, integer unitid returns nothing
         call SetBuildAll(BUILD_UNIT,qty,unitid,town)
     endfunction
     
     //============================================================================
-    // 在指定编号的基地建造指定数量的单位
+    // 在指定编号的基地建造指定数量的单位/科技，一般用于在分矿造塔和其他建筑
     function SecTown takes integer town, integer qty, integer unitid returns nothing
         call SetBuildAll(BUILD_UNIT,qty,unitid,town)
     endfunction
@@ -1186,6 +1193,7 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //============================================================================
+    // 开始升级科技
     function StartUpgrade takes integer level, integer upgid returns boolean
         local integer gold_cost
         local integer wood_cost
@@ -1208,6 +1216,7 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //============================================================================
+    // 建造/训练指定单位类型，当金大于1000，木大于500时造两个，否则造一个，默认用于检测建造工厂（造兵建筑）
     function BuildFactory takes integer unitid returns nothing
         if GetGold() > 1000 and GetWood() > 500 then
             call SetBuildUnit( 2, unitid )
@@ -1217,11 +1226,13 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //============================================================================
+    // 判断指定单位类型的数量（含建造/训练中）是否等于该单位类型总数量（不含建造/训练中），默认用于检测城镇类型的单位（基地）
     function HallsCompleted takes integer unitid returns boolean
         return GetUnitCount(unitid) == GetUnitCountDone(unitid) 
     endfunction
     
     //============================================================================
+    // 在指定分基地建造指定单位类型，一般用于在分矿造塔或其他建筑，训练单位无需使用此命令，AI会使用所有建筑训练，不论其在哪个基地，使用该命令建造/训练的单位会被登记为：制造于该分基地
     function GuardSecondary takes integer townid, integer qty, integer unitid returns nothing
         if TownHasHall(townid) and TownHasMine(townid) then
             call SecondaryTown( townid, qty, unitid )
@@ -1243,6 +1254,7 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //============================================================================
+    // 数量统计，指定单位类型，指定是否包含建造/训练中（only_done），指定分基地（townid，-1为不限），查询复核条件的单位类型数量
     function TownCountEx takes integer unitid, boolean only_done, integer townid returns integer
     
         local integer have_qty = GetUnitCountEx(unitid,only_done,townid)
@@ -1305,16 +1317,19 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //============================================================================
+    // 数量统计，指定单位类型，包含建造/训练中，不限基地，查询复核条件的单位类型数量
     function TownCountDone takes integer base returns integer
         return TownCountEx(base,true,-1)
     endfunction
     
     //============================================================================
+    // 数量统计，指定单位类型，不包含建造/训练中，不限基地，查询复核条件的单位类型数量
     function TownCount takes integer base returns integer
         return TownCountEx(base,false,-1)
     endfunction
     
     //============================================================================
+    // 基础开分基地，指定单位类型，包含建造/训练中，不限基地，查询复核条件的单位类型数量
     function BasicExpansion takes boolean build_it, integer unitid returns nothing
         if build_it and HallsCompleted(unitid) then
             call SetBuildExpa( TownCount(unitid)+1, unitid )
@@ -1322,11 +1337,13 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //============================================================================
+    // 升级科技，研究指定科技类型（baseid）已完成数量的升级科技类型（newid）
     function UpgradeAll takes integer baseid, integer newid returns nothing
         call SetBuildUnit( TownCountDone(baseid), newid )
     endfunction
     
     //============================================================================
+    // 数量统计，指定单位类型（base），指定分基地（townid，-1为不限），不否包含建造/训练中，查询复核条件的单位类型数量，默认用于检测城镇类型的单位（基地）
     function TownCountTown takes integer base, integer townid returns integer
         return TownCountEx(base,false,townid)
     endfunction
@@ -1334,6 +1351,7 @@ native DebugS               takes string str                            returns 
     //============================================================================
     //  FoodPool
     //============================================================================
+    // 根据人口占用情况训练指定单位类型，food为当前人口上限，use1为单位类型id1的人口占用（单个），use2为单位类型id2的人口占用（单个），当strong为真时，训练（（food - use1 * TownCount(id1)) / use2）个id2，当strong为假且weak为真时，训练（(food - use2 * TownCount(id2)) / use1）个id1
     function FoodPool takes integer food, boolean weak, integer id1, integer use1, boolean strong, integer id2, integer use2 returns nothing
         if strong then
             call SetBuildUnit( (food - use1 * TownCount(id1)) / use2, id2 )
@@ -1345,6 +1363,7 @@ native DebugS               takes string str                            returns 
     //============================================================================
     //  MeleeTownHall
     //============================================================================
+    // 补造分基地，当指定的基地（townid）有金矿且该基地没有城镇时，补造一个分基地
     function MeleeTownHall takes integer townid, integer unitid returns nothing
         if TownHasMine(townid) and not TownHasHall(townid) then
             call SecondaryTown ( townid, 1, unitid )
@@ -1361,6 +1380,7 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //============================================================================
+    // 开始训练单位/建造建筑
     function StartUnit takes integer ask_qty, integer unitid, integer town returns boolean
         local integer have_qty
         local integer need_qty
@@ -1450,6 +1470,7 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //============================================================================
+    // 开始建造分基地
     function StartExpansion takes integer qty, integer hall returns boolean
         local integer count
         local integer town
@@ -1487,6 +1508,7 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //============================================================================
+    // 建造核心循环，该程序负责执行所有排队中的建造/训练/研究命令
     function OneBuildLoop takes nothing returns nothing
         local integer index = 0
         local integer qty
@@ -1525,11 +1547,13 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //============================================================================
+    // 错开休眠，休眠 (base + spread * I2R(GetAiPlayer()) / I2R(GetPlayers())) 秒
     function StaggerSleep takes real base, real spread returns nothing
         call Sleep(base + spread * I2R(GetAiPlayer()) / I2R(GetPlayers()))
     endfunction
     
     //============================================================================
+    // 建造循环，启用建造核心循环程序，并无限循环
     function BuildLoop takes nothing returns nothing
         call OneBuildLoop()
         call StaggerSleep(1,2)
@@ -1546,11 +1570,13 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //============================================================================
+    // 设置初始波次，设置初始波次的时间
     function SetInitialWave takes integer seconds returns nothing
         set sleep_seconds = seconds
     endfunction
     
     //============================================================================
+    // 在原基础上增加初始波次的休眠时间
     function AddSleepSeconds takes integer seconds returns nothing
         set sleep_seconds = sleep_seconds + seconds
     endfunction
@@ -1572,6 +1598,7 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //============================================================================
+    // 当指定类型的单位/科技少于1个时（包含建造/训练/研究中），建造/训练/研究1个，默认用于补充合体/变形类单位
     function ConvertNeeds takes integer unitid returns nothing
         if GetUnitCount(unitid) < 1 then
             call StartUnit(1,unitid,-1)
@@ -1598,6 +1625,7 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //============================================================================
+    // 设置攻击组
     function SetAssaultGroup takes integer qty, integer max, integer unitid returns nothing
         call Conversions(max,unitid)
     
@@ -1657,6 +1685,7 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //============================================================================
+    // 将指定类型的单位添加到对战攻击组
     function SetMeleeGroup takes integer unitid returns nothing
         if unitid == hero_id then
             call SetAssaultGroup(1,9,unitid)
@@ -1666,6 +1695,7 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //============================================================================
+    // 将指定类型的单位添加到防御组，默认用于战役
     function CampaignDefender takes integer level, integer qty, integer unitid returns nothing
         if qty > 0 and difficulty >= level then
             set defense_qty[defense_length] = qty
@@ -1677,6 +1707,7 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //============================================================================
+    // 将指定类型的单位添加到防御组（指定各难度AI的添加数量），默认用于战役
     function CampaignDefenderEx takes integer easy, integer med, integer hard, integer unitid returns nothing
         if difficulty == EASY then
             call CampaignDefender(EASY,easy,unitid)
@@ -1688,6 +1719,7 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //============================================================================
+    // 将指定类型的单位添加到战役攻击组（level必须大于等于当前AI难度时才会添加），默认用于战役
     function CampaignAttacker takes integer level, integer qty, integer unitid returns nothing
         if qty > 0 and difficulty >= level then 
             call SetAssaultGroup(qty,qty,unitid)
@@ -1695,6 +1727,7 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //============================================================================
+    // 将指定类型的单位添加到攻击组（指定各难度AI的添加数量），默认用于战役
     function CampaignAttackerEx takes integer easy, integer med, integer hard, integer unitid returns nothing
         if difficulty == EASY then
             call CampaignAttacker(EASY,easy,unitid)
@@ -1706,6 +1739,7 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //============================================================================
+    // 等待进攻组完成组建，用于等待进攻组补充单位（用testReady指定组的准备情况，为真时需要攻击组准备满50，为假时准备0即可，seconds为最长等待时间）
     function FormGroup takes integer seconds, boolean testReady returns nothing
         local integer index
         local integer count
@@ -1771,11 +1805,13 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //============================================================================
+    // 获取指定单位/科技类型的建造/训练/研究时间，该时间默认用于备战（等待该时间已补充兵力）
     function WavePrepare takes integer unitid returns integer
         return GetUnitBuildTime(unitid)
     endfunction
     
     //============================================================================
+    // 获取等待所需时间
     function PrepTime takes nothing returns integer
         local integer unitid
         local integer missing
@@ -1803,6 +1839,7 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //============================================================================
+    // 休眠指定时间（seconds），并在休眠后判断攻击组准备是否完成
     function PrepSuicideOnPlayer takes integer seconds returns boolean
         local integer wave_prep   = PrepTime()
         local integer save_length
@@ -1872,6 +1909,7 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //============================================================================
+    // 通报各波次进攻情况（默认使用Trace命令发送文字，可能需要打开调试模式）
     function SuicideOnPlayerWave takes nothing returns nothing
         call Trace("waiting for attack wave to enter combat\n") //xxx
         loop
@@ -1926,6 +1964,7 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //--------------------------------------------------------------------------------------------------
+    // 设置各波次进攻，默认用于自杀（战役）
     function CommonSuicideOnPlayer takes boolean standard, boolean bldgs, integer seconds, player p, integer x, integer y returns nothing
         local integer save_peons
     
@@ -2131,6 +2170,7 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //============================================================================
+    // 战斗（循环发送进攻指定目标命令），直至攻击目标死亡或进攻组死光/撤退
     function CommonSleepUntilTargetDead takes unit target, boolean reform returns nothing
         loop
             exitwhen CaptainRetreating()
@@ -2157,6 +2197,7 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //============================================================================
+    // 至死方休（指定目标），死为目标死亡或进攻组死光/撤退，会调用战斗程序CommonSleepUntilTargetDead，reform默认为假
     function SleepUntilTargetDead takes unit target returns nothing
         call CommonSleepUntilTargetDead(target,false)
     endfunction
@@ -2418,34 +2459,39 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //============================================================================
+    // 设置AI是否需要购买飞艇，该设置默认是自动的
     function GetZeppelin takes nothing returns nothing
         if ready_for_zeppelin then
             set get_zeppelin = true
         endif
     endfunction
-    
+    PLAYER_STATE_FOOD_CAP_CEILING
     //============================================================================
-    // 当前AI玩家的人口使用量
+    // 获取当前AI玩家的已用人口数
     function FoodUsed takes nothing returns integer
         return GetPlayerState(ai_player,PLAYER_STATE_RESOURCE_FOOD_USED)
     endfunction
     
     //============================================================================
+    // 获取当前AI玩家的最大人口数（默认为人口建筑提供的数量），默认为100
     function FoodCap takes nothing returns integer
         return GetPlayerState(ai_player,PLAYER_STATE_RESOURCE_FOOD_CAP)
     endfunction
     
     //============================================================================
+    // 获取当前AI玩家的可用人口数（人口建筑提供的人口数-已使用的人口数）
     function FoodSpace takes nothing returns integer
         return FoodCap() - FoodUsed()
     endfunction
     
     //============================================================================
+    // 获取当前AI玩家人口建筑提供的人口数量，已完成的人口建筑（默认为racial_farm）*该建筑提供的人口数 + 已完成的主城（base指定）*该建筑提供的人口数
     function FoodAvail takes integer base returns integer
         return GetFoodMade(racial_farm) * TownCount(racial_farm) + GetFoodMade(base) * TownCount(base)
     endfunction
     
     //============================================================================
+    // 训练进攻组单位
     function BuildAttackers takes nothing returns nothing
         local integer index = 0
         local integer unitid
@@ -2470,6 +2516,7 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //============================================================================
+    // 训练防御组单位
     function BuildDefenders takes nothing returns nothing
         local integer index = 0
         local integer unitid
@@ -2488,6 +2535,7 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //============================================================================
+    // 战役循环，自动运行战役默认的采集/建造/训练/研究指令
     function CampaignBasicsA takes nothing returns nothing
         local integer food_each = GetFoodMade(racial_farm)
         local integer on_wood
@@ -2535,6 +2583,7 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //============================================================================
+    // 战役基础，运行后调用战役循环
     function CampaignBasics takes nothing returns nothing
         call Sleep(1)
         call CampaignBasicsA()
@@ -2546,6 +2595,7 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //============================================================================
+    // 设置战役AI
     function CampaignAI takes integer farms, code heroes returns nothing
         if GetGameDifficulty() == MAP_DIFFICULTY_EASY then
             set difficulty = EASY
@@ -2590,6 +2640,7 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //============================================================================
+    // 取消建造，运行后取消正在建造/训练/研究的单位/科技
     function UnsummonAll takes nothing returns nothing
         local unit bldg
         loop
@@ -2603,6 +2654,7 @@ native DebugS               takes string str                            returns 
     //============================================================================
     //  SkillArrays
     //============================================================================
+    // 获取技能组，让英雄升级后根据 SetSkillArray 的顺序自动学习技能，该代码在1.30~1.31中因官方BUG无法运行，需要手动使用触发或魔改该代码修正
     function SkillArrays takes nothing returns integer
         local integer level = GetHeroLevelAI()
     
@@ -2622,6 +2674,7 @@ native DebugS               takes string str                            returns 
     //--------------------------------------------------------------------------------------------------
     //  SetSkillArray
     //--------------------------------------------------------------------------------------------------
+    // 设置3个英雄的技能学习顺序（index 为1/2/3，分别对应三个英雄），id为三个英雄的单位类型，默认只能设置10级
     function SetSkillArray takes integer index, integer id returns nothing
         local integer i = 1
     
@@ -2658,6 +2711,7 @@ native DebugS               takes string str                            returns 
     //============================================================================
     //  AwaitMeleeHeroes
     //============================================================================
+    // 等待二发英雄，当首发英雄完成训练/复活，且 【take_exp为真 或 二发英雄存在且完成训练/复活时】 退出休眠，否则一直休眠
     function AwaitMeleeHeroes takes nothing returns nothing
         if GetUnitCountDone(hero_id2) > 0 then
             set two_heroes = true
@@ -2671,6 +2725,7 @@ native DebugS               takes string str                            returns 
     //============================================================================
     //  PickMeleeHero 
     //============================================================================
+    // 设置对战英雄（含混乱之治和冰封王座），设置4个种族的默认英雄（不含中立）及本局随机顺序（首发，二发，三发），4族之外的种族默认为空，heroes[4]默认为冰封王座新加的英雄，不会出现在混乱之治中
     function PickMeleeHero takes race raceid returns integer
         local integer first
         local integer second

--- a/static/common.ai
+++ b/static/common.ai
@@ -91,41 +91,41 @@ native DebugS               takes string str                            returns 
     native SetCampaignAI        takes nothing                               returns nothing
     // 启用对战AI
     native SetMeleeAI           takes nothing                               returns nothing
-    // 允许优先攻击英雄
+    // 允许/禁止 优先攻击英雄
     native SetTargetHeroes      takes boolean state                         returns nothing
-    // 允许工人维修建筑
+    // 允许/禁止 工人维修建筑
     native SetPeonsRepair       takes boolean state                         returns nothing
-    // 启用随机进攻路径
+    // 启用/禁用 随机进攻路径
     native SetRandomPaths       takes boolean state                         returns nothing
-    // 启用保护真人盟友
+    // 启用/禁用 保护真人盟友
     native SetDefendPlayer      takes boolean state                         returns nothing
-    // 允许英雄在受伤严重或遭受攻击时尝试逃跑
+    // 允许/禁止 英雄在受伤严重或遭受攻击时尝试逃跑
     native SetHeroesFlee        takes boolean state                         returns nothing
-    // 允许英雄购买物品
+    // 允许/禁止 英雄购买物品
     native SetHeroesBuyItems    takes boolean state                         returns nothing
-    // 没有怜悯（在敌人较弱或弱势时进攻）
+    // 启用/禁用 没有怜悯（在敌人较弱或弱势时进攻）
     native SetWatchMegaTargets  takes boolean state                         returns nothing
-    // 受伤单位（血量50%以下）不编入攻击组
+    // 启用/禁用 受伤单位（血量50%以下）不编入攻击组
     native SetIgnoreInjured     takes boolean state                         returns nothing
-    // 允许英雄拾取物品
+    // 允许/禁止 英雄拾取物品
     native SetHeroesTakeItems   takes boolean state                         returns nothing
-    // 允许单位逃跑
+    // 允许/禁止 单位逃跑
     native SetUnitsFlee         takes boolean state                         returns nothing
-    // 允许攻击组逃跑
+    // 允许/禁止 攻击组逃跑
     native SetGroupsFlee        takes boolean state                         returns nothing
-    // 启用慢速采矿（每次采集1金）
+    // 启用/禁用 慢速采矿（每次采集1金）
     native SetSlowChopping      takes boolean state                         returns nothing
-    // 允许变更主基地
+    // 允许/禁止 变更主基地
     native SetCaptainChanges    takes boolean allow                         returns nothing
-    // 启用主动攻击敌人基地
+    // 启用/禁用 主动攻击敌人基地
     native SetSmartArtillery    takes boolean state                         returns nothing
     // 防守单位被杀后，AI的补充次数
     native SetReplacementCount  takes integer qty                           returns nothing
-    // 允许受伤单位回主基地或生命之泉疗伤
+    // 允许/禁止 受伤单位回主基地或生命之泉疗伤
     native GroupTimedLife       takes boolean allow                         returns nothing
-    // 允许从攻击组中移除受伤单位（血量50%以下）
+    // 从攻击组中移除受伤单位（血量50%以下）
     native RemoveInjuries       takes nothing                               returns nothing
-    // 从攻击组中移除攻城单位（默认攻击类型为攻城的单位）
+    // 从攻击组中移除攻城单位（默认攻击类型为 攻城 的单位）
     native RemoveSiege          takes nothing                               returns nothing
     // 初始化攻击组
     native InitAssault          takes nothing                               returns nothing
@@ -162,9 +162,9 @@ native DebugS               takes string str                            returns 
     native SuicidePlayer        takes player id, boolean check_full         returns boolean
     // 检测自杀式攻击组是否满足指定条件（指定玩家），该指令被暴雪用于战役AI
     native SuicidePlayerUnits   takes player id, boolean check_full         returns boolean
-    // 攻击组是否在战斗
+    // 攻击组是否正在战斗
     native CaptainInCombat      takes boolean attack_captain                returns boolean
-    // 指定单位是否属于防御塔
+    // 指定单位是否有防御塔保护
     native IsTowered            takes unit target                           returns boolean
     // 清理上一次的AI采集工人分配设置，暴雪在每次运行 HarvestGold 和 HarvestWood 前都进行了清理，但清理后AI可能会交换多个基地之间的农民，比如让A矿的农民去B矿工作，反之亦然
     native ClearHarvestAI       takes nothing                               returns nothing
@@ -174,11 +174,11 @@ native DebugS               takes string str                            returns 
     native HarvestWood          takes integer town, integer peons           returns nothing
     // 获取开分基地的工人，系统会随机返回一个工人给AI，但可能返回null，如果AI有盟友，返回null的概率似乎会增加，如果是暗夜，建议另行判断工人是否在金矿内（是否运输单位），因为AI不会命令其离开金矿
     native GetExpansionPeon     takes nothing                               returns unit
-    // 停止收集
+    // 停止聚集，在初始化时自动调用，且必须调用（默认自动调用，无需理会），调用后，被训练的单位才会执行防守命令，否则只会在训练他们的建筑附近
     native StopGathering        takes nothing                               returns nothing
     // 在指定坐标增加指定类型的防守单位
     native AddGuardPost         takes integer id, real x, real y            returns nothing
-    // 补满防守岗位
+    // 填补防守岗位（即时），当一个单位被杀后，AI会立即训练一个同类型单位填补其空位
     native FillGuardPosts       takes nothing                               returns nothing
     // 返回防守岗位
     native ReturnGuardPosts     takes nothing                               returns nothing
@@ -368,11 +368,11 @@ native DebugS               takes string str                            returns 
         // human buildings
         // 狮鹫笼
         constant integer AVIARY             = 'hgra'
-        // 兵营
+        // 兵营（人族）
         constant integer BARRACKS           = 'hbar'
         // 铁匠铺
         constant integer BLACKSMITH         = 'hbla'
-        // 炮塔
+        // 炮塔（人族）
         constant integer CANNON_TOWER       = 'hctw'
         // 城堡（人族三本基地）
         constant integer CASTLE             = 'hcas'
@@ -380,7 +380,7 @@ native DebugS               takes string str                            returns 
         constant integer CHURCH             = 'htws'
         // 圣塔（编辑器无此单位 'htws'）
         constant integer MAGE_TOWER         =  CHURCH
-        // 防御塔
+        // 防御塔（人族）
         constant integer GUARD_TOWER        = 'hgtw'
         // 农场
         constant integer HOUSE              = 'hhou'
@@ -402,7 +402,7 @@ native DebugS               takes string str                            returns 
         constant integer WORKSHOP           = 'harm'
         // 神秘宝藏室
         constant integer ARCANE_VAULT       = 'hvlt'
-        // 神秘之塔
+        // 神秘之塔（人族）
         constant integer ARCANE_TOWER       = 'hatw'
     
         // human upgrades
@@ -542,7 +542,7 @@ native DebugS               takes string str                            returns 
         // orc buildings
         // 风暴祭坛
         constant integer ORC_ALTAR          = 'oalt'
-        // 兵营
+        // 兵营（兽族）
         constant integer ORC_BARRACKS       = 'obar'
         // 兽栏
         constant integer BESTIARY           = 'obea'
@@ -582,7 +582,7 @@ native DebugS               takes string str                            returns 
         constant integer UPG_ORC_BERSERK    = 'Robs'
         // 粉碎伤害强化
         constant integer UPG_ORC_PULVERIZE  = 'Rows'
-        // 诱捕
+        // 诱捕（兽族）
         constant integer UPG_ORC_ENSNARE    = 'Roen'
         // 毒矛
         constant integer UPG_ORC_VENOM      = 'Rovs'
@@ -596,13 +596,13 @@ native DebugS               takes string str                            returns 
         constant integer UPG_ORC_BURROWS    = 'Rorb'
         // 巨魔再生
         constant integer UPG_ORC_REGEN      = 'Rotr'
-        // 火油瓶
+        // 火油瓶（兽族）
         constant integer UPG_ORC_FIRE       = 'Rolf'
         // 灵魂行者专家级训练
         constant integer UPG_ORC_SWALKER    = 'Rowt'
         // 狂战士升级
         constant integer UPG_ORC_BERSERKER  = 'Robk'
-        // 燃油
+        // 燃油（兽族）
         constant integer UPG_ORC_NAPTHA     = 'Robf'
         // 混乱
         constant integer UPG_ORC_CHAOS      = 'Roch'
@@ -752,7 +752,7 @@ native DebugS               takes string str                            returns 
         constant integer NECROPOLIS_3       = 'unp2'    // full upgrade
         // 献祭深渊
         constant integer SAC_PIT            = 'usap'
-        // 地穴
+        // 地穴（不死族兵营）
         constant integer CRYPT              = 'usep'
         // 屠宰场
         constant integer SLAUGHTERHOUSE     = 'uslh'
@@ -790,7 +790,7 @@ native DebugS               takes string str                            returns 
         constant integer UPG_NECROS         = 'Rune'
         // 女妖专家级训练
         constant integer UPG_BANSHEE        = 'Ruba'
-        // 怀疑是背包（'Rupm'），但此处写成'Rump'
+        // 编辑器无此科技，怀疑是背包（'Rupm'），但此处写成'Rump'
         constant integer UPG_MEAT_WAGON     = 'Rump'
         // 冰冻吐息
         constant integer UPG_WYRM_BREATH    = 'Rufb'
@@ -872,11 +872,11 @@ native DebugS               takes string str                            returns 
         constant integer TRUESHOT           = 'AEar'
         // 技能 闪现（守望者）
         constant integer BLINK              = 'AEbl'
-        // 技能 刀扇
+        // 技能 刀扇（守望者）
         constant integer FAN_KNIVES         = 'AEfk'
-        // 技能 暗影突袭
+        // 技能 暗影突袭（守望者）
         constant integer SHADOW_TOUCH       = 'AEsh'
-        // 技能 复仇
+        // 技能 复仇（守望者）
         constant integer VENGEANCE          = 'AEsv'
     
         // elf units
@@ -948,7 +948,6 @@ native DebugS               takes string str                            returns 
         constant integer ANCIENT_PROTECT    = 'etrp'
         // 长者祭坛
         constant integer ELF_ALTAR          = 'eate'
-        constant integer BEAR_DEN           = 'edol'
         // 熊窝（编辑器无此单位 ）
         constant integer BEAR_DEN           = 'edol'
         // 奇美拉栖木
@@ -1009,7 +1008,7 @@ native DebugS               takes string str                            returns 
         constant integer UPG_DRUID_TALON    = 'Redt'
         // 利爪德鲁伊专家级训练
         constant integer UPG_DRUID_CLAW     = 'Redc'
-        // 驱除魔法
+        // 驱除魔法（暗夜）
         constant integer UPG_ABOLISH        = 'Resi'
         // 腐蚀吐息
         constant integer UPG_CHIM_ACID      = 'Recb'
@@ -1085,9 +1084,9 @@ native DebugS               takes string str                            returns 
         constant integer NAGA_WITCH         = 'nnsw'
         // 飞蛇
         constant integer NAGA_SERPENT       = 'nwgs' 
-        // 龙龟
+        // 龙龟（娜迦族）
         constant integer NAGA_HYDRA         = 'nhyc'    
-        // 深海鱼人奴隶
+        // 深海鱼人奴隶（娜迦族）
         constant integer NAGA_SLAVE         = 'nmpe'        // peon
         // 毒鳍龙
         constant integer NAGA_SNAP_DRAGON   =  NAGA_DRAGON  // weak ranged
@@ -1097,9 +1096,9 @@ native DebugS               takes string str                            returns 
         constant integer NAGA_SIREN         =  NAGA_WITCH   // caster
         // 纳迦侍从
         constant integer NAGA_MYRMIDON      = 'nmyr'        // knight
-        // 深海鱼人掠夺者
+        // 深海鱼人掠夺者（娜迦族）
         constant integer NAGA_REAVER        = 'nnmg'        // footman
-        // 龙龟
+        // 龙龟（娜迦族）
         constant integer NAGA_TURTLE        =  NAGA_HYDRA   // siege
         // 纳迦皇家卫兵
         constant integer NAGA_ROYAL         = 'nnrg'        // royal guard
@@ -1123,11 +1122,11 @@ native DebugS               takes string str                            returns 
         constant integer UPG_NAGA_ARMOR     = 'Rnam'
         // 珊瑚锋刃
         constant integer UPG_NAGA_ATTACK    = 'Rnat'
-        // 驱除魔法
+        // 驱除魔法（娜迦族）
         constant integer UPG_NAGA_ABOLISH   = 'Rnsi'
         // 纳迦海妖专家级训练
         constant integer UPG_SIREN          = 'Rnsw'
-        // 诱捕
+        // 诱捕（娜迦族）
         constant integer UPG_NAGA_ENSNARE   = 'Rnen'
     
     

--- a/static/common.ai
+++ b/static/common.ai
@@ -42,13 +42,16 @@ native DebugS               takes string str                            returns 
     // 获取指定单位/建筑/科技类型的训练/建造/研究时间
     native GetUnitBuildTime     takes integer unitid                        returns integer
     
-    // 拥有的金矿数，会检查开始点附近所有矿，而不是只查闹鬼金矿
+    // 拥有的金矿数
+    // 会检查开始点附近所有矿，而不是只查闹鬼金矿
     // 如果AI开始点有多个未被其他玩家占据的矿，可能会导致亡灵无法正常采矿，因为HarvestGold（0，n）指向到的是该函数在指定基地返回的第一座矿，如果返回的非闹鬼金矿，侍僧就无法采矿
     native GetMinesOwned        takes nothing                               returns integer
-    // 拥有的所有金矿的金钱数量，会检查开始点所有矿，而不是只查闹鬼金矿，并返回第一座矿的金钱数
+    // 拥有的所有金矿的金钱数量，并返回第一座矿的金钱数
+    // 会检查开始点所有矿，而不是只查闹鬼金矿
     // 如果开始点有多个金矿，且金钱数不同，会导致统计值偏差
     native GetGoldOwned         takes nothing                               returns integer
     // 有金矿的基地编号，如果多个基地都有金矿，则返回最小编号
+    // 只检查主城，如果亡灵开矿不造主城，AI会视为无基地
     // 配合TownHasMine检查当前哪座基地有矿时，可以直接获取最小编号，并从该编号查起，避免分基地过多时的逐个查询
     native TownWithMine         takes nothing                               returns integer
     // 指定编号的基地是否有金矿
@@ -1190,27 +1193,43 @@ native DebugS               takes string str                            returns 
     
     
         //--------------------------------------------------------------------
+        // 1分钟
         constant integer M1                 =    60
+        // 2分钟
         constant integer M2                 =  2*60
+        // 3分钟
         constant integer M3                 =  3*60
+        // 4分钟
         constant integer M4                 =  4*60
+        // 5分钟
         constant integer M5                 =  5*60
+        // 6分钟
         constant integer M6                 =  6*60
+        // 7分钟
         constant integer M7                 =  7*60
+        // 8分钟
         constant integer M8                 =  8*60
+        // 9分钟
         constant integer M9                 =  9*60
+        // 10分钟
         constant integer M10                = 10*60
+        // 11分钟
         constant integer M11                = 11*60
+        // 12分钟
         constant integer M12                = 12*60
+        // 13分钟
         constant integer M13                = 13*60
+        // 14分钟
         constant integer M14                = 14*60
+        // 15分钟
         constant integer M15                = 15*60
     
         constant integer EASY               = 1
         constant integer NORMAL             = 2
         constant integer HARD               = 3
+        // 该难度未使用，困难/疯狂难度为HARD
         constant integer INSANE             = 4 // not used
-    
+
         constant integer MELEE_NEWBIE       = 1
         constant integer MELEE_NORMAL       = 2
         constant integer MELEE_INSANE       = 3
@@ -1220,12 +1239,17 @@ native DebugS               takes string str                            returns 
         constant integer DEFENSE_CAPTAIN    = 2
         // 攻击组及防御组
         constant integer BOTH_CAPTAINS      = 3
-    
+        // 建造类型 单位或建筑，用于训练/建造/研究
         constant integer BUILD_UNIT         = 1
+        // 建造类型 科技，用于训练/建造/研究
         constant integer BUILD_UPGRADE      = 2
+        // 建造类型 分基地（分矿），用于训练/建造/研究
         constant integer BUILD_EXPAND       = 3
-    
+        // 建议用于升级二本主基地科技，默认值50
+        // 暴雪未使用该变量
         constant integer UPKEEP_TIER1       = 50
+        // 建议用于升级三本主基地科技，默认值80
+        // 暴雪未使用该变量
         constant integer UPKEEP_TIER2       = 80
     
         //--------------------------------------------------------------------
@@ -1233,8 +1257,15 @@ native DebugS               takes string str                            returns 
         player  ai_player
         // 等待时间
         integer sleep_seconds
+        // 黄金总计
+        // 用于计算当前黄金数量在训练/建造/研究指定（数量的）单位/建筑/科技后，还剩多少钱
         integer total_gold              = 0
+        // 木材总计
+        // 用于计算当前木材数量在训练/建造/研究指定（数量的）单位/建筑/科技后，还剩多少木
         integer total_wood              = 0
+        // 黄金预存数，使用后AI会一直保留该数量的黄金不使用
+        // 该值默认为0，AI不会使用，需要自行赋值，在完成指定的训练/建造/研究后请即使清零，否则AI会一直保持这笔存款
+        // 如果需要存木，请自行在 OneBuildLoop 添加
         integer gold_buffer             = 0 // usually for potion money
         // 难度
         integer difficulty              = NORMAL
@@ -1257,21 +1288,27 @@ native DebugS               takes string str                            returns 
         integer array skills3
         // 最大英雄等级，默认为0，会在英雄升级后自动调整，上限由平衡常数决定
         integer max_hero_level          = 0
-    
+        // 攻击组数组 单位数量，每种单位使用1个引索
         integer array harass_qty
+        // 攻击组数组 单位数量最大值，每种单位使用1个引索
         integer array harass_max
+        // 攻击组数组 单位类型，每种单位使用1个引索
         integer array harass_units
         // 攻击组数列，当前已记录到攻击组的单位类型，在下次初始化前，AI会使用这些单位类型进行攻击
         integer harass_length           = 0
-    
+        // 防御组数组 单位数量，每种单位使用1个引索
         integer array defense_qty
+        // 防御组数组 单位类型，每种单位使用1个引索
         integer array defense_units
         // 防御组数列，当前已记录到防御组的单位类型，在下次初始化前，AI会使用这些单位类型进行防御
         integer defense_length          = 0
-    
+        // 训练/建造/研究数组 建造数量，每种单位/建筑/科技使用1个引索
         integer array build_qty
+        // 训练/建造/研究数组 建造类型（单位/建筑，科技，分基地），每种单位/建筑/科技使用1个引索
         integer array build_type
+        // 训练/建造/研究数组 单位/建筑/科技类型（具体的单位ID），每种单位/建筑/科技使用1个引索
         integer array build_item
+        // 训练/建造/研究数组 建造位置（在哪个主/分基地建造），每种单位/建筑/科技使用1个引索
         integer array build_town
         // 建造组数列，当前已记录到建造队列的单位/建筑/科技类型，在下次初始化前，AI会依次训练/建造/研究
         integer build_length            = 0
@@ -1281,39 +1318,39 @@ native DebugS               takes string str                            returns 
         integer campaign_wood_peons     = 3
         // 战役等待时间，默认5秒
         integer campaign_basics_speed   = 5
-        // （中立敌对玩家）最小野怪等级，默认-1
+        // 最小野怪（中立敌对玩家单位）等级，默认-1
         integer min_creeps              = -1
-        // （中立敌对玩家）最大野怪等级，默认-1
+        // 最大野怪（中立敌对玩家单位）等级，默认-1
         integer max_creeps              = -1
-        // 是否允许AI在第一座基地采集黄金/木材
+        // 是否允许AI在第一座基地，以采集黄金/木材
         boolean harvest_town1           = true
-        // 是否允许AI在第二座基地采集黄金/木材
+        // 是否允许AI在第二座基地，以采集黄金/木材
         boolean harvest_town2           = true
-        // 是否允许AI在第三座基地采集黄金/木材
+        // 是否允许AI在第三座基地，以采集黄金/木材
         boolean harvest_town3           = true
-        // 战役人口模式
+        // 战役人口（建筑）建造模式
         boolean do_campaign_farms       = true
         // 二发英雄存在
         boolean two_heroes              = false
-        // 是否允许获取（中立敌对玩家）飞行野怪，默认不允许
+        // 是否允许获取飞行野怪（中立敌对玩家单位），默认不允许
         boolean allow_air_creeps        = false
-        // 是否开分矿
+        // 是否攻击分矿的野怪（中立敌对玩家单位），默认允许
         boolean take_exp                = false
         // 多用于退出自杀等待
         boolean allow_signal_abort      = false
-        // 是否完成飞艇购买
+        // 是否已完成飞艇购买
         boolean ready_for_zeppelin      = true
-        // 是否购买飞艇，默认为否
+        // 是否允许购买飞艇，默认为否
         boolean get_zeppelin            = false
         // 是否建造战役进攻单位
         boolean build_campaign_attackers = true
-    
+        // 可用于调测
         boolean do_debug_cheats         = false
         // 是否在游戏中显示 Trace 文本（开启后可用于调试，只需要调用对应的 Trace 发送指定文本即可）
         boolean trace_on                = true
         // 是否需要飞艇空投
         boolean zep_next_wave           = false
-        // 是否允许 进攻组组建超时
+        // 是否允许进攻组组建超时
         boolean form_group_timeouts     = true
     endglobals
     
@@ -2502,6 +2539,7 @@ native DebugS               takes string str                            returns 
     // 设置各波次进攻（指定玩家和坐标），默认用于自杀式攻击
     // @param standard为真时会额外判断退出条件且不进攻指定坐标，为假时会进攻指定坐标
     // @param bldgs当standard为真时，若bldgs为真，会额外判断退出条件 SuicidePlayer(p,sleep_seconds >= -60)，反之额外判断退出条件 SuicidePlayerUnits(p,sleep_seconds >= -60)
+    // @param seconds等待攻击组组建时间，若在指定时间后攻击组仍未完成组建，则不会进攻
     function CommonSuicideOnPlayer takes boolean standard, boolean bldgs, integer seconds, player p, integer x, integer y returns nothing
         local integer save_peons
     

--- a/static/common.ai
+++ b/static/common.ai
@@ -24,11 +24,11 @@ native DebugS               takes string str                            returns 
     // 英雄升级技能相关函数 获取英雄等级
     native GetHeroLevelAI       takes nothing                               returns integer
     
-    // 获取AI玩家指定类型单位/科技的数量，统计训练/建造/研究指定/研究中及已训练/建造/研究指定/研究完成
+    // 获取AI玩家指定类型单位的数量/科技的等级，含训练/建造/研究中及已训练/建造/研究完成
     native GetUnitCount         takes integer unitid                        returns integer
-    // 获取指定玩家的该类型单位的数量，统计训练/建造/研究指定/研究中及已训练/建造/研究指定/研究完成
+    // 获取指定玩家的该类型单位的数量/科技的等级，含训练/建造/研究中及已训练/建造/研究完成
     native GetPlayerUnitTypeCount takes player p, integer unitid            returns integer
-    // 获取AI玩家指定类型单位的数量，仅统计已训练/建造/研究指定/研究完成
+    // 获取AI玩家指定类型单位的数量/科技的等级，仅统计已训练/建造/研究完成
     native GetUnitCountDone     takes integer unitid                        returns integer
     // 指定基地对应类型的单位数，0为第一个基地
     native GetTownUnitCount     takes integer id, integer tn, boolean dn    returns integer
@@ -36,7 +36,7 @@ native DebugS               takes string str                            returns 
     native GetUnitGoldCost      takes integer unitid                        returns integer
     // 训练/建造/研究指定/研究一个指定类型单位/科技需要消耗的木材数量
     native GetUnitWoodCost      takes integer unitid                        returns integer
-    // 获取指定单位/科技类型的建造/训练/研究时间
+    // 获取指定单位/科技类型的训练/建造/研究时间
     native GetUnitBuildTime     takes integer unitid                        returns integer
     
     // 拥有的金矿数，对于亡灵，该函数会检查开始点所有矿，而不是只查闹鬼金矿，如果AI开始点有多个未被其他玩家占据的矿，可能会导致亡灵无法正常采矿，因为HarvestGold（0，n）指向到的是该函数在指定基地返回的第一座矿，如果返回的非闹鬼金矿，侍僧就无法采矿
@@ -62,17 +62,17 @@ native DebugS               takes string str                            returns 
     native GetMegaTarget        takes nothing                               returns unit
     // 获取指定玩家正在训练/建造的单位
     native GetBuilding          takes player p                              returns unit
-    // 获得敌人进攻组强度
+    // 获得敌人攻击组强度
     native GetEnemyPower        takes nothing                               returns integer
     // 设置盟友当前的攻击目标（仅对AI盟友生效）
     native SetAllianceTarget    takes unit id                               returns nothing
     // 获取盟友当前的攻击目标
     native GetAllianceTarget    takes nothing                               returns unit
-    // 命令训练/建造/研究指定/研究单位/科技(数量,单位类型,基地)
+    // 命令训练/建造/研究指定/研究单位/科技(指定数量,单位类型,基地)
     native SetProduce           takes integer qty, integer id, integer town returns boolean
     // 取消/反召唤指定单位（亡灵卖建筑），单位正在建造/训练会取消，建造完成时可能会被卖掉
     native Unsummon             takes unit unitid                           returns nothing
-    // 建造扩张点/分基地（指定工人类型和建筑类型）
+    // 建造扩张点/分基地（指定工人（具体到某个单位）和城镇单位的类型）
     native SetExpansion         takes unit peon, integer id                 returns boolean
     // 升级指定科技
     native SetUpgrade           takes integer id                            returns boolean
@@ -105,13 +105,13 @@ native DebugS               takes string str                            returns 
     native SetHeroesBuyItems    takes boolean state                         returns nothing
     // 没有怜悯（在敌人较弱或弱势时进攻）
     native SetWatchMegaTargets  takes boolean state                         returns nothing
-    // 受伤单位（血量50%以下）不编入进攻组
+    // 受伤单位（血量50%以下）不编入攻击组
     native SetIgnoreInjured     takes boolean state                         returns nothing
     // 允许英雄拾取物品
     native SetHeroesTakeItems   takes boolean state                         returns nothing
     // 允许单位逃跑
     native SetUnitsFlee         takes boolean state                         returns nothing
-    // 允许进攻组逃跑
+    // 允许攻击组逃跑
     native SetGroupsFlee        takes boolean state                         returns nothing
     // 启用慢速采矿（每次采集1金）
     native SetSlowChopping      takes boolean state                         returns nothing
@@ -123,9 +123,9 @@ native DebugS               takes string str                            returns 
     native SetReplacementCount  takes integer qty                           returns nothing
     // 允许受伤单位回主基地或生命之泉疗伤
     native GroupTimedLife       takes boolean allow                         returns nothing
-    // 允许从进攻组中移除受伤单位（血量50%以下）
+    // 允许从攻击组中移除受伤单位（血量50%以下）
     native RemoveInjuries       takes nothing                               returns nothing
-    // 从进攻组中移除攻城单位（默认攻击类型为攻城的单位）
+    // 从攻击组中移除攻城单位（默认攻击类型为攻城的单位）
     native RemoveSiege          takes nothing                               returns nothing
     // 初始化攻击组
     native InitAssault          takes nothing                               returns nothing
@@ -142,7 +142,7 @@ native DebugS               takes string str                            returns 
     native WaitGetEnemyBase     takes nothing                               returns boolean
     // 获取敌人主基地的单位
     native GetEnemyBase         takes nothing                               returns unit
-    // 下一个扩张点是否存在具有威胁的单位
+    // 下一个扩张点是否存在具有威胁的单位（只检测中立敌对的单位）
     native GetExpansionFoe      takes nothing                               returns unit
     // 获取敌人分基地
     native GetEnemyExpansion    takes nothing                               returns unit
@@ -162,7 +162,7 @@ native DebugS               takes string str                            returns 
     native SuicidePlayer        takes player id, boolean check_full         returns boolean
     // 检测自杀攻击组是否满足指定条件（指定玩家），自杀指令被暴雪用于战役AI
     native SuicidePlayerUnits   takes player id, boolean check_full         returns boolean
-    // 进攻组是否在战斗
+    // 攻击组是否在战斗
     native CaptainInCombat      takes boolean attack_captain                returns boolean
     // 指定单位是否属于防御塔
     native IsTowered            takes unit target                           returns boolean
@@ -174,27 +174,27 @@ native DebugS               takes string str                            returns 
     native HarvestWood          takes integer town, integer peons           returns nothing
     // 获取开分基地的工人，系统会随机返回一个工人给AI，但可能返回null，如果AI有盟友，返回null的概率似乎会增加，如果是暗夜，建议另行判断工人是否在金矿内（是否运输单位），因为AI不会命令其离开金矿
     native GetExpansionPeon     takes nothing                               returns unit
-    // 停止聚集
+    // 停止收集
     native StopGathering        takes nothing                               returns nothing
     // 在指定坐标增加指定类型的防守单位
     native AddGuardPost         takes integer id, real x, real y            returns nothing
-    // 填满防守岗位
+    // 补满防守岗位
     native FillGuardPosts       takes nothing                               returns nothing
     // 返回防守岗位
     native ReturnGuardPosts     takes nothing                               returns nothing
     // 创建攻击组
     native CreateCaptains       takes nothing                               returns nothing
-    // 设置指定组（进攻组、防守组、两组一起执行）回家后的聚集坐标，AI默认把单位聚集在主基地的采矿路线上，应该就是这个坐标
+    // 设置指定组（攻击组、防守组、两组一起执行）回家后的集结坐标，AI默认把单位聚在主基地的采矿路线上，应该就是这个坐标
     native SetCaptainHome       takes integer which, real x, real y         returns nothing
-    // 命令攻击组复位
+    // 命令攻击组复位（回到 SetCaptainHome 的集结点）
     native ResetCaptainLocs     takes nothing                               returns nothing
     // 转移基地到指定坐标
     native ShiftTownSpot        takes real x, real y                        returns nothing
-    // 让攻击组使用传送到指定坐标
+    // 传送攻击组到指定坐标
     native TeleportCaptain      takes real x, real y                        returns nothing
-    // 清除攻击组当前攻击的目标
+    // 清除攻击组当前的攻击目标
     native ClearCaptainTargets  takes nothing                               returns nothing
-    // 让攻击组攻击到指定坐标
+    // 让攻击组攻击到指定坐标，可配合 DisablePathing 控制是否允许攻击组在路上战斗（移动攻击）
     native CaptainAttack        takes real x, real y                        returns nothing
     // 让攻击组攻击玩家的单位
     native CaptainVsUnits       takes player id                             returns nothing
@@ -202,29 +202,29 @@ native DebugS               takes string str                            returns 
     native CaptainVsPlayer      takes player id                             returns nothing
     // 让攻击组回家
     native CaptainGoHome        takes nothing                               returns nothing
-    // 进攻组是否在家
+    // 攻击组是否在家
     native CaptainIsHome        takes nothing                               returns boolean
-    // 进攻组是否完整
+    // 攻击组是否完整
     native CaptainIsFull        takes nothing                               returns boolean
-    // 进攻组是否为空
+    // 攻击组是否为空
     native CaptainIsEmpty       takes nothing                               returns boolean
-    // 进攻组规模
+    // 攻击组规模，数值越高，规模越大
     native CaptainGroupSize     takes nothing                               returns integer
     // 攻击组准备情况，似乎是百分制，数值越高，准备越充分
     native CaptainReadiness     takes nothing                               returns integer
-    // 进攻组是否在撤退
+    // 攻击组是否在撤退
     native CaptainRetreating    takes nothing                               returns boolean
-    // 进攻组整体生命值，似乎是百分制且转百分比
+    // 攻击组整体生命值，似乎是百分制且转百分比
     native CaptainReadinessHP   takes nothing                               returns integer
-    // 进攻组整体魔法值，似乎是百分制且转百分比
+    // 攻击组整体魔法值，似乎是百分制且转百分比
     native CaptainReadinessMa   takes nothing                               returns integer
-    // 进攻组是否到达目的地
+    // 攻击组是否到达目的地
     native CaptainAtGoal        takes nothing                               returns boolean
     // 地图上是否还有中立敌对玩家的单位，即野怪，在1.29及以上版本中，中立敌对玩家为玩家24，在以下版本则为12
     native CreepsOnMap          takes nothing                               returns boolean
-    // 在进攻组添加自杀单位，指定单位类型和数量，自杀指令被暴雪用于战役AI
+    // 在攻击组添加自杀单位，指定单位类型和数量，自杀指令被暴雪用于战役AI
     native SuicideUnit          takes integer count, integer unitid         returns nothing
-    // 在进攻组添加自杀单位，指定单位类型、数量和玩家，自杀指令被暴雪用于战役AI
+    // 在攻击组添加自杀单位，指定单位类型、数量和玩家，自杀指令被暴雪用于战役AI
     native SuicideUnitEx        takes integer ct, integer uid, integer pid  returns nothing
     // 开始进程，AI脚本最多可运行6条进程，最多可有6条进程同时运行（包含默认线程，自行添加之前请检查已调用的默认线程数量），不同进程之间互不干涉（异步），可共用全局变量，但在一条进程运行到读取变量的代码时，可能因变量已在几十秒前被另一个变量改写，造成滞后的假象
     native StartThread          takes code func                             returns nothing
@@ -238,7 +238,7 @@ native DebugS               takes string str                            returns 
     native IgnoredUnits         takes integer unitid                        returns integer
     // AI的任意基地被攻击，与小地图警报的触发条件相同，但只针对基地
     native TownThreatened       takes nothing                               returns boolean
-    // 是否允许在未到达目的地前（进攻组/防御组移动过程中）战斗
+    // 是否允许在未到达目的地前（攻击组/防御组移动过程中）战斗
     native DisablePathing       takes nothing                               returns nothing
     // 获得命令队列中的指令条数
     native SetAmphibious        takes nothing                               returns nothing
@@ -264,108 +264,193 @@ native DebugS               takes string str                            returns 
         //--------------------------------------------------------------------
     
         // human heroes
+        // 大法师
         constant integer ARCHMAGE           = 'Hamg'
+        // 圣骑士
         constant integer PALADIN            = 'Hpal'
+        // 山丘之王
         constant integer MTN_KING           = 'Hmkg'
+        // 血魔法师
         constant integer BLOOD_MAGE         = 'Hblm'
     
         // human hero abilities
+        // 技能 天神下凡（山丘之王）
         constant integer AVATAR             = 'AHav'
+        // 技能 猛击（山丘之王）
         constant integer BASH               = 'AHbh'
+        // 技能 风暴之锤（山丘之王）
         constant integer THUNDER_BOLT       = 'AHtb'
+        // 技能 雷霆一击（山丘之王）
         constant integer THUNDER_CLAP       = 'AHtc'
-    
+        // 技能 虔诚光环（圣骑士）
         constant integer DEVOTION_AURA      = 'AHad'
+        // 技能 圣盾术（圣骑士）
         constant integer DIVINE_SHIELD      = 'AHds'
+        // 技能 圣光术（圣骑士）
         constant integer HOLY_BOLT          = 'AHhb'
+        // 技能 复活术（圣骑士）
         constant integer RESURRECTION       = 'AHre'
-    
+        // 技能 暴风雪（大法师）
         constant integer BLIZZARD           = 'AHbz'
+        // 技能 辉煌光环（大法师）
         constant integer BRILLIANCE_AURA    = 'AHab'
+        // 技能 群体传送（大法师）
         constant integer MASS_TELEPORT      = 'AHmt'
+        // 技能 水元素（大法师）
         constant integer WATER_ELEMENTAL    = 'AHwe'
-    
+        // 放逐（血法）
         constant integer BANISH             = 'AHbn'
+        // 技能 烈焰风暴（血法）
         constant integer FLAME_STRIKE       = 'AHfs'
+        // 技能 火凤凰（血法）
         constant integer SUMMON_PHOENIX     = 'AHpx'
+        // 技能 法力虹吸（血法）
         constant integer SIPHON_MANA        = 'AHdr'
     
         // special human heroes
+        // 吉安娜
         constant integer JAINA              = 'Hjai'
+        // 穆拉丁·铜须
         constant integer MURADIN            = 'Hmbr'
+        // 加里瑟斯
         constant integer GARITHOS           = 'Hlgr'
+        // 卡尔萨斯
         constant integer KAEL               = 'Hkal'
     
         // human units
+        // 矮人直升机
         constant integer COPTER             = 'hgyr'
+        // 矮人直升机
         constant integer GYRO               =  COPTER
+        // 水元素
         constant integer ELEMENTAL          = 'hwat'
+        // 人族步兵
         constant integer FOOTMAN            = 'hfoo'
+        // 人族步兵
         constant integer FOOTMEN            =  FOOTMAN
+        // 狮鹫骑士
         constant integer GRYPHON            = 'hgry'
+        // 人族骑士
         constant integer KNIGHT             = 'hkni'
+        // 矮人迫机炮
         constant integer MORTAR             = 'hmtm'
+        // 农民
         constant integer PEASANT            = 'hpea'
+        // 牧师
         constant integer PRIEST             = 'hmpr'
+        // 矮人火枪手
         constant integer RIFLEMAN           = 'hrif'
+        // 矮人火枪手
         constant integer RIFLEMEN           =  RIFLEMAN
+        // 女巫
         constant integer SORCERESS          = 'hsor'
+        // 攻城坦克
         constant integer TANK               = 'hmtt'
+        // 攻城坦克
         constant integer STEAM_TANK         =  TANK
+        // 攻城坦克（弹幕升级）
         constant integer ROCKET_TANK        = 'hrtt'
+        // 民兵
         constant integer MILITIA            = 'hmil'
+        // 魔法破坏者（破法）
         constant integer SPELL_BREAKER      = 'hspt'
+        // 龙鹰骑士
         constant integer HUMAN_DRAGON_HAWK  = 'hdhw'
     
         // special human units
+        // 血精灵牧师
         constant integer BLOOD_PRIEST       = 'hbep'
+        // 血精灵女巫
         constant integer BLOOD_SORCERESS    = 'hbes'
+        // 血精灵工人
         constant integer BLOOD_PEASANT      = 'nhew'
     
         // human buildings
+        // 狮鹫笼
         constant integer AVIARY             = 'hgra'
+        // 兵营
         constant integer BARRACKS           = 'hbar'
+        // 铁匠铺
         constant integer BLACKSMITH         = 'hbla'
+        // 炮塔
         constant integer CANNON_TOWER       = 'hctw'
+        // 城堡（人族三本基地）
         constant integer CASTLE             = 'hcas'
+        // 圣塔（编辑器无此单位 'htws'）
         constant integer CHURCH             = 'htws'
+        // 圣塔（编辑器无此单位 'htws'）
         constant integer MAGE_TOWER         =  CHURCH
+        // 防御塔
         constant integer GUARD_TOWER        = 'hgtw'
+        // 农场
         constant integer HOUSE              = 'hhou'
+        // 国王祭坛
         constant integer HUMAN_ALTAR        = 'halt'
+        // 主城（人族二本基地）
         constant integer KEEP               = 'hkee'
+        // 伐木场
         constant integer LUMBER_MILL        = 'hlum'
+        // 神秘圣地
         constant integer SANCTUM            = 'hars'
+        // 神秘圣地
         constant integer ARCANE_SANCTUM     =  SANCTUM
+        // 城镇大厅（人族一本基地）
         constant integer TOWN_HALL          = 'htow'
+        // 哨塔
         constant integer WATCH_TOWER        = 'hwtw'
+        // 车间
         constant integer WORKSHOP           = 'harm'
+        // 神秘宝藏室
         constant integer ARCANE_VAULT       = 'hvlt'
+        // 神秘之塔
         constant integer ARCANE_TOWER       = 'hatw'
     
         // human upgrades
+        // 钢铁铸剑
         constant integer UPG_MELEE          = 'Rhme'
+        // 黑火药
         constant integer UPG_RANGED         = 'Rhra'
+        // 炮兵（编辑器无此科技 'Rhaa'）
         constant integer UPG_ARTILLERY      = 'Rhaa'
+        // 钢铁装甲
         constant integer UPG_ARMOR          = 'Rhar'
+        // 黄金（编辑器无此科技 'Rhmi'）
         constant integer UPG_GOLD           = 'Rhmi'
+        // 改良石工技术
         constant integer UPG_MASONRY        = 'Rhac'
+        // 控制魔法
         constant integer UPG_SIGHT          = 'Rhss'
+        // 防御
         constant integer UPG_DEFEND         = 'Rhde'
+        // 坐骑作战训练
         constant integer UPG_BREEDING       = 'Rhan'
+        // 牧师专家级训练
         constant integer UPG_PRAYING        = 'Rhpt'
+        // 女巫专家级训练
         constant integer UPG_SORCERY        = 'Rhst'
+        // 镶钉皮甲
         constant integer UPG_LEATHER        = 'Rhla'
+        // 长管火枪
         constant integer UPG_GUN_RANGE      = 'Rhri'
+        // 改良伐木技术
         constant integer UPG_WOOD           = 'Rhlh'
+        // 魔法岗哨
         constant integer UPG_SENTINEL       = 'Rhse'
+        // 散射（编辑器无此科技 'Rhsr'）
         constant integer UPG_SCATTER        = 'Rhsr'
+        // 飞行器炸弹
         constant integer UPG_BOMBS          = 'Rhgb'
+        // 风暴战锤
         constant integer UPG_HAMMERS        = 'Rhhb'
+        // 控制魔法
         constant integer UPG_CONT_MAGIC     = 'Rhss'
+        // 破片榴弹
         constant integer UPG_FRAGS          = 'Rhfs'
+        // 火箭弹幕
         constant integer UPG_TANK           = 'Rhrt'
+        // 对空炮机
         constant integer UPG_FLAK           = 'Rhfc'
+        // 迷雾之云
         constant integer UPG_CLOUD          = 'Rhcd'
     
         //--------------------------------------------------------------------
@@ -373,106 +458,187 @@ native DebugS               takes string str                            returns 
         //--------------------------------------------------------------------
     
         // orc heroes
+        // 剑圣
         constant integer BLADE_MASTER       = 'Obla'
+        // 先知
         constant integer FAR_SEER           = 'Ofar'
+        // 牛头人酋长
         constant integer TAUREN_CHIEF       = 'Otch'
+        // 暗影猎手
         constant integer SHADOW_HUNTER      = 'Oshd'
     
         // special orc heroes
+        // 格罗玛什·地狱咆哮
         constant integer GROM               = 'Ogrh'
+        // 萨尔
         constant integer THRALL             = 'Othr'
     
         // orc hero abilities
+        // 技能 致命一击（剑圣）
         constant integer CRITICAL_STRIKE    = 'AOcr'
+        // 技能 镜像（剑圣）
         constant integer MIRROR_IMAGE       = 'AOmi'
+        // 技能 剑刃风暴（剑圣）
         constant integer BLADE_STORM        = 'AOww'
+        // 技能 疾风步（剑圣）
         constant integer WIND_WALK          = 'AOwk'
-    
+        // 技能 闪电链（先知）
         constant integer CHAIN_LIGHTNING    = 'AOcl'
+        // 技能 地震术（先知）
         constant integer EARTHQUAKE         = 'AOeq'
+        // 技能 视界术（先知）
         constant integer FAR_SIGHT          = 'AOfs'
+        // 技能 野性之魂（先知）（招狼）
         constant integer SPIRIT_WOLF        = 'AOsf'
-    
+        // 技能 坚韧光环（牛头）
         constant integer ENDURANE_AURA      = 'AOae'
+        // 技能 重生（牛头）
         constant integer REINCARNATION      = 'AOre'
+        // 技能 技能 震荡波（牛头）
         constant integer SHOCKWAVE          = 'AOsh'
+        // 技能 战争践踏（牛头）
         constant integer WAR_STOMP          = 'AOws'
-    
+        // 技能 治疗波（暗影猎手）
         constant integer HEALING_WAVE       = 'AOhw'
+        // 技能 妖术（暗影猎手）
         constant integer HEX                = 'AOhx'
+        // 技能 毒蛇结界（暗影猎手）（蛇棒）
         constant integer SERPENT_WARD       = 'AOsw'
+        // 技能 巫毒狂舞（暗影猎手）（友军无敌）
         constant integer VOODOO             = 'AOvd'
     
         // orc units
+        // 兽族步兵（编辑器无此单位 'oang'）
         constant integer GUARDIAN           = 'oang'
+        // 投石车
         constant integer CATAPULT           = 'ocat'
+        // 巫医
         constant integer WITCH_DOCTOR       = 'odoc'
+        // 兽族步兵
         constant integer GRUNT              = 'ogru'
+        // 猎头者
         constant integer HEAD_HUNTER        = 'ohun'
+        // 狂战士（猎头升级）
         constant integer BERSERKER          = 'otbk'
+        // 科多兽
         constant integer KODO_BEAST         = 'okod'
+        // 苦工
         constant integer PEON               = 'opeo'
+        // 狼骑兵
         constant integer RAIDER             = 'orai'
+        // 萨满祭司
         constant integer SHAMAN             = 'oshm'
+        // 牛头人
         constant integer TAUREN             = 'otau'
+        // 驭风者
         constant integer WYVERN             = 'owyv'
+        // 蝙蝠骑士
         constant integer BATRIDER           = 'otbr'
+        // 灵魂行者
         constant integer SPIRIT_WALKER      = 'ospw'
+        // 灵魂行者（虚无形态）
         constant integer SPIRIT_WALKER_M    = 'ospm'
     
         // orc buildings
+        // 风暴祭坛
         constant integer ORC_ALTAR          = 'oalt'
+        // 兵营
         constant integer ORC_BARRACKS       = 'obar'
+        // 兽栏
         constant integer BESTIARY           = 'obea'
+        // 战争磨坊
         constant integer FORGE              = 'ofor'
+        // 堡垒（兽人三本基地）
         constant integer FORTRESS           = 'ofrt'
+        // 大厅（兽人一本基地）
         constant integer GREAT_HALL         = 'ogre'
+        // 灵魂小屋
         constant integer LODGE              = 'osld'
+        // 据点（兽人二本基地）
         constant integer STRONGHOLD         = 'ostr'
+        // 兽人地洞
         constant integer BURROW             = 'otrb'
+        // 牛头人图腾
         constant integer TOTEM              = 'otto'
+        // 了望塔
         constant integer ORC_WATCH_TOWER    = 'owtw'
+        // 巫毒小屋
         constant integer VOODOO_LOUNGE      = 'ovln'
     
         // orc upgrades
+        // 精钢近战武器
         constant integer UPG_ORC_MELEE      = 'Rome'
+        // 精钢远程武器
         constant integer UPG_ORC_RANGED     = 'Rora'
+        // 火炮（编辑器无此科技 'Roaa'）
         constant integer UPG_ORC_ARTILLERY  = 'Roaa'
+        // 精钢护甲
         constant integer UPG_ORC_ARMOR      = 'Roar'
+        // 战鼓伤害强化
         constant integer UPG_ORC_WAR_DRUMS  = 'Rwdm'
+        // 掠夺
         constant integer UPG_ORC_PILLAGE    = 'Ropg'
+        // 野蛮之力
         constant integer UPG_ORC_BERSERK    = 'Robs'
+        // 粉碎伤害强化
         constant integer UPG_ORC_PULVERIZE  = 'Rows'
+        // 诱捕
         constant integer UPG_ORC_ENSNARE    = 'Roen'
+        // 毒矛
         constant integer UPG_ORC_VENOM      = 'Rovs'
+        // 巫医专家级训练
         constant integer UPG_ORC_DOCS       = 'Rowd'
+        // 萨满祭司专家级训练
         constant integer UPG_ORC_SHAMAN     = 'Rost'
+        // 尖刺障碍
         constant integer UPG_ORC_SPIKES     = 'Rosp'
+        // 加强型防御
         constant integer UPG_ORC_BURROWS    = 'Rorb'
+        // 巨魔再生
         constant integer UPG_ORC_REGEN      = 'Rotr'
+        // 火油瓶
         constant integer UPG_ORC_FIRE       = 'Rolf'
+        // 灵魂行者专家级训练
         constant integer UPG_ORC_SWALKER    = 'Rowt'
+        // 狂战士升级
         constant integer UPG_ORC_BERSERKER  = 'Robk'
+        // 燃油
         constant integer UPG_ORC_NAPTHA     = 'Robf'
+        // 混乱
         constant integer UPG_ORC_CHAOS      = 'Roch'
     
         // Warcraft 2 orc units
+        // 食人魔法师
         constant integer OGRE_MAGI          = 'nomg'
+        // 红色巨龙
         constant integer ORC_DRAGON         = 'nrwm'
+        // 地精自爆工兵
         constant integer SAPPER             = 'ngsp'
+        // 地精飞艇
         constant integer ZEPPLIN            = 'nzep'
+        // 地精飞艇
         constant integer ZEPPELIN           =  ZEPPLIN
+        // 兽人术士
         constant integer W2_WARLOCK         = 'nw2w'
+        // 猪圈
         constant integer PIG_FARM           = 'npgf'
     
         // special orc units
+        // 邪兽人步兵
         constant integer CHAOS_GRUNT        = 'nchg'
+        // 邪兽人术士
         constant integer CHAOS_WARLOCK      = 'nchw'
+        // 邪兽人狼骑兵
         constant integer CHAOS_RAIDER       = 'nchr'
+        // 邪兽人苦工
         constant integer CHAOS_PEON         = 'ncpn'
+        // 邪兽人科多兽
         constant integer CHAOS_KODO         = 'nckb'
+        // 格罗玛什·地狱咆哮（喝下恶魔之血）
         constant integer CHAOS_GROM         = 'Opgh'
+        // 黑石氏族剑圣
         constant integer CHAOS_BLADEMASTER  = 'Nbbc'
+        // 邪兽人地洞
         constant integer CHAOS_BURROW       = 'ocbw'
     
         //--------------------------------------------------------------------
@@ -480,96 +646,171 @@ native DebugS               takes string str                            returns 
         //--------------------------------------------------------------------
     
         // undead heroes
+        // 死亡骑士
         constant integer DEATH_KNIGHT       = 'Udea'
+        // 恐惧魔王
         constant integer DREAD_LORD         = 'Udre'
+        // 巫妖
         constant integer LICH               = 'Ulic'
+        // 地穴领主
         constant integer CRYPT_LORD         = 'Ucrl'
     
         // special undead heroes
+        // 玛尔甘尼斯
         constant integer MALGANIS           = 'Umal'
+        // 提克迪奥斯
         constant integer TICHONDRIUS        = 'Utic'
+        // 阿兹加洛
         constant integer PIT_LORD           = 'Npld'
+        // 迪瑟洛克
         constant integer DETHEROC           = 'Udth'
     
         // undead hero abilities
+        // 技能 沉睡（恐惧魔王）
         constant integer SLEEP              = 'AUsl'
+        // 技能 吸血光环（恐惧魔王）
         constant integer VAMP_AURA          = 'AUav'
+        // 技能 腐臭蜂群（恐惧魔王）
         constant integer CARRION_SWARM      = 'AUcs'
+        // 技能 地狱火（恐惧魔王）
         constant integer INFERNO            = 'AUin'
-    
+        // 技能 黑暗仪式（巫妖）
         constant integer DARK_RITUAL        = 'AUdr'
+        // 技能 枯萎凋零（巫妖）
         constant integer DEATH_DECAY        = 'AUdd'
+        // 技能 冰霜新星（巫妖）
         constant integer FROST_ARMOR        = 'AUfu'
+        // 技能 霜甲术（自动施法）（巫妖）
         constant integer FROST_NOVA         = 'AUfn'
-    
+        // 技能 亡者再临（死骑）
         constant integer ANIM_DEAD          = 'AUan'
+        // 技能 凋零/死亡缠绕（死骑）
         constant integer DEATH_COIL         = 'AUdc'
+        // 技能 天灾/死亡契约（死骑）
         constant integer DEATH_PACT         = 'AUdp'
+        // 技能 邪恶光环（死骑）
         constant integer UNHOLY_AURA        = 'AUau'
-    
+        // 技能 腐尸甲虫（小强）
         constant integer CARRION_SCARAB     = 'AUcb'
+        // 技能 穿刺（小强）
         constant integer IMPALE             = 'AUim'
+        // 技能 虫群风暴（小强）
         constant integer LOCUST_SWARM       = 'AUls'
+        // 技能 尖刺甲壳（小强）
         constant integer THORNY_SHIELD      = 'AUts'
     
         // undead units
+        // 憎恶
         constant integer ABOMINATION        = 'uabo'
+        // 侍僧
         constant integer ACOLYTE            = 'uaco'
+        // 女妖
         constant integer BANSHEE            = 'uban'
+        // 地穴恶魔
         constant integer PIT_FIEND          = 'ucry'
+        // 地穴恶魔
         constant integer CRYPT_FIEND        =  PIT_FIEND
+        // 冰霜巨龙
         constant integer FROST_WYRM         = 'ufro'
+        // 石像鬼
         constant integer GARGOYLE           = 'ugar'
+        // 石像鬼石像形态
         constant integer GARGOYLE_MORPH     = 'ugrm'
+        // 食尸鬼
         constant integer GHOUL              = 'ugho'
+        // 清道夫（绞肉机）
         constant integer MEAT_WAGON         = 'umtw'
+        // 通灵师（亡灵男巫）
         constant integer NECRO              = 'unec'
+        // 骷髅战士
         constant integer SKEL_WARRIOR       = 'uske'
+        // 影魔（阴影）
         constant integer SHADE              = 'ushd'
+        // 邪灵空艇
         constant integer UNDEAD_BARGE       = 'uarb'
+        // 黑曜石雕像
         constant integer OBSIDIAN_STATUE    = 'uobs'
+        // 黑曜石雕像
         constant integer OBS_STATUE         =  OBSIDIAN_STATUE
+        // 毁灭者
         constant integer BLK_SPHINX         = 'ubsp'
     
         // undead buildings
+        // 闹鬼金矿
         constant integer UNDEAD_MINE        = 'ugol'
+        // 黑暗祭坛
         constant integer UNDEAD_ALTAR       = 'uaod'
+        // 埋骨地
         constant integer BONEYARD           = 'ubon'
+        // 某种尖塔（编辑器无此单位 'ugsp'）
         constant integer GARG_SPIRE         = 'ugsp'
+        // 浮空城（大墓地）
         constant integer NECROPOLIS_1       = 'unpl'    // normal
+        // 亡者大厅
         constant integer NECROPOLIS_2       = 'unp1'    // upgraded once
+        // 黑色城堡
         constant integer NECROPOLIS_3       = 'unp2'    // full upgrade
+        // 献祭深渊
         constant integer SAC_PIT            = 'usap'
+        // 地穴
         constant integer CRYPT              = 'usep'
+        // 屠宰场
         constant integer SLAUGHTERHOUSE     = 'uslh'
+        // 诅咒神殿
         constant integer DAMNED_TEMPLE      = 'utod'
+        // 通灵塔
         constant integer ZIGGURAT_1         = 'uzig'    // normal
+        // 幽魂之塔
         constant integer ZIGGURAT_2         = 'uzg1'    // upgraded
+        // 蛛魔之塔（冰塔）
         constant integer ZIGGURAT_FROST     = 'uzg2'    // frost tower
+        // 坟场
         constant integer GRAVEYARD          = 'ugrv'
+        // 遗物陵墓
         constant integer TOMB_OF_RELICS     = 'utom'
     
         // undead upgrades
+        // 邪恶力量
         constant integer UPG_UNHOLY_STR     = 'Rume'
+        // 生物攻击
         constant integer UPG_CR_ATTACK      = 'Rura'
+        // 邪恶护甲
         constant integer UPG_UNHOLY_ARMOR   = 'Ruar'
+        // 食尸
         constant integer UPG_CANNIBALIZE    = 'Ruac'
+        // 食尸鬼狂暴
         constant integer UPG_GHOUL_FRENZY   = 'Rugf'
+        // 蛛网
         constant integer UPG_FIEND_WEB      = 'Ruwb'
+        // 不明科技（编辑器无此科技'Ruab'）
         constant integer UPG_ABOM           = 'Ruab'
+        // 石像形态
         constant integer UPG_STONE_FORM     = 'Rusf'
+        // 通灵师/亡灵男巫专家级训练
         constant integer UPG_NECROS         = 'Rune'
+        // 女妖专家级训练
         constant integer UPG_BANSHEE        = 'Ruba'
+        // 怀疑是背包（'Rupm'），但此处写成'Rump'
         constant integer UPG_MEAT_WAGON     = 'Rump'
+        // 冰冻吐息
         constant integer UPG_WYRM_BREATH    = 'Rufb'
+        // 骷髅持久术
         constant integer UPG_SKEL_LIFE      = 'Rusl'
+        // 骷髅精通
         constant integer UPG_SKEL_MASTERY   = 'Rusm'
+        // 发掘尸体
         constant integer UPG_EXHUME         = 'Ruex'
+        // 牺牲（编辑器无此科技'Rurs'）
         constant integer UPG_SACRIFICE      = 'Rurs'
+        // 不明科技（编辑器无此科技'Ruax'）
         constant integer UPG_ABOM_EXPL      = 'Ruax'
+        // 生物甲壳
         constant integer UPG_CR_ARMOR       = 'Rucr'
+        // 疾病之云
         constant integer UPG_PLAGUE         = 'Rupc'
+        // 毁灭者形态
         constant integer UPG_BLK_SPHINX     = 'Rusp'
+        // 钻地
         constant integer UPG_BURROWING      = 'Rubu'
     
         //--------------------------------------------------------------------
@@ -577,141 +818,254 @@ native DebugS               takes string str                            returns 
         //--------------------------------------------------------------------
     
         // elf heroes
+        // 恶魔猎手
         constant integer DEMON_HUNTER       = 'Edem'
+        // 恶魔猎手（变身形态）
         constant integer DEMON_HUNTER_M     = 'Edmm'
+        // 丛林守护者
         constant integer KEEPER             = 'Ekee'
+        // 月之女祭司
         constant integer MOON_CHICK         = 'Emoo'
+        // 月之女祭司
         constant integer MOON_BABE          =  MOON_CHICK
+        // 月之女祭司
         constant integer MOON_HONEY         =  MOON_CHICK
+        // 守望者
         constant integer WARDEN             = 'Ewar'
     
         // special elf heroes
+        // 希尔瓦娜斯
         constant integer SYLVANUS           = 'Hvwd'
+        // 塞纳留斯
         constant integer CENARIUS           = 'Ecen'
+        // 伊利丹
         constant integer ILLIDAN            = 'Eevi'
+        // 伊利丹（恶魔形态）
         constant integer ILLIDAN_DEMON      = 'Eevm'
+        // 玛維
         constant integer MAIEV              = 'Ewrd'
     
         // elf hero abilities
+        // 技能 自然之力（丛林守护者）
         constant integer FORCE_NATURE       = 'AEfn'
+        // 技能 纠缠根须（丛林守护者）
         constant integer ENT_ROOTS          = 'AEer'
+        // 技能 荆棘光环（丛林守护者）
         constant integer THORNS_AURA        = 'AEah'
+        // 技能 宁静（丛林守护者）
         constant integer TRANQUILITY        = 'AEtq'
-    
+        // 技能 闪避（恶魔猎手）
         constant integer EVASION            = 'AEev'
+        // 技能 献祭（恶魔猎手）
         constant integer IMMOLATION         = 'AEim'
+        // 技能 法力燃烧（恶魔猎手）
         constant integer MANA_BURN          = 'AEmb'
+        // 技能 恶魔变形（恶魔猎手）
         constant integer METAMORPHOSIS      = 'AEme'
-    
+        // 技能 灼热之箭（白虎）
         constant integer SEARING_ARROWS     = 'AHfa'
+        // 技能 斥候（白虎）
         constant integer SCOUT              = 'AEst'
+        // 技能 星辰坠落（流星雨）（白虎）
         constant integer STARFALL           = 'AEsf'
+        // 技能 强击光环（白虎）
         constant integer TRUESHOT           = 'AEar'
-    
+        // 技能 闪现（守望者）
         constant integer BLINK              = 'AEbl'
+        // 技能 刀扇
         constant integer FAN_KNIVES         = 'AEfk'
+        // 技能 暗影突袭
         constant integer SHADOW_TOUCH       = 'AEsh'
+        // 技能 复仇
         constant integer VENGEANCE          = 'AEsv'
     
         // elf units
+        // 小精灵
         constant integer WISP               = 'ewsp'
+        // 弓箭手
         constant integer ARCHER             = 'earc'
+        // 猛禽德鲁伊（鸟德）（人形）
         constant integer DRUID_TALON        = 'edot'
+        // 猛禽德鲁伊（鸟德）（鸦形）
         constant integer DRUID_TALON_M      = 'edtm'
+        // 投刃车
         constant integer BALLISTA           = 'ebal'
+        // 利爪德鲁伊（熊德）（人形）
         constant integer DRUID_CLAW         = 'edoc'
+        // 利爪德鲁伊（熊德）（熊形）
         constant integer DRUID_CLAW_M       = 'edcm'
+        // 树妖（小鹿）
         constant integer DRYAD              = 'edry'
+        // 角鹰兽
         constant integer HIPPO              = 'ehip'
+        // 角鹰兽骑士
         constant integer HIPPO_RIDER        = 'ehpr'
+        // 女猎手
         constant integer HUNTRESS           = 'esen'
+        // 奇美拉
         constant integer CHIMAERA           = 'echm'
+        // 树人
         constant integer ENT                = 'efon'
+        // 山岭巨人
         constant integer MOUNTAIN_GIANT     = 'emtg'
+        // 精灵龙
         constant integer FAERIE_DRAGON      = 'efdr'
     
         // special elf units
+        // 弓箭手（高等精灵）
         constant integer HIGH_ARCHER        = 'nhea'
+        // 队长（高等精灵）
         constant integer HIGH_FOOTMAN       = 'hcth'
+        // 队长（高等精灵）
         constant integer HIGH_FOOTMEN       =  HIGH_FOOTMAN
+        // 剑士（高等精灵）
         constant integer HIGH_SWORDMAN      = 'hhes'
+        // 龙鹰（高等精灵）
         constant integer DRAGON_HAWK        = 'nws1'
+        // 腐化的树人
         constant integer CORRUPT_TREANT     = 'nenc'
+        // 剧毒树人
         constant integer POISON_TREANT      = 'nenp'
+        // 瘟疫树人
         constant integer PLAGUE_TREANT      = 'nepl'
+        // 珊蒂斯
         constant integer SHANDRIS           = 'eshd'
     
         // elf buildings
+        // 知识古树
         constant integer ANCIENT_LORE       = 'eaoe'
+        // 战争古树
         constant integer ANCIENT_WAR        = 'eaom'
+        // 风之古树
         constant integer ANCIENT_WIND       = 'eaow'
+        // 纪元之树（暗夜二本）
         constant integer TREE_AGES          = 'etoa'
+        // 永恒之树（暗夜三本）
         constant integer TREE_ETERNITY      = 'etoe'
+        // 生命之树（暗夜一本）
         constant integer TREE_LIFE          = 'etol'
+        // 守护古树
         constant integer ANCIENT_PROTECT    = 'etrp'
+        // 长者祭坛
         constant integer ELF_ALTAR          = 'eate'
         constant integer BEAR_DEN           = 'edol'
+        // 熊窝（编辑器无此单位 ）
+        constant integer BEAR_DEN           = 'edol'
+        // 奇美拉栖木
         constant integer CHIMAERA_ROOST     = 'edos'
+        // 猎手大厅
         constant integer HUNTERS_HALL       = 'edob'
+        // 月亮井
         constant integer MOON_WELL          = 'emow'
+        // 被缠绕的金矿
         constant integer ELF_MINE           = 'egol'
+        // 奇迹古树
         constant integer DEN_OF_WONDERS     = 'eden'
     
         // special elf buildings
+        // 高等精灵农场
         constant integer ELF_FARM           = 'nefm'
+        // 高等精灵警戒塔
         constant integer ELF_GUARD_TOWER    = 'negt'
+        // 天怒塔
         constant integer HIGH_SKY           = 'negm'
+        // 地怒塔 
         constant integer HIGH_EARTH         = 'negf'
+        // 高等精灵警戒塔
         constant integer HIGH_TOWER         = 'negt'
+        // 高等精灵兵营
         constant integer ELF_HIGH_BARRACKS  = 'nheb'
+        // 腐化的生命之树
         constant integer CORRUPT_LIFE       = 'nctl'
+        // 腐化的月亮井
         constant integer CORRUPT_WELL       = 'ncmw'
+        // 腐化的守护古树
         constant integer CORRUPT_PROTECTOR  = 'ncap'
+        // 腐化的战争古树
         constant integer CORRUPT_WAR        = 'ncaw'
     
         // elf upgrades
+        // 月之力量
         constant integer UPG_STR_MOON       = 'Resm'
+        // 野性力量
         constant integer UPG_STR_WILD       = 'Resw'
+        // 月之护甲
         constant integer UPG_MOON_ARMOR     = 'Rema'
+        // 强化外皮
         constant integer UPG_HIDES          = 'Rerh'
+        // 夜视能力
         constant integer UPG_ULTRAVISION    = 'Reuv'
+        // 自然祝福
         constant integer UPG_BLESSING       = 'Renb'
+        // 哨兵
         constant integer UPG_SCOUT          = 'Resc'
+        // 升级月刃
         constant integer UPG_GLAIVE         = 'Remg'
+        // 强弓
         constant integer UPG_BOWS           = 'Reib'
+        // 箭术
         constant integer UPG_MARKSMAN       = 'Remk'
+        // 猛禽德鲁伊专家级训练
         constant integer UPG_DRUID_TALON    = 'Redt'
+        // 利爪德鲁伊专家级训练
         constant integer UPG_DRUID_CLAW     = 'Redc'
+        // 驱除魔法
         constant integer UPG_ABOLISH        = 'Resi'
+        // 腐蚀吐息
         constant integer UPG_CHIM_ACID      = 'Recb'
+        // 角鹰兽训练
         constant integer UPG_HIPPO_TAME     = 'Reht'
+        // 不明科技（编辑器无此科技'Repd'）
         constant integer UPG_BOLT           = 'Repd'
+        // 利爪之印
         constant integer UPG_MARK_CLAW      = 'Reeb'
+        // 猛禽之印
         constant integer UPG_MARK_TALON     = 'Reec'
+        // 硬化体肤
         constant integer UPG_HARD_SKIN      = 'Rehs'
+        // 抗性体肤
         constant integer UPG_RESIST_SKIN    = 'Rers'
+        // 月井之春
         constant integer UPG_WELL_SPRING    = 'Rews'
     
         //--------------------------------------------------------------------
         // Neutral
         //--------------------------------------------------------------------
+        // 恶魔之门
         constant integer DEMON_GATE         = 'ndmg'
+        // 恶魔猎犬
         constant integer FELLHOUND          = 'nfel'
+        // 地狱火
         constant integer INFERNAL           = 'ninf'
+        // 末日守卫（标准）
         constant integer DOOMGUARD          = 'nbal'
+        // 萨特
         constant integer SATYR              = 'nsty'
+        // 萨特欺诈者
         constant integer TRICKSTER          = 'nsat'
+        // 萨特影舞者
         constant integer SHADOWDANCER       = 'nsts'
+        // 萨特窃魂者
         constant integer SOULSTEALER        = 'nstl'
+        // 萨特唤魔者
         constant integer HELLCALLER         = 'nsth'
+        // 骷髅弓箭手
         constant integer SKEL_ARCHER        = 'nska'
+        // 骷髅神射手
         constant integer SKEL_MARKSMAN      = 'nskm'
+        // 燃烧弓箭手
         constant integer SKEL_BURNING       = 'nskf'
+        // 巨型骷髅战士
         constant integer SKEL_GIANT         = 'nskg'
+        // 熊怪
         constant integer FURBOLG            = 'nfrl'
+        // 熊怪追踪者
         constant integer FURBOLG_TRACKER    = 'nfrb'
+        // 熊怪萨满
         constant integer FURBOLG_SHAMAN     = 'nfrs'
+        // 熊怪勇士
         constant integer FURBOLG_CHAMP      = 'nfrg'
+        // 熊怪萨满长者
         constant integer FURBOLG_ELDER      = 'nfre'
     
         //--------------------------------------------------------------------
@@ -719,37 +1073,61 @@ native DebugS               takes string str                            returns 
         //--------------------------------------------------------------------
     
         // naga heroes
+        // 海巫（娜迦族）
         constant integer NAGA_SORCERESS     = 'Nngs' 
+        // 瓦斯琪
         constant integer NAGA_VASHJ         = 'Hvsh' 
     
         // naga units
+        // 毒鳍龙
         constant integer NAGA_DRAGON        = 'nsnp'        // old names
+        // 纳迦海妖
         constant integer NAGA_WITCH         = 'nnsw'
+        // 飞蛇
         constant integer NAGA_SERPENT       = 'nwgs' 
+        // 龙龟
         constant integer NAGA_HYDRA         = 'nhyc'    
-    
+        // 深海鱼人奴隶
         constant integer NAGA_SLAVE         = 'nmpe'        // peon
+        // 毒鳍龙
         constant integer NAGA_SNAP_DRAGON   =  NAGA_DRAGON  // weak ranged
+        // 飞蛇
         constant integer NAGA_COUATL        =  NAGA_SERPENT // weak air
+        // 纳迦海妖
         constant integer NAGA_SIREN         =  NAGA_WITCH   // caster
+        // 纳迦侍从
         constant integer NAGA_MYRMIDON      = 'nmyr'        // knight
+        // 深海鱼人掠夺者
         constant integer NAGA_REAVER        = 'nnmg'        // footman
+        // 龙龟
         constant integer NAGA_TURTLE        =  NAGA_HYDRA   // siege
+        // 纳迦皇家卫兵
         constant integer NAGA_ROYAL         = 'nnrg'        // royal guard
     
         // naga buildings
+        // 潮汐神殿
         constant integer NAGA_TEMPLE        = 'nntt'        // town hall
+        // 珊瑚礁
         constant integer NAGA_CORAL         = 'nnfm'        // farm
+        // 艾萨拉圣所
         constant integer NAGA_SHRINE        = 'nnsa'        // sirens & couatls
+        // 孵化场
         constant integer NAGA_SPAWNING      = 'nnsg'        // myrm, snap dragon, hydra
+        // 潮汐守卫
         constant integer NAGA_GUARDIAN      = 'nntg'        // tower
+        // 深渊祭坛
         constant integer NAGA_ALTAR         = 'nnad'        // altar
     
         // naga upgrades
+        // 珊瑚鳞甲
         constant integer UPG_NAGA_ARMOR     = 'Rnam'
+        // 珊瑚锋刃
         constant integer UPG_NAGA_ATTACK    = 'Rnat'
+        // 驱除魔法
         constant integer UPG_NAGA_ABOLISH   = 'Rnsi'
+        // 纳迦海妖专家级训练
         constant integer UPG_SIREN          = 'Rnsw'
+        // 诱捕
         constant integer UPG_NAGA_ENSNARE   = 'Rnen'
     
     
@@ -778,9 +1156,11 @@ native DebugS               takes string str                            returns 
         constant integer MELEE_NEWBIE       = 1
         constant integer MELEE_NORMAL       = 2
         constant integer MELEE_INSANE       = 3
-    
+        // 攻击组
         constant integer ATTACK_CAPTAIN     = 1
+        // 防御组
         constant integer DEFENSE_CAPTAIN    = 2
+        // 攻击组及防御组
         constant integer BOTH_CAPTAINS      = 3
     
         constant integer BUILD_UNIT         = 1
@@ -791,23 +1171,33 @@ native DebugS               takes string str                            returns 
         constant integer UPKEEP_TIER2       = 80
     
         //--------------------------------------------------------------------
-    
+        // 当前AI玩家
         player  ai_player
-    
+        // 休眠/等待时间
         integer sleep_seconds
         integer total_gold              = 0
         integer total_wood              = 0
         integer gold_buffer             = 0 // usually for potion money
+        // 难度
         integer difficulty              = NORMAL
         integer exp_seen                = 0
+        // 默认人口建筑单位类型
         integer racial_farm             = 'hhou'
+        // 首发英雄单位类型
         integer hero_id                 = 'Hamg'
+        // 二发英雄单位类型
         integer hero_id2                = 'Hmkg'
+        // 三发英雄单位类型
         integer hero_id3                = 'Hpal'
+        // 技能数组
         integer array skill
+        // 首发英雄技能数组
         integer array skills1
+        // 二发英雄技能数组
         integer array skills2
+        // 三发英雄技能数组
         integer array skills3
+        // 最大英雄等级，默认为0
         integer max_hero_level          = 0
     
         integer array harass_qty
@@ -824,29 +1214,39 @@ native DebugS               takes string str                            returns 
         integer array build_item
         integer array build_town
         integer build_length            = 0
-    
+        // 战役采金工人数量，默认5
         integer campaign_gold_peons     = 5
+        // 战役采木工人数量，默认3
         integer campaign_wood_peons     = 3
+        // 战役等待时间，默认5秒
         integer campaign_basics_speed   = 5
-    
+        // （中立敌对玩家）最小野怪等级，默认-1
         integer min_creeps              = -1
+        // （中立敌对玩家）最大野怪等级，默认-1
         integer max_creeps              = -1
     
         boolean harvest_town1           = true
         boolean harvest_town2           = true
         boolean harvest_town3           = true
+        // 战役人口模式
         boolean do_campaign_farms       = true
+        // 二发英雄存在
         boolean two_heroes              = false
+        // 是否允许获取（中立敌对玩家）飞行野怪，默认不允许
         boolean allow_air_creeps        = false
+        // 是否开分矿
         boolean take_exp                = false
         boolean allow_signal_abort      = false
+        // 是否完成飞艇购买
         boolean ready_for_zeppelin      = true
+        // 是否购买飞艇，默认为否
         boolean get_zeppelin            = false
-    
+        // 是否建造战役进攻单位
         boolean build_campaign_attackers = true
     
         boolean do_debug_cheats         = false
         boolean trace_on                = true
+        // 是否需要飞艇空投
         boolean zep_next_wave           = false
         boolean form_group_timeouts     = true
     endglobals
@@ -947,7 +1347,7 @@ native DebugS               takes string str                            returns 
             return B
         endif
     endfunction
-    // 设置运输下一波状态开启，用于飞艇空投，但鉴于AI本身会使用飞艇，无需使用该程序
+    // 设置运输状态开启，用于飞艇空投，但鉴于AI本身会使用飞艇，无需使用该程序
     function SetZepNextWave takes nothing returns nothing
         set zep_next_wave = true
     endfunction
@@ -1553,7 +1953,7 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //============================================================================
-    // 建造循环，启用建造核心循环程序，并无限循环
+    // 建造线程，启用建造核心循环程序，并无限循环
     function BuildLoop takes nothing returns nothing
         call OneBuildLoop()
         call StaggerSleep(1,2)
@@ -1639,6 +2039,7 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //============================================================================
+    // 循环交错设置进攻组，会设置各难度AI，e用于简单，m用于中等，h用于困难，1~3分别代表具体的数量（即每个难度都可设置3个档位），u1~u3为单位类型（即每个难度都可设置3种单位类型）
     function Interleave3 takes integer e1, integer m1, integer h1, integer u1, integer e2, integer m2, integer h2, integer u2, integer e3, integer m3, integer h3, integer u3 returns nothing
         local integer i1 = 1
         local integer i2 = 1
@@ -1739,7 +2140,7 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //============================================================================
-    // 等待进攻组完成组建，用于等待进攻组补充单位（用testReady指定组的准备情况，为真时需要攻击组准备满50，为假时准备0即可，seconds为最长等待时间）
+    // 等待攻击组完成组建，用于等待攻击组补充单位（用testReady指定组的准备情况，为真时需要攻击组准备满50，为假时准备0即可，seconds为最长等待时间）
     function FormGroup takes integer seconds, boolean testReady returns nothing
         local integer index
         local integer count
@@ -1865,7 +2266,7 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //============================================================================
-    // 进军休眠，进攻组撤退、进攻组到达目的地、进攻组回到家、进攻组为空 任意事件返回 是 时，退出休眠
+    // 进军休眠，攻击组撤退、攻击组到达目的地、攻击组回到家、攻击组为空 任意事件返回 是 时，退出休眠
     function SleepUntilAtGoal takes nothing returns nothing
         loop
             exitwhen CaptainRetreating()
@@ -1877,7 +2278,7 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //============================================================================
-    // 战斗休眠，进攻组脱离战斗 或 进攻组为空 时，退出内层休眠，当内层循环退出8次时，退出外层循环，两层循环都退出时，结束休眠
+    // 战斗休眠，攻击组脱离战斗 或 攻击组为空 时，退出内层休眠，当内层循环退出8次时，退出外层循环，两层循环都退出时，结束休眠
     function SleepInCombat takes nothing returns nothing
         local integer count = 0
         debug call Trace("SleepInCombat\n")
@@ -1895,7 +2296,7 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //============================================================================
-    // 命令进攻组移动攻击到指定坐标
+    // 命令攻击组移动攻击到指定坐标
     function AttackMoveXYA takes integer x, integer y returns nothing
     
         if zep_next_wave then
@@ -1964,7 +2365,7 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //--------------------------------------------------------------------------------------------------
-    // 设置各波次进攻，默认用于自杀（战役）
+    // 设置各波次进攻，默认用于自杀（战役），启用standard时判断退出条件
     function CommonSuicideOnPlayer takes boolean standard, boolean bldgs, integer seconds, player p, integer x, integer y returns nothing
         local integer save_peons
     
@@ -2013,21 +2414,25 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //--------------------------------------------------------------------------------------------------
+    // 自杀进攻（指定玩家）
     function SuicideOnPlayer takes integer seconds, player p returns nothing
         call CommonSuicideOnPlayer(true,true,seconds,p,0,0)
     endfunction
     
     //--------------------------------------------------------------------------------------------------
+    // 自杀进攻（指定玩家）
     function SuicideOnUnits takes integer seconds, player p returns nothing
         call CommonSuicideOnPlayer(true,false,seconds,p,0,0)
     endfunction
     
     //--------------------------------------------------------------------------------------------------
+    // 自杀进攻（指定坐标）
     function SuicideOnPoint takes integer seconds, player p, integer x, integer y returns nothing
         call CommonSuicideOnPlayer(false,false,seconds,p,x,y)
     endfunction
     
     //============================================================================
+    // 等待自杀信号
     function SuicideUntilSignal takes integer seconds, player p returns nothing
         local integer save
         local integer wave_prep = PrepTime()
@@ -2062,6 +2467,7 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //--------------------------------------------------------------------------------------------------
+    // 添加自杀单位类型到攻击组，指定各种AI难度的数量
     function SuicideOnce takes integer easy, integer med, integer hard, integer unitid returns nothing
         if difficulty == EASY then
             call SuicideUnit(easy,unitid)
@@ -2073,6 +2479,7 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //--------------------------------------------------------------------------------------------------
+    // 添加自杀单位类型到攻击组，每次添加1个
     function SuicideUnitA takes integer unitid returns nothing
         if unitid != 0 then
             call SuicideUnit(1,unitid)
@@ -2081,6 +2488,7 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //--------------------------------------------------------------------------------------------------
+    // 添加自杀单位类型到攻击组（指定玩家），每次添加1个
     function SuicideUnitB takes integer unitid, integer playerid returns nothing
         if unitid != 0 then
             call SuicideUnitEx(1,unitid,playerid)
@@ -2089,6 +2497,7 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //--------------------------------------------------------------------------------------------------
+    // 循环添加自杀单位到单位组（指定单位类型，u1~uA），该循环不会退出
     function SuicideUnits takes integer u1, integer u2, integer u3, integer u4, integer u5, integer u6, integer u7, integer u8, integer u9, integer uA returns nothing
         call Trace("MASS SUICIDE - this script is now technically done\n") //xxx
     
@@ -2108,6 +2517,7 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //--------------------------------------------------------------------------------------------------
+    // 循环添加自杀单位到单位组（指定玩家，指定单位类型，u1~uA），该循环不会退出
     function SuicideUnitsEx takes integer playerid, integer u1, integer u2, integer u3, integer u4, integer u5, integer u6, integer u7, integer u8, integer u9, integer uA returns nothing
         call Trace("MASS SUICIDE - this script is now technically done\n") //xxx
     
@@ -2127,6 +2537,7 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //--------------------------------------------------------------------------------------------------
+    // 自杀进攻（指定玩家），指定各难度的等待时间
     function SuicideOnPlayerEx takes integer easy, integer med, integer hard, player p returns nothing
         if difficulty == EASY then
             call SuicideOnPlayer(easy,p)
@@ -2138,6 +2549,7 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //--------------------------------------------------------------------------------------------------
+    // 自杀进攻（指定玩家），指定各难度的等待时间
     function SuicideOnUnitsEx takes integer easy, integer med, integer hard, player p returns nothing
         if difficulty == EASY then
             call SuicideOnUnits(easy,p)
@@ -2149,6 +2561,7 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //--------------------------------------------------------------------------------------------------
+    // 自杀进攻（指定坐标），指定各难度的等待时间
     function SuicideOnPointEx takes integer easy, integer med, integer hard, player p, integer x, integer y returns nothing
         if difficulty == EASY then
             call SuicideOnPoint(easy,p,x,y)
@@ -2160,6 +2573,7 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //============================================================================
+    // 持续自杀进攻（指定玩家）
     function ForeverSuicideOnPlayer takes integer seconds, player p returns nothing
         local integer length = harass_length
         loop
@@ -2170,7 +2584,7 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //============================================================================
-    // 战斗（循环发送进攻指定目标命令），直至攻击目标死亡或进攻组死光/撤退
+    // 战斗（循环发送进攻指定目标命令），直至攻击目标死亡或攻击组死光/撤退
     function CommonSleepUntilTargetDead takes unit target, boolean reform returns nothing
         loop
             exitwhen CaptainRetreating()
@@ -2197,18 +2611,20 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //============================================================================
-    // 至死方休（指定目标），死为目标死亡或进攻组死光/撤退，会调用战斗程序CommonSleepUntilTargetDead，reform默认为假
+    // 至死方休（指定目标），死为目标死亡或攻击组死光/撤退，会调用战斗程序CommonSleepUntilTargetDead，reform默认为假
     function SleepUntilTargetDead takes unit target returns nothing
         call CommonSleepUntilTargetDead(target,false)
     endfunction
     
     //============================================================================
+    // 至死方休（指定目标），死为目标死亡或攻击组死光/撤退，会调用战斗程序CommonSleepUntilTargetDead，reform默认为真
     function ReformUntilTargetDead takes unit target returns nothing
         debug call Trace("ReformUntilTargetDead\n")
         call CommonSleepUntilTargetDead(target,true)
     endfunction
     
     //============================================================================
+    // 攻击指定目标（移动攻击）
     function AttackMoveKillA takes unit target returns nothing
         if target == null then
             call SuicideSleep(3)
@@ -2222,6 +2638,7 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //============================================================================
+   // 攻击小型中立敌对玩家（打野）
     function MinorCreepAttack takes nothing returns nothing
         local unit target = GetMinorCreep()
         call SetAllianceTarget(target)
@@ -2230,6 +2647,7 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //============================================================================
+   // 攻击大型中立敌对玩家（打野）
     function MajorCreepAttack takes nothing returns nothing
         local unit target = GetMajorCreep()
         call SetAllianceTarget(target)
@@ -2238,6 +2656,7 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //============================================================================
+    // 攻击中立敌对玩家（打野），根据当前的min_creeps、max_creeps，allow_air_creeps获取野怪
     function CreepAttackEx takes nothing returns nothing
         local unit target = GetCreepCamp(min_creeps,max_creeps,allow_air_creeps)
         call SetAllianceTarget(target)
@@ -2246,6 +2665,7 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //============================================================================
+    // 攻击任意玩家
     function AnyPlayerAttack takes nothing returns nothing
         local unit hall
     
@@ -2265,6 +2685,7 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //============================================================================
+    // 攻击扩展点
     function ExpansionAttack takes nothing returns nothing
         local unit creep = GetExpansionFoe()
         local integer x
@@ -2283,6 +2704,7 @@ native DebugS               takes string str                            returns 
     //============================================================================
     //  AddSiege
     //============================================================================
+    // 添加攻城单位到进攻组
     function AddSiege takes nothing returns nothing
         call SetAssaultGroup( 0, 9, SHADE       )
         call SetAssaultGroup( 0, 9, MEAT_WAGON  )
@@ -2295,6 +2717,7 @@ native DebugS               takes string str                            returns 
     //===========================================================================
     //  GetAllyCount
     //============================================================================
+    // 获取盟友玩家数量
     function GetAllyCount takes player whichPlayer returns integer
         local integer    playerIndex = 0
         local integer    count = 0
@@ -2323,6 +2746,7 @@ native DebugS               takes string str                            returns 
     //============================================================================
     //  SingleMeleeAttack
     //============================================================================
+    // 对战进攻循环，包含打野、开矿、攻击玩家、购买飞艇等命令
     function SingleMeleeAttack takes boolean needs_exp, boolean has_siege, boolean major_ok, boolean air_units returns nothing
         local boolean   can_siege
         local real      daytime 
@@ -2491,7 +2915,7 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //============================================================================
-    // 训练进攻组单位
+    // 训练攻击组单位
     function BuildAttackers takes nothing returns nothing
         local integer index = 0
         local integer unitid
@@ -2583,7 +3007,7 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //============================================================================
-    // 战役基础，运行后调用战役循环
+    // 战役基础线程，内置战役循环
     function CampaignBasics takes nothing returns nothing
         call Sleep(1)
         call CampaignBasicsA()
@@ -2595,7 +3019,7 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //============================================================================
-    // 设置战役AI
+    // 运行战役AI，运行后启用战役基础线程
     function CampaignAI takes integer farms, code heroes returns nothing
         if GetGameDifficulty() == MAP_DIFFICULTY_EASY then
             set difficulty = EASY
@@ -2654,7 +3078,7 @@ native DebugS               takes string str                            returns 
     //============================================================================
     //  SkillArrays
     //============================================================================
-    // 获取技能组，让英雄升级后根据 SetSkillArray 的顺序自动学习技能，该代码在1.30~1.31中因官方BUG无法运行，需要手动使用触发或魔改该代码修正
+    // 技能线程，让英雄升级后根据 SetSkillArray 的顺序自动学习技能，该代码在1.30~1.31中因官方BUG无法运行，需要手动使用触发或魔改该代码修正
     function SkillArrays takes nothing returns integer
         local integer level = GetHeroLevelAI()
     

--- a/static/common.ai
+++ b/static/common.ai
@@ -17,7 +17,8 @@ native DebugS               takes string str                            returns 
     native DisplayTextIII       takes integer p, string str, integer v1, integer v2, integer v3 returns nothing
     // AI脚本是否允许显示调试文本，供开发者DEBUG
     native DoAiScriptDebug      takes nothing                               returns boolean
-    // 获取当前脚本控制的AI玩家（非中立玩家）编号（在1.29及以上版本中，返回的是0~23任意一个实数，以下则是0~11）
+    // 获取当前脚本控制的AI玩家（非中立玩家）编号
+    // 在1.29及以上版本中，返回的是0~23任意一个整数，以下则是0~11
     native GetAiPlayer          takes nothing                               returns integer
     // 英雄升级技能相关函数 获取升级的英雄类型
     native GetHeroId            takes nothing                               returns integer
@@ -39,15 +40,18 @@ native DebugS               takes string str                            returns 
     // 获取指定单位/科技类型的训练/建造/研究时间
     native GetUnitBuildTime     takes integer unitid                        returns integer
     
-    // 拥有的金矿数，对于亡灵，该函数会检查开始点所有矿，而不是只查闹鬼金矿，如果AI开始点有多个未被其他玩家占据的矿，可能会导致亡灵无法正常采矿，因为HarvestGold（0，n）指向到的是该函数在指定基地返回的第一座矿，如果返回的非闹鬼金矿，侍僧就无法采矿
+    // 拥有的金矿数，对于亡灵，该函数会检查开始点所有矿，而不是只查闹鬼金矿
+    // 如果AI开始点有多个未被其他玩家占据的矿，可能会导致亡灵无法正常采矿，因为HarvestGold（0，n）指向到的是该函数在指定基地返回的第一座矿，如果返回的非闹鬼金矿，侍僧就无法采矿
     native GetMinesOwned        takes nothing                               returns integer
-    // 拥有的所有金矿的金钱数量，对于亡灵，该函数会检查开始点所有矿，而不是只查闹鬼金矿，并返回第一座矿，如果此时基地有多个金矿，且金钱数不同，会导致统计值偏差
+    // 拥有的所有金矿的金钱数量，对于亡灵，该函数会检查开始点所有矿，而不是只查闹鬼金矿，并返回第一座矿
+    // 如果开始点有多个金矿，且金钱数不同，会导致统计值偏差
     native GetGoldOwned         takes nothing                               returns integer
-    // 有金矿的基地编号，如果多个基地都有金矿 则返回最小编号，配合TownHasMine检查当前哪座基地有矿时，可以直接获取最小编号，并从该编号查起，避免分基地过多时的逐个查询
+    // 有金矿的基地编号，如果多个基地都有金矿 则返回最小编号
+    // 配合TownHasMine检查当前哪座基地有矿时，可以直接获取最小编号，并从该编号查起，避免分基地过多时的逐个查询
     native TownWithMine         takes nothing                               returns integer
     // 指定编号的基地是否有金矿，0为第一个基地
     native TownHasMine          takes integer townid                        returns boolean
-    // 指定编号的基地是有城镇单位（主城/基地），0为第一个基地
+    // 指定编号的基地是有城镇单位（基地），0为第一个基地
     native TownHasHall          takes integer townid                        returns boolean
     
     // 指定科技类型当前升级的等级（如攻防默认有3级，大师级科技默认有2级）
@@ -58,7 +62,8 @@ native DebugS               takes string str                            returns 
     native GetUpgradeWoodCost   takes integer id                            returns integer
     // 获取下一个扩张点
     native GetNextExpansion     takes nothing                               returns integer
-    // 获取大型攻击目标，此时暴雪会往攻击组添加默认攻击类型为攻城的单位，似乎该单位是某种建筑或位于建筑群中
+    // 获取大型攻击目标
+    // 因运行时暴雪会往攻击组添加默认攻击类型为攻城的单位，故猜测该单位是某种建筑或位于建筑群中
     native GetMegaTarget        takes nothing                               returns unit
     // 获取指定玩家正在训练/建造的单位
     native GetBuilding          takes player p                              returns unit
@@ -70,7 +75,8 @@ native DebugS               takes string str                            returns 
     native GetAllianceTarget    takes nothing                               returns unit
     // 命令训练/建造/研究指定/研究单位/科技(指定数量,单位类型,基地)
     native SetProduce           takes integer qty, integer id, integer town returns boolean
-    // 取消/反召唤指定单位（亡灵卖建筑），单位正在建造/训练会取消，建造完成时可能会被卖掉
+    // 取消指定单位，单位正在建造/训练会取消
+    // 因单词为反召唤，怀疑可用于建造完成时卖建筑（亡灵）
     native Unsummon             takes unit unitid                           returns nothing
     // 建造扩张点/分基地（指定工人（具体到某个单位）和城镇单位的类型）
     native SetExpansion         takes unit peon, integer id                 returns boolean
@@ -78,13 +84,16 @@ native DebugS               takes string str                            returns 
     native SetUpgrade           takes integer id                            returns boolean
     // 设置英雄升级技能函数
     native SetHeroLevels        takes code func                             returns nothing
-    // 是否允许设置新英雄，意义不明，可能和学习技能有关
+    // 是否允许设置新英雄，
+    // 意义不明，可能和学习技能有关
     native SetNewHeroes         takes boolean state                         returns nothing
     // 购买地精飞艇，运行后AI会自动前往地精实验室并自动购买地精飞艇，无需额外命令
     native PurchaseZeppelin     takes nothing                               returns nothing
-    // 训练/建造/研究指定指定数量的合体单位类型（单位类型a,单位类型b,合体成单位类型make），运行后AI会分别训练a和b并合体，直到make数量达标，如角鹰兽和弓箭手合体
+    // 训练/建造/研究指定指定数量的合体单位类型（单位类型a,单位类型b,合体成单位类型make）
+    // 运行后AI会分别训练a和b并合体，直到make数量达标，如角鹰兽和弓箭手合体
     native MergeUnits           takes integer qty, integer a, integer b, integer make returns boolean
-    // 训练/建造/研究指定指定数量的变形单位类型，此变形不是英雄/熊德/鸟德/白牛/猎头/坦克的变身/升级，而是十胜石雕像和毁灭者这种额外付费的个体变形，运行后AI会训练变形前单位并变形，直到数量达标
+    // 训练/建造/研究指定指定数量的变形单位类型，此变形不是英雄/熊德/鸟德/白牛/猎头/坦克的变身/升级，而是十胜石雕像和毁灭者这种额外付费的个体变形
+    // 运行后AI会训练变形前单位并变形，直到数量达标
     native ConvertUnits         takes integer qty, integer id               returns boolean
     
     // 启用战役AI
@@ -134,7 +143,8 @@ native DebugS               takes string str                            returns 
     // 增加指定数量的指定单位类型到防守组
     native AddDefenders         takes integer qty, integer id               returns boolean
     
-    // 获取指定等级范围内的中立敌对玩家控制的单位，即野怪（ture 为可获取飞行单位，false 为不获取），在1.29及以上版本中，中立敌对玩家为玩家24，在以下版本则为12
+    // 获取指定等级范围内的中立敌对玩家控制的单位，即野怪（ture 为可获取飞行单位，false 为不获取）
+    // 在1.29及以上版本中，中立敌对玩家为玩家24，在以下版本则为12
     native GetCreepCamp         takes integer min, integer max, boolean flyers_ok returns unit
     // 开始获取敌人主基地
     native StartGetEnemyBase    takes nothing                               returns nothing
@@ -156,7 +166,8 @@ native DebugS               takes string str                            returns 
     native AttackMoveKill       takes unit target                           returns nothing
     // 让攻击指组攻击指定坐标
     native AttackMoveXY         takes integer x, integer y                  returns nothing
-    // 在指定坐标卸载单位，该命令似乎只对卸载（地精飞艇）技能生效，且AI无需任何辅助代码就能自己控制好飞艇的装卸（运输船不行），建议不要对飞艇类单位发送忽略防守指令，忽略后AI不会自动控制飞艇卸载
+    // 在指定坐标卸载单位，该命令似乎只对卸载（地精飞艇）技能生效，且AI无需任何辅助代码就能自己控制好飞艇的装卸（运输船不行）
+    // 建议不要对飞艇类单位发送忽略防守指令，忽略后AI不会自动控制飞艇卸载
     native LoadZepWave          takes integer x, integer y                  returns nothing
     // 检测自杀式攻击是否满足指定条件（指定玩家），该指令被暴雪用于战役AI
     native SuicidePlayer        takes player id, boolean check_full         returns boolean
@@ -166,13 +177,17 @@ native DebugS               takes string str                            returns 
     native CaptainInCombat      takes boolean attack_captain                returns boolean
     // 指定单位是否有防御塔保护
     native IsTowered            takes unit target                           returns boolean
-    // 清理上一次的AI采集工人分配设置，暴雪在每次运行 HarvestGold 和 HarvestWood 前都进行了清理，但清理后AI可能会交换多个基地之间的农民，比如让A矿的农民去B矿工作，反之亦然
+    // 清理上一次的AI采集工人分配设置，暴雪在每次运行 HarvestGold 和 HarvestWood 前都进行了清理
+    // 清理后AI可能会交换多个基地之间的农民，比如让A矿的农民去B矿工作，反之亦然
     native ClearHarvestAI       takes nothing                               returns nothing
-    // 分配指定数量的工人在指定基地采集金矿，如果金矿和基地之间最短距离的路线可以游过深水地形到达，两栖工人会优先走最短距离到达金矿，但其采集完成返回时自动会停在岸边，就像它忘记自己可以游泳一样
+    // 分配指定数量的工人在指定基地采集金矿
+    // 如果金矿和基地之间最短距离的路线可以游过深水地形到达，两栖工人会优先走最短距离到达金矿，但其采集完成返回时自动会停在岸边，就像它忘记自己可以游泳一样
     native HarvestGold          takes integer town, integer peons           returns nothing
-    // 分配指定数量的工人在指定基地采集木材，如果树和基地之间最短距离的路线可以游过深水地形到达，两栖工人会优先走最短距离到达树，但其采集完成返回时自动停会在岸边，就像它忘记自己可以游泳一样
+    // 分配指定数量的工人在指定基地采集木材
+    // 如果树和基地之间最短距离的路线可以游过深水地形到达，两栖工人会优先走最短距离到达树，但其采集完成返回时自动停会在岸边，就像它忘记自己可以游泳一样
     native HarvestWood          takes integer town, integer peons           returns nothing
-    // 获取开分基地的工人，系统会随机返回一个工人给AI，但可能返回null，如果AI有盟友，返回null的概率似乎会增加，如果是暗夜，建议另行判断工人是否在金矿内（是否运输单位），因为AI不会命令其离开金矿
+    // 获取开分基地的工人，系统会随机返回一个工人给AI，但可能返回null
+    // 如果AI有盟友，返回null的概率似乎会增加，如果是暗夜，建议另行判断工人是否在金矿内（是否运输单位），因为AI不会命令其离开金矿
     native GetExpansionPeon     takes nothing                               returns unit
     // 停止聚集，在初始化时自动调用，且必须调用（默认自动调用，无需理会），调用后，被训练的单位才会执行防守命令，否则只会在训练他们的建筑附近
     native StopGathering        takes nothing                               returns nothing
@@ -184,7 +199,8 @@ native DebugS               takes string str                            returns 
     native ReturnGuardPosts     takes nothing                               returns nothing
     // 创建攻击组
     native CreateCaptains       takes nothing                               returns nothing
-    // 设置指定组（攻击组、防守组、两组一起执行）回家后的集结坐标，AI默认把单位聚在主基地的采矿路线上，应该就是这个坐标
+    // 设置指定组（攻击组、防守组、两组一起执行）回家后的集结坐标
+    // AI默认把单位聚在主基地的采矿路线上，应该就是这个坐标
     native SetCaptainHome       takes integer which, real x, real y         returns nothing
     // 命令攻击组复位（回到 SetCaptainHome 的集结点）
     native ResetCaptainLocs     takes nothing                               returns nothing
@@ -194,7 +210,8 @@ native DebugS               takes string str                            returns 
     native TeleportCaptain      takes real x, real y                        returns nothing
     // 清除攻击组当前的攻击目标
     native ClearCaptainTargets  takes nothing                               returns nothing
-    // 让攻击组攻击到指定坐标，可配合 DisablePathing 控制是否允许攻击组在路上战斗（移动攻击）
+    // 让攻击组攻击到指定坐标
+    // 可配合 DisablePathing 控制是否允许攻击组在路上战斗（移动攻击）
     native CaptainAttack        takes real x, real y                        returns nothing
     // 让攻击组攻击玩家的单位
     native CaptainVsUnits       takes player id                             returns nothing
@@ -210,23 +227,28 @@ native DebugS               takes string str                            returns 
     native CaptainIsEmpty       takes nothing                               returns boolean
     // 攻击组规模，数值越高，规模越大
     native CaptainGroupSize     takes nothing                               returns integer
-    // 攻击组准备情况，似乎是百分制，数值越高，准备越充分
+    // 攻击组准备情况
+    // 似乎是百分制，数值越高，准备越充分
     native CaptainReadiness     takes nothing                               returns integer
     // 攻击组是否在撤退
     native CaptainRetreating    takes nothing                               returns boolean
-    // 攻击组整体生命值，似乎是百分制且转百分比
+    // 攻击组整体生命值
+    // 似乎是百分制且转百分比
     native CaptainReadinessHP   takes nothing                               returns integer
-    // 攻击组整体魔法值，似乎是百分制且转百分比
+    // 攻击组整体魔法值
+    // 似乎是百分制且转百分比
     native CaptainReadinessMa   takes nothing                               returns integer
     // 攻击组是否到达目的地
     native CaptainAtGoal        takes nothing                               returns boolean
-    // 地图上是否还有中立敌对玩家的单位，即野怪，在1.29及以上版本中，中立敌对玩家为玩家24，在以下版本则为12
+    // 地图上是否还有中立敌对玩家的单位，即野怪 
+    // 在1.29及以上版本中，中立敌对玩家为玩家24，在以下版本则为12
     native CreepsOnMap          takes nothing                               returns boolean
     // 在攻击组添加自杀单位，指定单位类型和数量，该指令被暴雪用于战役AI
     native SuicideUnit          takes integer count, integer unitid         returns nothing
     // 在攻击组添加自杀单位，指定单位类型、数量和玩家，该指令被暴雪用于战役AI
     native SuicideUnitEx        takes integer ct, integer uid, integer pid  returns nothing
-    // 开始进程，AI脚本最多可运行6条进程，最多可有6条进程同时运行（包含默认线程，自行添加之前请检查已调用的默认线程数量），不同进程之间互不干涉（异步，即使一条线程在等待，也不影响其他线程），可共用全局变量，但在一条进程运行到读取变量的代码时，可能因变量已在几十秒前被另一个变量改写，造成滞后的假象
+    // 开始进程，AI脚本最多可运行6条进程，且同时运行（包含默认线程，自行添加之前请检查已调用的默认线程数量）
+    // 可共用全局变量，但在一条进程运行到读取变量的代码时，可能因变量已在几十秒前被另一个变量改写，造成滞后的假象
     native StartThread          takes code func                             returns nothing
     // 等待指定时间，按秒计时（期间不执行任何指令）
     native Sleep                takes real seconds                          returns nothing
@@ -243,11 +265,14 @@ native DebugS               takes string str                            returns 
     // 获得命令队列中的指令条数
     native SetAmphibious        takes nothing                               returns nothing
     
-    // 获取指令类型，可通过BJ发送，未发送时获取的值是0，（暴雪用该指令打破循环，exitwhen CommandsWaiting() != 0，比如电影结束后，BJ发送1给AI，这就实现了游戏初始化时运行AI，但电影结束前AI不进攻，只发展），指令包含类型和数据，需灵活运用，比如设定1类为进攻指令，数据0~1代表不同的攻击点，2类为防守指令，数据0~1代表不同的防御点
+    // 获取指令类型，可通过BJ发送，未发送时获取的值是0
+    // 暴雪用该指令打破循环，exitwhen CommandsWaiting() != 0，比如电影结束后，BJ发送1给AI，这就实现了游戏初始化时运行AI，但电影结束前AI不进攻，只发展
     native CommandsWaiting      takes nothing                               returns integer
-    // 获取最新的指令类型，可通过BJ发送，未发送时获取的值是0，指令包含类型和数据，需灵活运用，比如设定1类型为进攻指令，数据0~N代表不同的攻击点，2类型为防守指令，数据0~N代表不同的防御点
+    // 获取最新的指令类型，可通过BJ发送，未发送时获取的值是0，指令包含类型和数据
+    // 需灵活运用，比如设定1类型为进攻指令，数据0~N代表不同的攻击点，2类型为防守指令，数据0~N代表不同的防御点
     native GetLastCommand       takes nothing                               returns integer
-    // 获取最新指令的数据，可通过BJ发送，未发送时获取的值是0，指令包含类型和数据，需灵活运用，比如设定1类型为进攻指令，数据0~N代表不同的攻击点，2类型为防守指令，数据0~N代表不同的防御点
+    // 获取最新指令的数据，可通过BJ发送，未发送时获取的值是0，指令包含类型和数据
+    // 需灵活运用，比如设定1类型为进攻指令，数据0~N代表不同的攻击点，2类型为防守指令，数据0~N代表不同的防御点
     native GetLastData          takes nothing                               returns integer
     // 将最新指令踢出队列
     native PopLastCommand       takes nothing                               returns nothing
@@ -1305,7 +1330,10 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //============================================================================
-    // 标准AI初始化程序，运行后AI将已对战模式开始工作，可指定3条线程并使其开始运行，heroes默认用于英雄学习技能，peons和attacks可自定义
+    // 标准AI初始化程序，运行后AI将已对战模式开始工作，可指定3条线程并使其开始运行
+    // @param heroes默认用于英雄学习技能
+    // @param peons可指定自定义线程
+    // @param attacks可指定自定义线程
     function StandardAI takes code heroes, code peons, code attacks returns nothing
     
         local boolean isNewbie = (MeleeDifficulty() == MELEE_NEWBIE)
@@ -1487,7 +1515,8 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //============================================================================
-    // 初始化攻击组（包含初始化攻击组数组长度、移除受伤单位、移除攻城单位3条命令）
+    // 初始化攻击组
+    // 执行初始化攻击组数组长度、移除受伤单位、移除攻城单位3条命令
     function InitMeleeGroup takes nothing returns nothing
         call InitAssaultGroup()
         call RemoveInjuries()
@@ -1495,7 +1524,8 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //============================================================================
-    // 准备自杀（包含初始化攻击组数组、初始化防御组数组、采集（金和木）工人置零4条命令）
+    // 准备自杀
+    // 执行初始化攻击组数组、初始化防御组数组、采集（金和木）工人置零4条命令
     function PrepFullSuicide takes nothing returns nothing
         call InitAssaultGroup()
         call InitDefenseGroup()
@@ -1504,7 +1534,10 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //============================================================================
-    // 设置3种难度AI的防守单位补充次数
+    // 设置防守单位补充次数
+    // @param easy简单AI的补充次数
+    // @param med中等AI的补充次数
+    // @param hard疯狂AI的补充次数
     function SetReplacements takes integer easy, integer med, integer hard returns nothing
         if difficulty == EASY then
             call SetReplacementCount(easy)
@@ -1523,6 +1556,7 @@ native DebugS               takes string str                            returns 
     
     //============================================================================
     // 设置建造序列，每个建造/训练命令都会被统一引导到此写入建造先后的排序，等 建造线程 建造/训练/研究，当 build_length 重置时，之前的建造/训练/研究队列清空
+    // @param town基地编号，-1为不限
     function SetBuildAll takes integer t, integer qty, integer unitid, integer town returns nothing
         if qty > 0 then
             set build_qty[build_length] = qty
@@ -1550,7 +1584,10 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //============================================================================
-    // 训练/建造/研究指定指定类型的单位/科技（指定各AI难度的数量）
+    // 训练/建造/研究指定指定类型的单位/科技
+    // @param easy简单AI的数量
+    // @param med中等AI的数量
+    // @param hard疯狂AI的数量
     function SetBuildUnitEx takes integer easy, integer med, integer hard, integer unitid returns nothing
         if difficulty == EASY then
             call SetBuildAll(BUILD_UNIT,easy,unitid,-1)
@@ -1563,18 +1600,20 @@ native DebugS               takes string str                            returns 
     
     //============================================================================
     // 在指定编号的基地建造指定数量的单位/科技，一般用于在分矿造塔和其他建筑
+    // @param town基地编号，-1为不限
     function SecondaryTown takes integer town, integer qty, integer unitid returns nothing
         call SetBuildAll(BUILD_UNIT,qty,unitid,town)
     endfunction
     
     //============================================================================
     // 在指定编号的基地建造指定数量的单位/科技，一般用于在分矿造塔和其他建筑
+    // @param town基地编号，-1为不限
     function SecTown takes integer town, integer qty, integer unitid returns nothing
         call SetBuildAll(BUILD_UNIT,qty,unitid,town)
     endfunction
     
     //============================================================================
-    // 研究/升级指定科技（默认简单难度AI不执行该命令，且只研究/升级1级）
+    // 研究/升级指定科技（简单难度AI默认不执行该命令，且只研究/升级1级）
     function SetBuildUpgr takes integer qty, integer unitid returns nothing
         if MeleeDifficulty() != MELEE_NEWBIE or qty == 1 then
             call SetBuildAll(BUILD_UPGRADE,qty,unitid,-1)
@@ -1582,7 +1621,10 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //============================================================================
-    // 研究/升级指定科技（指定各AI难度的数量，指定研究/升级的级数）
+    // 研究/升级指定科技
+    // @param easy简单AI的数量
+    // @param med中等AI的数量
+    // @param hard疯狂AI的数量
     function SetBuildUpgrEx takes integer easy, integer med, integer hard, integer unitid returns nothing
         if difficulty == EASY then
             call SetBuildAll(BUILD_UPGRADE,easy,unitid,-1)
@@ -1601,6 +1643,8 @@ native DebugS               takes string str                            returns 
     
     //============================================================================
     // 开始升级科技
+    // @param level科技等级
+    // @param upgid科技类型
     function StartUpgrade takes integer level, integer upgid returns boolean
         local integer gold_cost
         local integer wood_cost
@@ -1640,6 +1684,8 @@ native DebugS               takes string str                            returns 
     
     //============================================================================
     // 在指定分基地建造指定单位类型，一般用于在分矿造塔或其他建筑，训练单位无需使用此命令，AI会使用所有建筑训练，不论其在哪个基地，使用该命令建造/训练的单位会被登记为：制造于该分基地
+    // @param townid基地编号，-1为不限
+    // @param qty指定数量
     function GuardSecondary takes integer townid, integer qty, integer unitid returns nothing
         if TownHasHall(townid) and TownHasMine(townid) then
             call SecondaryTown( townid, qty, unitid )
@@ -1647,7 +1693,9 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //============================================================================
-    // 获取指定单位类型的数量（指定是否包含建造/训练中，指定是否区分基地）
+    // 获取指定单位类型的数量
+    // @param only_done是否包含建造/训练中的单位
+    // @param townid基地编号，-1为不限
     function GetUnitCountEx takes integer unitid, boolean only_done, integer townid returns integer
         if townid == -1 then
             if only_done then
@@ -1661,7 +1709,10 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //============================================================================
-    // 数量统计，指定单位类型，指定是否包含建造/训练中（only_done），指定分基地（townid，-1为不限），查询复核条件的单位类型数量
+    // 获取指定单位类型的数量，默认用于等价物单位，如城镇/变形单位这一类升级/变形后还当同一种单位统计的单位类型
+    // 例如，统计一本城镇时，会统计一、二、三城镇的数量，统计熊德时，会统计熊德（人形）和熊德（熊形）的数量
+    // @param only_done是否包含建造/训练中的单位
+    // @param townid基地编号，-1为不限
     function TownCountEx takes integer unitid, boolean only_done, integer townid returns integer
     
         local integer have_qty = GetUnitCountEx(unitid,only_done,townid)
@@ -1724,19 +1775,20 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //============================================================================
-    // 数量统计，指定单位类型，包含建造/训练中，不限基地，查询复核条件的单位类型数量
+    // 统计指定单位类型的数量，包含建造/训练中，不限基地，默认用于检测城镇类型的单位（基地）
     function TownCountDone takes integer base returns integer
         return TownCountEx(base,true,-1)
     endfunction
     
     //============================================================================
-    // 数量统计，指定单位类型，不包含建造/训练中，不限基地，查询复核条件的单位类型数量
+    // 统计指定单位类型的数量，不包含建造/训练中，不限基地，默认用于检测城镇类型的单位（基地）
     function TownCount takes integer base returns integer
         return TownCountEx(base,false,-1)
     endfunction
     
     //============================================================================
-    // 基础开分基地，指定单位类型，包含建造/训练中，不限基地，查询复核条件的单位类型数量
+    // 开分基地
+    // @param build_it为假时不执行任何操作，当 build_it 和 HallsCompleted(unitid) 都为真时才会开
     function BasicExpansion takes boolean build_it, integer unitid returns nothing
         if build_it and HallsCompleted(unitid) then
             call SetBuildExpa( TownCount(unitid)+1, unitid )
@@ -1744,13 +1796,17 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //============================================================================
-    // 升级科技，研究指定科技类型（baseid）已完成数量的升级科技类型（newid）
+    // 升级科技
+    // @param baseid指定科技类型
+    // @param newid新升级的数量/等级
     function UpgradeAll takes integer baseid, integer newid returns nothing
         call SetBuildUnit( TownCountDone(baseid), newid )
     endfunction
     
     //============================================================================
-    // 数量统计，指定单位类型（base），指定分基地（townid，-1为不限），不否包含建造/训练中，查询复核条件的单位类型数量，默认用于检测城镇类型的单位（基地）
+    // 统计指定单位类型数量，不否包含建造/训练中，默认用于检测城镇类型的单位（基地）
+    // @param base，指定单位类型
+    // @param townid基地编号，-1为不限
     function TownCountTown takes integer base, integer townid returns integer
         return TownCountEx(base,false,townid)
     endfunction
@@ -1758,7 +1814,12 @@ native DebugS               takes string str                            returns 
     //============================================================================
     //  FoodPool
     //============================================================================
-    // 根据人口占用情况训练指定单位类型，food为当前人口上限，use1为单位类型id1的人口占用（单个），use2为单位类型id2的人口占用（单个），当strong为真时，训练（（food - use1 * TownCount(id1)) / use2）个id2，当strong为假且weak为真时，训练（(food - use2 * TownCount(id2)) / use1）个id1
+    // 根据人口占用情况训练指定单位类型
+    // @param food建议使用当前已用人口
+    // @param use1单位类型id1的人口占用（单个）
+    // @param use2单位类型id2的人口占用（单个）
+    // @param strong当 strong 为真时，不论 weak 如何，训练（（food - use1 * TownCount(id1)) / use2）个id2，
+    // @param weak当 strong 为假且 weak 为真时，训练（(food - use2 * TownCount(id2)) / use1）个id1
     function FoodPool takes integer food, boolean weak, integer id1, integer use1, boolean strong, integer id2, integer use2 returns nothing
         if strong then
             call SetBuildUnit( (food - use1 * TownCount(id1)) / use2, id2 )
@@ -1770,7 +1831,8 @@ native DebugS               takes string str                            returns 
     //============================================================================
     //  MeleeTownHall
     //============================================================================
-    // 补造分基地，当指定的基地（townid）有金矿且该基地没有城镇时，补造一个分基地
+    // 补造分基地，当指定的基地有金矿且该基地没有城镇时，补造一个分基地
+    // @param townid基地编号，-1为不限
     function MeleeTownHall takes integer townid, integer unitid returns nothing
         if TownHasMine(townid) and not TownHasHall(townid) then
             call SecondaryTown ( townid, 1, unitid )
@@ -1788,6 +1850,7 @@ native DebugS               takes string str                            returns 
     
     //============================================================================
     // 开始训练单位/建造建筑
+    // @param town 基地编号，-1为不限
     function StartUnit takes integer ask_qty, integer unitid, integer town returns boolean
         local integer have_qty
         local integer need_qty
@@ -1866,6 +1929,7 @@ native DebugS               takes string str                            returns 
     
     //============================================================================
     // 等待指定的单位类型（包含建造/训练中）数量大于或等于指定数量，满足条件前循环等待，若120秒后仍未满足，自动退出
+    // @param towns 基地编号，-1为不限
     function WaitForTown takes integer towns, integer townid returns nothing
         local integer i = 0
         loop
@@ -1878,6 +1942,8 @@ native DebugS               takes string str                            returns 
     
     //============================================================================
     // 开始建造分基地
+    // @param qty数量
+    // @param hall单位类型
     function StartExpansion takes integer qty, integer hall returns boolean
         local integer count
         local integer town
@@ -2013,7 +2079,9 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //============================================================================
-    // 建造/训练 指定数量（desire）的特殊单位（如角鹰骑士或毁灭者这类合体/变形单位），当指定单位类型的数量（含建造/训练中）大于等于指定数量时，该程序不会运行
+    // 建造/训练特殊单位（如角鹰骑士或毁灭者这类合体/变形单位），当指定单位类型的数量（含建造/训练中）大于等于指定数量时，该程序不会运行
+    // @param desire指定数量
+    // @param unitid指定单位类型
     function Conversions takes integer desire, integer unitid returns nothing
     
         if GetUnitCount(unitid) >= desire then
@@ -2033,6 +2101,9 @@ native DebugS               takes string str                            returns 
     
     //============================================================================
     // 设置攻击组
+    // @param qty最小数量
+    // @param max最大数量
+    // @param unitid单位类型
     function SetAssaultGroup takes integer qty, integer max, integer unitid returns nothing
         call Conversions(max,unitid)
     
@@ -2046,7 +2117,11 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //============================================================================
-    // 循环交错设置进攻组，会设置3种难度AI，e用于简单，m用于中等，h用于困难，1~3分别代表具体的数量（即每个难度都可设置3个档位），u1~u3为单位类型（即每个难度都可设置3种单位类型）
+    // 交错设置进攻组
+    // @param e1~e3 简单AI添加的数量，可设置3个档位
+    // @param m1~m3 中等AI添加的数量，可设置3个档位
+    // @param h1~h3 疯狂AI添加的数量，可设置3个档位
+    // @param u1~u3 添加的单位类型，可设置3种类型，与难度无关
     function Interleave3 takes integer e1, integer m1, integer h1, integer u1, integer e2, integer m2, integer h2, integer u2, integer e3, integer m3, integer h3, integer u3 returns nothing
         local integer i1 = 1
         local integer i2 = 1
@@ -2115,7 +2190,10 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //============================================================================
-    // 将指定类型的单位添加到防御组（指定3种难度AI的添加数量），默认用于战役
+    // 将指定类型的单位添加到防御组，默认用于战役
+    // @param easy简单AI添加的数量
+    // @param med中等AI添加的数量
+    // @param hard疯狂AI添加的数量
     function CampaignDefenderEx takes integer easy, integer med, integer hard, integer unitid returns nothing
         if difficulty == EASY then
             call CampaignDefender(EASY,easy,unitid)
@@ -2127,7 +2205,8 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //============================================================================
-    // 将指定类型的单位添加到战役攻击组（level必须大于等于当前AI难度时才会添加），默认用于战役
+    // 将指定类型的单位添加到战役攻击组，默认用于战役
+    // @param level AI难度，会与当前AI的难度进行比对，输入值必须大于等于当前AI难度时才会添加
     function CampaignAttacker takes integer level, integer qty, integer unitid returns nothing
         if qty > 0 and difficulty >= level then 
             call SetAssaultGroup(qty,qty,unitid)
@@ -2135,7 +2214,10 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //============================================================================
-    // 将指定类型的单位添加到攻击组（指定3种难度AI的添加数量），默认用于战役
+    // 将指定类型的单位添加到攻击组，默认用于战役
+    // @param easy简单AI添加的数量
+    // @param med中等AI添加的数量
+    // @param hard疯狂AI添加的数量
     function CampaignAttackerEx takes integer easy, integer med, integer hard, integer unitid returns nothing
         if difficulty == EASY then
             call CampaignAttacker(EASY,easy,unitid)
@@ -2147,7 +2229,9 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //============================================================================
-    // 等待攻击组完成组建，给予AI一定的时间补充兵力（用testReady指定组的准备情况，为真时需要攻击组准备满50，为假时准备0即可，seconds为最长等待时间）
+    // 等待攻击组完成组建，给予AI一定的时间补充兵力
+    // @param testReady指定组的准备情况，为真时需要攻击组准备满50，为假时准备0即可
+    // @param seconds指定最长等待时间
     function FormGroup takes integer seconds, boolean testReady returns nothing
         local integer index
         local integer count
@@ -2219,7 +2303,8 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //============================================================================
-    // 获取当前累计的等待时间（WavePrepare的累计时间），无等待时返回默认值--30秒
+    // 获取当前累计的等待时间（WavePrepare的累计时间）
+    // 无等待时返回默认值 30秒
     function PrepTime takes nothing returns integer
         local integer unitid
         local integer missing
@@ -2273,7 +2358,8 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //============================================================================
-    // 进军等待，攻击组撤退、攻击组到达目的地、攻击组回到家、攻击组为空 任意事件返回 是 时，结束等待
+    // 进军等待
+    // 攻击组撤退、攻击组到达目的地、攻击组回到家、攻击组为空 任意事件返回 是 时，结束等待
     function SleepUntilAtGoal takes nothing returns nothing
         loop
             exitwhen CaptainRetreating()
@@ -2285,7 +2371,8 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //============================================================================
-    // 战斗等待，攻击组脱离战斗 或 攻击组为空 时，退出内层循环，当内层循环退出8次时，退出外层循环，两层循环都退出时，结束等待
+    // 战斗等待
+    // 攻击组脱离战斗 或 攻击组为空 时，退出内层循环，当内层循环退出8次时，退出外层循环，两层循环都退出时，结束等待
     function SleepInCombat takes nothing returns nothing
         local integer count = 0
         debug call Trace("SleepInCombat\n")
@@ -2317,7 +2404,7 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //============================================================================
-    // 通报各波次进攻情况（默认使用Trace命令发送文字，可能需要打开调试模式）
+    // 通报各波次进攻情况（默认使用Trace命令发送文字，查看可能需要打开调试模式）
     function SuicideOnPlayerWave takes nothing returns nothing
         call Trace("waiting for attack wave to enter combat\n") //xxx
         loop
@@ -2372,7 +2459,8 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //--------------------------------------------------------------------------------------------------
-    // 设置各波次进攻，默认用于自杀式攻击，启用standard时判断退出条件
+    // 设置各波次进攻，默认用于自杀式攻击
+    // @param standard为真时会判断退出条件
     function CommonSuicideOnPlayer takes boolean standard, boolean bldgs, integer seconds, player p, integer x, integer y returns nothing
         local integer save_peons
     
@@ -2474,7 +2562,10 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //--------------------------------------------------------------------------------------------------
-    // 添加自杀单位类型到攻击组，指定3种AI难度的数量
+    // 添加自杀单位类型到攻击组
+    // @param easy简单AI添加的数量
+    // @param med中等AI添加的数量
+    // @param hard疯狂AI添加的数量
     function SuicideOnce takes integer easy, integer med, integer hard, integer unitid returns nothing
         if difficulty == EASY then
             call SuicideUnit(easy,unitid)
@@ -2504,7 +2595,8 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //--------------------------------------------------------------------------------------------------
-    // 循环添加自杀单位到单位组（指定单位类型，u1~uA），该循环不会退出
+    // 循环添加自杀单位到单位组，该循环不会退出
+    // @param u1~uA 单位类型，可指定10种
     function SuicideUnits takes integer u1, integer u2, integer u3, integer u4, integer u5, integer u6, integer u7, integer u8, integer u9, integer uA returns nothing
         call Trace("MASS SUICIDE - this script is now technically done\n") //xxx
     
@@ -2524,7 +2616,9 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //--------------------------------------------------------------------------------------------------
-    // 循环添加自杀单位类型到单位组（指定玩家，指定单位类型：u1~uA），该循环不会退出
+    // 循环添加自杀单位类型到单位组，该循环不会退出
+    // @param playerid指定玩家
+    // @param u1~uA 单位类型，可指定10种
     function SuicideUnitsEx takes integer playerid, integer u1, integer u2, integer u3, integer u4, integer u5, integer u6, integer u7, integer u8, integer u9, integer uA returns nothing
         call Trace("MASS SUICIDE - this script is now technically done\n") //xxx
     
@@ -2544,7 +2638,10 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //--------------------------------------------------------------------------------------------------
-    // 自杀式攻击（指定玩家），指定3种难度的等待时间
+    // 自杀式攻击（指定玩家）
+    // @param easy简单AI的等待时间
+    // @param med中等AI的等待时间
+    // @param hard疯狂AI的等待时间
     function SuicideOnPlayerEx takes integer easy, integer med, integer hard, player p returns nothing
         if difficulty == EASY then
             call SuicideOnPlayer(easy,p)
@@ -2556,7 +2653,10 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //--------------------------------------------------------------------------------------------------
-    // 自杀式攻击（指定玩家），指定3种难度的等待时间
+    // 自杀式攻击（指定玩家）
+    // @param easy简单AI的等待时间
+    // @param med中等AI的等待时间
+    // @param hard疯狂AI的等待时间
     function SuicideOnUnitsEx takes integer easy, integer med, integer hard, player p returns nothing
         if difficulty == EASY then
             call SuicideOnUnits(easy,p)
@@ -2568,7 +2668,10 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //--------------------------------------------------------------------------------------------------
-    // 自杀式攻击（指定坐标），指定3种难度的等待时间
+    // 自杀式攻击（指定坐标）
+    // @param easy简单AI的等待时间
+    // @param med中等AI的等待时间
+    // @param hard疯狂AI的等待时间
     function SuicideOnPointEx takes integer easy, integer med, integer hard, player p, integer x, integer y returns nothing
         if difficulty == EASY then
             call SuicideOnPoint(easy,p,x,y)
@@ -2618,13 +2721,15 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //============================================================================
-    // 至死方休（指定目标），死为目标死亡或攻击组死光/撤退，会调用战斗程序CommonSleepUntilTargetDead，reform默认为假
+    // 至死方休（指定目标），死为目标死亡或攻击组死光/撤退
+    // 调用战斗程序CommonSleepUntilTargetDead，且reform默认为假
     function SleepUntilTargetDead takes unit target returns nothing
         call CommonSleepUntilTargetDead(target,false)
     endfunction
     
     //============================================================================
-    // 至死方休（指定目标），死为目标死亡或攻击组死光/撤退，会调用战斗程序CommonSleepUntilTargetDead，reform默认为真
+    // 至死方休（指定目标），死为目标死亡或攻击组死光/撤退
+    // 调用战斗程序CommonSleepUntilTargetDead，且reform默认为真
     function ReformUntilTargetDead takes unit target returns nothing
         debug call Trace("ReformUntilTargetDead\n")
         call CommonSleepUntilTargetDead(target,true)
@@ -2663,7 +2768,8 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //============================================================================
-    // 攻击中立敌对玩家（打野），根据当前的min_creeps、max_creeps，allow_air_creeps获取野怪
+    // 攻击中立敌对玩家（打野）
+    // 根据当前的min_creeps、max_creeps，allow_air_creeps获取野怪
     function CreepAttackEx takes nothing returns nothing
         local unit target = GetCreepCamp(min_creeps,max_creeps,allow_air_creeps)
         call SetAllianceTarget(target)
@@ -2754,6 +2860,10 @@ native DebugS               takes string str                            returns 
     //  SingleMeleeAttack
     //============================================================================
     // 对战进攻循环，包含打野、开矿、攻击玩家、购买飞艇等命令
+    // @param needs_exp 是否开矿
+    // @param has_siege 是否包含攻城单位
+    // @param major_ok 是否允许攻击大型野怪营地（中立敌对玩家）
+    // @param air_units 获取野怪营地时是否包含飞行单位
     function SingleMeleeAttack takes boolean needs_exp, boolean has_siege, boolean major_ok, boolean air_units returns nothing
         local boolean   can_siege
         local real      daytime 
@@ -2916,7 +3026,8 @@ native DebugS               takes string str                            returns 
     endfunction
     
     //============================================================================
-    // 获取当前AI玩家人口建筑提供的人口数量，已完成的人口建筑（默认为racial_farm）*该建筑提供的人口数 + 已完成的主城（base指定）*该建筑提供的人口数
+    // 获取当前AI玩家人口建筑提供的人口数量
+    // 公式：已完成的人口建筑数量（默认单位类型为racial_farm）*该建筑提供的人口数 + 已完成的城镇数量（单位类型用base指定）*该建筑提供的人口数
     function FoodAvail takes integer base returns integer
         return GetFoodMade(racial_farm) * TownCount(racial_farm) + GetFoodMade(base) * TownCount(base)
     endfunction
@@ -3027,6 +3138,8 @@ native DebugS               takes string str                            returns 
     
     //============================================================================
     // 运行战役AI，运行后开始运行战役基础线程
+    // @param farms 指定人口建筑的单位类型（即指定racial_farm）
+    // @param heroes 指定英雄升级函数
     function CampaignAI takes integer farms, code heroes returns nothing
         if GetGameDifficulty() == MAP_DIFFICULTY_EASY then
             set difficulty = EASY
@@ -3085,7 +3198,8 @@ native DebugS               takes string str                            returns 
     //============================================================================
     //  SkillArrays
     //============================================================================
-    // 技能线程，让英雄升级后根据 SetSkillArray 的顺序自动学习技能，该代码在1.30~1.31中因官方BUG无法运行，需要手动使用触发或魔改该代码修正
+    // 技能线程，让英雄升级后根据 SetSkillArray 的顺序自动学习技能
+    // 该代码在1.30~1.31中因官方BUG无法运行，需要手动使用触发或魔改该代码修正
     function SkillArrays takes nothing returns integer
         local integer level = GetHeroLevelAI()
     
@@ -3105,7 +3219,9 @@ native DebugS               takes string str                            returns 
     //--------------------------------------------------------------------------------------------------
     //  SetSkillArray
     //--------------------------------------------------------------------------------------------------
-    // 设置3个英雄的技能学习顺序（index 为1/2/3，分别对应三个英雄），id为三个英雄的单位类型，默认只能设置10级
+    // 设置3个英雄的技能学习顺序，默认只能设置10级
+    // @param index 仅可输入1和2，其他值都会默认视为3，分别代表首、二、三发英雄
+    // @param id，分别代表首、二、三发英雄对应的单位类型
     function SetSkillArray takes integer index, integer id returns nothing
         local integer i = 1
     
@@ -3142,7 +3258,8 @@ native DebugS               takes string str                            returns 
     //============================================================================
     //  AwaitMeleeHeroes
     //============================================================================
-    // 等待二发英雄，当首发英雄完成训练/复活，且 【take_exp为真 或 二发英雄存在且完成训练/复活时】 结束等待，否则循环等待
+    // 等待二发英雄
+    // 当首发英雄完成训练/复活，且 【take_exp为真 或 二发英雄存在且完成训练/复活时】 结束等待，否则循环等待
     function AwaitMeleeHeroes takes nothing returns nothing
         if GetUnitCountDone(hero_id2) > 0 then
             set two_heroes = true
@@ -3156,7 +3273,9 @@ native DebugS               takes string str                            returns 
     //============================================================================
     //  PickMeleeHero 
     //============================================================================
-    // 设置对战英雄（含混乱之治和冰封王座），设置4个种族的默认英雄（不含中立）及本局随机顺序（首发，二发，三发），4族之外的种族默认为空，heroes[4]默认为冰封王座新加的英雄，不会出现在混乱之治中
+    // 设置对战英雄（含混乱之治和冰封王座），设置4个种族的默认英雄（不含中立）及本局随机顺序（首发，二发，三发）
+    // @param raceid指代种族，4族之外的其他种族会默认为空
+    // heroes[4]默认为冰封王座新加的英雄，不会出现在混乱之治中
     function PickMeleeHero takes race raceid returns integer
         local integer first
         local integer second

--- a/static/common.j
+++ b/static/common.j
@@ -630,7 +630,7 @@ globals
 	constant subanimtype SUBANIM_TYPE_RIGHT = ConvertSubAnimType(25)
 	// 子动画类型 - 开火
 	constant subanimtype SUBANIM_TYPE_FIRE = ConvertSubAnimType(26)
-	// 子动画类型 - 刮
+	// 子动画类型 - 吃肉
 	constant subanimtype SUBANIM_TYPE_FLESH = ConvertSubAnimType(27)
 	// 子动画类型 - 打击
 	constant subanimtype SUBANIM_TYPE_HIT = ConvertSubAnimType(28)
@@ -706,19 +706,19 @@ globals
 	
 	// Map Setup Constants
 	
-	// 固定玩家种族为 人类
+	// 预设玩家种族 人类
 	constant racepreference RACE_PREF_HUMAN = ConvertRacePref(1)
-	// 固定玩家种族为 兽族
+	// 预设玩家种族 兽族
 	constant racepreference RACE_PREF_ORC = ConvertRacePref(2)
-	// 固定玩家种族为 暗夜
+	// 预设玩家种族 暗夜
 	constant racepreference RACE_PREF_NIGHTELF = ConvertRacePref(4)
-	// 固定玩家种族为 亡灵
+	// 预设玩家种族 亡灵
 	constant racepreference RACE_PREF_UNDEAD = ConvertRacePref(8)
-	// 固定玩家种族为 恶魔
+	// 预设玩家种族 恶魔
 	constant racepreference RACE_PREF_DEMON = ConvertRacePref(16)
-	// 固定玩家种族为 随机
+	// 预设玩家种族 随机
 	constant racepreference RACE_PREF_RANDOM = ConvertRacePref(32)
-	// 固定玩家种族为 用户可选择
+	// 预设玩家种族 用户可选择
 	constant racepreference RACE_PREF_USER_SELECTABLE = ConvertRacePref(64)
 	// 玩家控制者类型 用户
 	constant mapcontrol MAP_CONTROL_USER = ConvertMapControl(0)
@@ -732,67 +732,67 @@ globals
 	constant mapcontrol MAP_CONTROL_CREEP = ConvertMapControl(4)
 	// 玩家控制者类型 没有玩家
 	constant mapcontrol MAP_CONTROL_NONE = ConvertMapControl(5)
-	// 游戏类型-对战
+	// 游戏类型 - 对战
 	constant gametype GAME_TYPE_MELEE = ConvertGameType(1)
-	// 游戏类型-自由竞赛
+	// 游戏类型 - 自由竞赛
 	constant gametype GAME_TYPE_FFA = ConvertGameType(2)
-	// 游戏类型-使用地图设置
+	// 游戏类型 - 使用地图设置
 	constant gametype GAME_TYPE_USE_MAP_SETTINGS = ConvertGameType(4)
-	// 游戏类型-官方地图
+	// 游戏类型 - 官方地图
 	constant gametype GAME_TYPE_BLIZ = ConvertGameType(8)
-	// 游戏类型- 1 V 1
+	// 游戏类型 -  1 V 1
 	constant gametype GAME_TYPE_ONE_ON_ONE = ConvertGameType(16)
-	// 游戏类型-2队竞赛
+	// 游戏类型 - 2支队伍竞赛
 	constant gametype GAME_TYPE_TWO_TEAM_PLAY = ConvertGameType(32)
-	// 游戏类型-3队竞赛
+	// 游戏类型 - 3支队伍竞赛
 	constant gametype GAME_TYPE_THREE_TEAM_PLAY = ConvertGameType(64)
-	// 游戏类型-4队竞赛
+	// 游戏类型 - 4支队伍竞赛
 	constant gametype GAME_TYPE_FOUR_TEAM_PLAY = ConvertGameType(128)
-	// 地图迷雾-隐藏地图（默认迷雾状态）
+	// 地图迷雾 - 隐藏地图（默认迷雾状态）
 	constant mapflag MAP_FOG_HIDE_TERRAIN = ConvertMapFlag(1)
-	// 地图迷雾-地图已探索（探索后总是可见）
+	// 地图迷雾 - 地图已探索（探索后总是可见）
 	constant mapflag MAP_FOG_MAP_EXPLORED = ConvertMapFlag(2)
-	// 地图迷雾-总是可见
+	// 地图迷雾 - 总是可见
 	constant mapflag MAP_FOG_ALWAYS_VISIBLE = ConvertMapFlag(4)
-	// 地图-使用障碍
+	// 地图 - 使用障碍
 	constant mapflag MAP_USE_HANDICAPS = ConvertMapFlag(8)
-	// 地图-允许有观察者
+	// 地图 - 允许有观察者
 	constant mapflag MAP_OBSERVERS = ConvertMapFlag(16)
-	// 地图-默认为观看者
+	// 地图 - 默认为观看者
 	constant mapflag MAP_OBSERVERS_ON_DEATH = ConvertMapFlag(32)
-	// 地图-固定玩家颜色
+	// 地图 - 固定玩家颜色
 	constant mapflag MAP_FIXED_COLORS = ConvertMapFlag(128)
-	// 地图-禁止资源交易
+	// 地图 - 禁止资源交易
 	constant mapflag MAP_LOCK_RESOURCE_TRADING = ConvertMapFlag(256)
-	// 地图-容许联盟资源交易
+	// 地图 - 容许联盟资源交易
 	constant mapflag MAP_RESOURCE_TRADING_ALLIES_ONLY = ConvertMapFlag(512)
-	// 地图-禁止改变联盟类型
+	// 地图 - 禁止改变联盟类型
 	constant mapflag MAP_LOCK_ALLIANCE_CHANGES = ConvertMapFlag(1024)
-	// 地图-隐藏联盟类型改变
+	// 地图 - 隐藏联盟类型改变
 	constant mapflag MAP_ALLIANCE_CHANGES_HIDDEN = ConvertMapFlag(2048)
-	// 地图-允许作弊码
+	// 地图 - 允许作弊码
 	constant mapflag MAP_CHEATS = ConvertMapFlag(4096)
-	// 地图-隐藏作弊码
+	// 地图 - 隐藏作弊码
 	constant mapflag MAP_CHEATS_HIDDEN = ConvertMapFlag(8192)
-	// 地图-锁定游戏速度
+	// 地图 - 锁定游戏速度
 	constant mapflag MAP_LOCK_SPEED = ConvertMapFlag(8192 * 2)
-	// 地图-禁止随机游戏速度
+	// 地图 - 禁止随机游戏速度
 	constant mapflag MAP_LOCK_RANDOM_SEED = ConvertMapFlag(8192 * 4)
-	// 地图-共享高级控制
+	// 地图 - 共享高级控制
 	constant mapflag MAP_SHARED_ADVANCED_CONTROL = ConvertMapFlag(8192 * 8)
-	// 地图-随机英雄
+	// 地图 - 随机英雄
 	constant mapflag MAP_RANDOM_HERO = ConvertMapFlag(8192 * 16)
-	// 地图-随机种族
+	// 地图 - 随机种族
 	constant mapflag MAP_RANDOM_RACES = ConvertMapFlag(8192 * 32)
-	// 地图-地图转换
+	// 地图 - 地图转换
 	constant mapflag MAP_RELOADED = ConvertMapFlag(8192 * 64)
-	// 地图-玩家开始点随机
+	// 地图 - 玩家开始点随机
 	constant placement MAP_PLACEMENT_RANDOM = ConvertPlacement(0)   // random among all slots
-	// 地图-玩家开始点固定
+	// 地图 - 玩家开始点固定
 	constant placement MAP_PLACEMENT_FIXED = ConvertPlacement(1)   // player 0 in start loc 0...
-	// 地图-使用地图设置的玩家开始点
+	// 地图 - 使用地图设置的玩家开始点
 	constant placement MAP_PLACEMENT_USE_MAP_SETTINGS = ConvertPlacement(2)   // whatever was specified by the script
-	// 地图-联盟玩家开始点放在一起
+	// 地图 - 联盟玩家开始点放在一起
 	constant placement MAP_PLACEMENT_TEAMS_TOGETHER = ConvertPlacement(3)   // random with allies next to each other
 	// 起始位置分布优先权-低
 	constant startlocprio MAP_LOC_PRIO_LOW = ConvertStartLocPrio(0)
@@ -800,13 +800,13 @@ globals
 	constant startlocprio MAP_LOC_PRIO_HIGH = ConvertStartLocPrio(1)
 	// 起始位置分布优先权-无
 	constant startlocprio MAP_LOC_PRIO_NOT = ConvertStartLocPrio(2)
-	// 地图-无密度
+	// 地图 - 无密度
 	constant mapdensity MAP_DENSITY_NONE = ConvertMapDensity(0)
-	// 地图-低密度
+	// 地图 - 低密度
 	constant mapdensity MAP_DENSITY_LIGHT = ConvertMapDensity(1)
-	// 地图-中等密度
+	// 地图 - 中等密度
 	constant mapdensity MAP_DENSITY_MEDIUM = ConvertMapDensity(2)
-	// 地图-高密度
+	// 地图 - 高密度
 	constant mapdensity MAP_DENSITY_HEAVY = ConvertMapDensity(3)
 	
 	// 游戏难度 简单
@@ -2794,7 +2794,7 @@ globals
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_HTB1 = ConvertAbilityRealLevelField('Htb1')
     // 技能实数等级域 范围伤害 ('Htc1')
 	constant abilityreallevelfield ABILITY_RLF_AOE_DAMAGE = ConvertAbilityRealLevelField('Htc1')
-    // 技能实数等级域 指定目标伤害 ('Htc2')
+    // 技能实数等级域 指定目标伤害（无效） ('Htc2')
 	constant abilityreallevelfield ABILITY_RLF_SPECIFIC_TARGET_DAMAGE_HTC2 = ConvertAbilityRealLevelField('Htc2')
     // 技能实数等级域 移动速度减少（%） ('Htc3')
 	constant abilityreallevelfield ABILITY_RLF_MOVEMENT_SPEED_REDUCTION_PERCENT_HTC3 = ConvertAbilityRealLevelField('Htc3')
@@ -2806,9 +2806,9 @@ globals
 	constant abilityreallevelfield ABILITY_RLF_AMOUNT_HEALED_DAMAGED_HHB1 = ConvertAbilityRealLevelField('Hhb1')
     // 技能实数等级域 附加伤害 ('Hca1')
 	constant abilityreallevelfield ABILITY_RLF_EXTRA_DAMAGE_HCA1 = ConvertAbilityRealLevelField('Hca1')
-    // 技能实数等级域 移动速度系数（%） ('Hca2')
+    // 技能实数等级域 移动速度减少（%） ('Hca2')
 	constant abilityreallevelfield ABILITY_RLF_MOVEMENT_SPEED_FACTOR_HCA2 = ConvertAbilityRealLevelField('Hca2')
-    // 技能实数等级域 攻击速度系数（%） ('Hca3')
+    // 技能实数等级域 攻击速度减少（%） ('Hca3')
 	constant abilityreallevelfield ABILITY_RLF_ATTACK_SPEED_FACTOR_HCA3 = ConvertAbilityRealLevelField('Hca3')
     // 技能实数等级域 移动速度增加（%） ('Oae1')
 	constant abilityreallevelfield ABILITY_RLF_MOVEMENT_SPEED_INCREASE_PERCENT_OAE1 = ConvertAbilityRealLevelField('Oae1')
@@ -3108,351 +3108,351 @@ globals
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_CTB1 = ConvertAbilityRealLevelField('Ctb1')
     // 技能实数等级域 魔法施放延迟 ('Uds2')
 	constant abilityreallevelfield ABILITY_RLF_CASTING_DELAY_SECONDS = ConvertAbilityRealLevelField('Uds2')
-    // 技能实数等级域 
+    // 技能实数等级域 范围目标魔法损耗 ('Dtn1')
 	constant abilityreallevelfield ABILITY_RLF_MANA_LOSS_PER_UNIT_DTN1 = ConvertAbilityRealLevelField('Dtn1')
-    // 技能实数等级域 
+    // 技能实数等级域 对召唤单位伤害 ('Dtn2')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_TO_SUMMONED_UNITS_DTN2 = ConvertAbilityRealLevelField('Dtn2')
-    // 技能实数等级域 
+    // 技能实数等级域 转变时间 ('Ivs1')
 	constant abilityreallevelfield ABILITY_RLF_TRANSITION_TIME_SECONDS = ConvertAbilityRealLevelField('Ivs1')
-    // 技能实数等级域 
+    // 技能实数等级域 每秒魔法消耗 ('Nmr1')
 	constant abilityreallevelfield ABILITY_RLF_MANA_DRAINED_PER_SECOND_NMR1 = ConvertAbilityRealLevelField('Nmr1')
-    // 技能实数等级域 
+    // 技能实数等级域 减少伤害几率（%） ('Ssk1')
 	constant abilityreallevelfield ABILITY_RLF_CHANCE_TO_REDUCE_DAMAGE_PERCENT = ConvertAbilityRealLevelField('Ssk1')
-    // 技能实数等级域 
+    // 技能实数等级域 最小伤害 ('Ssk2')
 	constant abilityreallevelfield ABILITY_RLF_MINIMUM_DAMAGE = ConvertAbilityRealLevelField('Ssk2')
-    // 技能实数等级域 
+    // 技能实数等级域 忽略伤害 ('Ssk3')
 	constant abilityreallevelfield ABILITY_RLF_IGNORED_DAMAGE = ConvertAbilityRealLevelField('Ssk3')
-    // 技能实数等级域 
+    // 技能实数等级域 全伤害数值 ('Hfs1')
 	constant abilityreallevelfield ABILITY_RLF_FULL_DAMAGE_DEALT = ConvertAbilityRealLevelField('Hfs1')
-    // 技能实数等级域 
+    // 技能实数等级域 全伤害间隔 ('Hfs2')
 	constant abilityreallevelfield ABILITY_RLF_FULL_DAMAGE_INTERVAL = ConvertAbilityRealLevelField('Hfs2')
-    // 技能实数等级域 
+    // 技能实数等级域 半伤害数值 ('Hfs3')
 	constant abilityreallevelfield ABILITY_RLF_HALF_DAMAGE_DEALT = ConvertAbilityRealLevelField('Hfs3')
-    // 技能实数等级域 
+    // 技能实数等级域 半伤害间隔 ('Hfs4')
 	constant abilityreallevelfield ABILITY_RLF_HALF_DAMAGE_INTERVAL = ConvertAbilityRealLevelField('Hfs4')
-    // 技能实数等级域 
+    // 技能实数等级域 建筑伤害因素（%） ('Hfs5')
 	constant abilityreallevelfield ABILITY_RLF_BUILDING_REDUCTION_HFS5 = ConvertAbilityRealLevelField('Hfs5')
-    // 技能实数等级域 
+    // 技能实数等级域 最大伤害 ('Hfs6')
 	constant abilityreallevelfield ABILITY_RLF_MAXIMUM_DAMAGE_HFS6 = ConvertAbilityRealLevelField('Hfs6')
-    // 技能实数等级域 
+    // 技能实数等级域 每点魔法抵消的伤害值 ('Nms1')
 	constant abilityreallevelfield ABILITY_RLF_MANA_PER_HIT_POINT = ConvertAbilityRealLevelField('Nms1')
-    // 技能实数等级域 
+    // 技能实数等级域 伤害吸收（%） ('Nms2')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_ABSORBED_PERCENT = ConvertAbilityRealLevelField('Nms2')
-    // 技能实数等级域 
+    // 技能实数等级域 波距离 ('Uim1')
 	constant abilityreallevelfield ABILITY_RLF_WAVE_DISTANCE = ConvertAbilityRealLevelField('Uim1')
-    // 技能实数等级域 
+    // 技能实数等级域 波持续时间 ('Uim2')
 	constant abilityreallevelfield ABILITY_RLF_WAVE_TIME_SECONDS = ConvertAbilityRealLevelField('Uim2')
-    // 技能实数等级域 
+    // 技能实数等级域 施加伤害 ('Uim3')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_DEALT_UIM3 = ConvertAbilityRealLevelField('Uim3')
-    // 技能实数等级域 
+    // 技能实数等级域 空中停留时间 ('Uim4')
 	constant abilityreallevelfield ABILITY_RLF_AIR_TIME_SECONDS_UIM4 = ConvertAbilityRealLevelField('Uim4')
-    // 技能实数等级域 
+    // 技能实数等级域 单位施放间隔 ('Uls2')
 	constant abilityreallevelfield ABILITY_RLF_UNIT_RELEASE_INTERVAL_SECONDS = ConvertAbilityRealLevelField('Uls2')
-    // 技能实数等级域 
+    // 技能实数等级域 生命偷取参数 ('Uls4')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_RETURN_FACTOR = ConvertAbilityRealLevelField('Uls4')
-    // 技能实数等级域 
+    // 技能实数等级域 生命偷取极限 ('Uls5')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_RETURN_THRESHOLD = ConvertAbilityRealLevelField('Uls5')
-    // 技能实数等级域 
+    // 技能实数等级域 近战伤害反弹 ('Uts1')
 	constant abilityreallevelfield ABILITY_RLF_RETURNED_DAMAGE_FACTOR = ConvertAbilityRealLevelField('Uts1')
-    // 技能实数等级域 
+    // 技能实数等级域 所受近战伤害（%） ('Uts2')
 	constant abilityreallevelfield ABILITY_RLF_RECEIVED_DAMAGE_FACTOR = ConvertAbilityRealLevelField('Uts2')
-    // 技能实数等级域 
+    // 技能实数等级域 防御奖励 ('Uts3')
 	constant abilityreallevelfield ABILITY_RLF_DEFENSE_BONUS_UTS3 = ConvertAbilityRealLevelField('Uts3')
-    // 技能实数等级域 
+    // 技能实数等级域 伤害奖励 ('Nba1')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_BONUS_NBA1 = ConvertAbilityRealLevelField('Nba1')
-    // 技能实数等级域 
+    // 技能实数等级域 召唤单位持续时间 ('Nba3')
 	constant abilityreallevelfield ABILITY_RLF_SUMMONED_UNIT_DURATION_SECONDS_NBA3 = ConvertAbilityRealLevelField('Nba3')
-    // 技能实数等级域 
+    // 技能实数等级域 召唤单位每点生命需要的魔法值 ('Cmg2')
 	constant abilityreallevelfield ABILITY_RLF_MANA_PER_SUMMONED_HITPOINT = ConvertAbilityRealLevelField('Cmg2')
-    // 技能实数等级域 
+    // 技能实数等级域 增加当前生命值 ('Cmg3')
 	constant abilityreallevelfield ABILITY_RLF_CHARGE_FOR_CURRENT_LIFE = ConvertAbilityRealLevelField('Cmg3')
-    // 技能实数等级域 
+    // 技能实数等级域 生命值汲取 ('Ndr1')
 	constant abilityreallevelfield ABILITY_RLF_HIT_POINTS_DRAINED = ConvertAbilityRealLevelField('Ndr1')
-    // 技能实数等级域 
+    // 技能实数等级域 魔法值汲取 ('Ndr2')
 	constant abilityreallevelfield ABILITY_RLF_MANA_POINTS_DRAINED = ConvertAbilityRealLevelField('Ndr2')
-    // 技能实数等级域 
+    // 技能实数等级域 汲取间隔 ('Ndr3')
 	constant abilityreallevelfield ABILITY_RLF_DRAIN_INTERVAL_SECONDS = ConvertAbilityRealLevelField('Ndr3')
-    // 技能实数等级域 
+    // 技能实数等级域 每秒传输的生命值 ('Ndr4')
 	constant abilityreallevelfield ABILITY_RLF_LIFE_TRANSFERRED_PER_SECOND = ConvertAbilityRealLevelField('Ndr4')
-    // 技能实数等级域 
+    // 技能实数等级域 每秒传输的魔法值 ('Ndr5')
 	constant abilityreallevelfield ABILITY_RLF_MANA_TRANSFERRED_PER_SECOND = ConvertAbilityRealLevelField('Ndr5')
-    // 技能实数等级域 
+    // 技能实数等级域 生命值奖励参数 ('Ndr6')
 	constant abilityreallevelfield ABILITY_RLF_BONUS_LIFE_FACTOR = ConvertAbilityRealLevelField('Ndr6')
-    // 技能实数等级域 
+    // 技能实数等级域 生命值奖励衰减 ('Ndr7')
 	constant abilityreallevelfield ABILITY_RLF_BONUS_LIFE_DECAY = ConvertAbilityRealLevelField('Ndr7')
-    // 技能实数等级域 
+    // 技能实数等级域 魔法值奖励参数 ('Ndr8')
 	constant abilityreallevelfield ABILITY_RLF_BONUS_MANA_FACTOR = ConvertAbilityRealLevelField('Ndr8')
-    // 技能实数等级域 
+    // 技能实数等级域 魔法值奖励衰减 ('Ndr9')
 	constant abilityreallevelfield ABILITY_RLF_BONUS_MANA_DECAY = ConvertAbilityRealLevelField('Ndr9')
-    // 技能实数等级域 
+    // 技能实数等级域 未命中率（%） ('Nsi2')
 	constant abilityreallevelfield ABILITY_RLF_CHANCE_TO_MISS_PERCENT = ConvertAbilityRealLevelField('Nsi2')
-    // 技能实数等级域 
+    // 技能实数等级域 移动速度增加（%） ('Nsi3')
 	constant abilityreallevelfield ABILITY_RLF_MOVEMENT_SPEED_MODIFIER = ConvertAbilityRealLevelField('Nsi3')
-    // 技能实数等级域 
+    // 技能实数等级域 攻击速度增加（%） ('Nsi4')
 	constant abilityreallevelfield ABILITY_RLF_ATTACK_SPEED_MODIFIER = ConvertAbilityRealLevelField('Nsi4')
-    // 技能实数等级域 
+    // 技能实数等级域 每秒伤害 ('Tdg1')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_PER_SECOND_TDG1 = ConvertAbilityRealLevelField('Tdg1')
-    // 技能实数等级域 
+    // 技能实数等级域 中范围半径 ('Tdg2')
 	constant abilityreallevelfield ABILITY_RLF_MEDIUM_DAMAGE_RADIUS_TDG2 = ConvertAbilityRealLevelField('Tdg2')
-    // 技能实数等级域 
+    // 技能实数等级域 中范围每秒伤害 ('Tdg3')
 	constant abilityreallevelfield ABILITY_RLF_MEDIUM_DAMAGE_PER_SECOND = ConvertAbilityRealLevelField('Tdg3')
-    // 技能实数等级域 
+    // 技能实数等级域 小范围半径 ('Tdg4')
 	constant abilityreallevelfield ABILITY_RLF_SMALL_DAMAGE_RADIUS_TDG4 = ConvertAbilityRealLevelField('Tdg4')
-    // 技能实数等级域 
+    // 技能实数等级域 小范围每秒伤害 ('Tdg5')
 	constant abilityreallevelfield ABILITY_RLF_SMALL_DAMAGE_PER_SECOND = ConvertAbilityRealLevelField('Tdg5')
-    // 技能实数等级域 
+    // 技能实数等级域 空中时间 ('Tsp1')
 	constant abilityreallevelfield ABILITY_RLF_AIR_TIME_SECONDS_TSP1 = ConvertAbilityRealLevelField('Tsp1')
-    // 技能实数等级域 
+    // 技能实数等级域 最小间隔 ('Tsp2')
 	constant abilityreallevelfield ABILITY_RLF_MINIMUM_HIT_INTERVAL_SECONDS = ConvertAbilityRealLevelField('Tsp2')
-    // 技能实数等级域 
+    // 技能实数等级域 每秒伤害 ('Nbf5')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_PER_SECOND_NBF5 = ConvertAbilityRealLevelField('Nbf5')
-    // 技能实数等级域 
+    // 技能实数等级域 最大范围 ('Ebl1')
 	constant abilityreallevelfield ABILITY_RLF_MAXIMUM_RANGE = ConvertAbilityRealLevelField('Ebl1')
-    // 技能实数等级域 
+    // 技能实数等级域 最小范围 ('Ebl2')
 	constant abilityreallevelfield ABILITY_RLF_MINIMUM_RANGE = ConvertAbilityRealLevelField('Ebl2')
-    // 技能实数等级域 
+    // 技能实数等级域 目标伤害 ('Efk1')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_PER_TARGET_EFK1 = ConvertAbilityRealLevelField('Efk1')
-    // 技能实数等级域 
+    // 技能实数等级域 最大输出伤害 ('Efk2')
 	constant abilityreallevelfield ABILITY_RLF_MAXIMUM_TOTAL_DAMAGE = ConvertAbilityRealLevelField('Efk2')
-    // 技能实数等级域 
+    // 技能实数等级域 最大速度调整 ('Efk4')
 	constant abilityreallevelfield ABILITY_RLF_MAXIMUM_SPEED_ADJUSTMENT = ConvertAbilityRealLevelField('Efk4')
-    // 技能实数等级域 
+    // 技能实数等级域 持续伤害 ('Esh1')
 	constant abilityreallevelfield ABILITY_RLF_DECAYING_DAMAGE = ConvertAbilityRealLevelField('Esh1')
-    // 技能实数等级域 
+    // 技能实数等级域 移动速度系数（%） ('Esh2')
 	constant abilityreallevelfield ABILITY_RLF_MOVEMENT_SPEED_FACTOR_ESH2 = ConvertAbilityRealLevelField('Esh2')
-    // 技能实数等级域 
+    // 技能实数等级域 攻击速度减少 ('Esh3')
 	constant abilityreallevelfield ABILITY_RLF_ATTACK_SPEED_FACTOR_ESH3 = ConvertAbilityRealLevelField('Esh3')
-    // 技能实数等级域 
+    // 技能实数等级域 速度衰减幅度 ('Esh4')
 	constant abilityreallevelfield ABILITY_RLF_DECAY_POWER = ConvertAbilityRealLevelField('Esh4')
-    // 技能实数等级域 
+    // 技能实数等级域 初始伤害 ('Esh5')
 	constant abilityreallevelfield ABILITY_RLF_INITIAL_DAMAGE_ESH5 = ConvertAbilityRealLevelField('Esh5')
-    // 技能实数等级域 
+    // 技能实数等级域 最大生命吸收 ('abs1')
 	constant abilityreallevelfield ABILITY_RLF_MAXIMUM_LIFE_ABSORBED = ConvertAbilityRealLevelField('abs1')
-    // 技能实数等级域 
+    // 技能实数等级域 最大魔法吸收 ('abs2')
 	constant abilityreallevelfield ABILITY_RLF_MAXIMUM_MANA_ABSORBED = ConvertAbilityRealLevelField('abs2')
-    // 技能实数等级域 
+    // 技能实数等级域 移动速度增加（%） ('bsk1')
 	constant abilityreallevelfield ABILITY_RLF_MOVEMENT_SPEED_INCREASE_BSK1 = ConvertAbilityRealLevelField('bsk1')
-    // 技能实数等级域 
+    // 技能实数等级域 攻击速度增加（%） ('bsk2')
 	constant abilityreallevelfield ABILITY_RLF_ATTACK_SPEED_INCREASE_BSK2 = ConvertAbilityRealLevelField('bsk2')
-    // 技能实数等级域 
+    // 技能实数等级域 所受伤害增加（%） ('bsk3')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_TAKEN_INCREASE = ConvertAbilityRealLevelField('bsk3')
-    // 技能实数等级域 
+    // 技能实数等级域 每个单位给予生命值 ('dvm1')
 	constant abilityreallevelfield ABILITY_RLF_LIFE_PER_UNIT = ConvertAbilityRealLevelField('dvm1')
-    // 技能实数等级域 
+    // 技能实数等级域 每个单位给予魔法值 ('dvm2')
 	constant abilityreallevelfield ABILITY_RLF_MANA_PER_UNIT = ConvertAbilityRealLevelField('dvm2')
-    // 技能实数等级域 
+    // 技能实数等级域 每个Buff给予生命值 ('dvm3')
 	constant abilityreallevelfield ABILITY_RLF_LIFE_PER_BUFF = ConvertAbilityRealLevelField('dvm3')
-    // 技能实数等级域 
+    // 技能实数等级域 每个Buff给予魔法值 ('dvm4')
 	constant abilityreallevelfield ABILITY_RLF_MANA_PER_BUFF = ConvertAbilityRealLevelField('dvm4')
-    // 技能实数等级域 
+    // 技能实数等级域 对召唤单位伤害 ('dvm5')
 	constant abilityreallevelfield ABILITY_RLF_SUMMONED_UNIT_DAMAGE_DVM5 = ConvertAbilityRealLevelField('dvm5')
-    // 技能实数等级域 
+    // 技能实数等级域 伤害奖励 ('fak1')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_BONUS_FAK1 = ConvertAbilityRealLevelField('fak1')
-    // 技能实数等级域 
+    // 技能实数等级域 中伤害参数 ('fak2')
 	constant abilityreallevelfield ABILITY_RLF_MEDIUM_DAMAGE_FACTOR_FAK2 = ConvertAbilityRealLevelField('fak2')
-    // 技能实数等级域 
+    // 技能实数等级域 小伤害参数 ('fak3')
 	constant abilityreallevelfield ABILITY_RLF_SMALL_DAMAGE_FACTOR_FAK3 = ConvertAbilityRealLevelField('fak3')
-    // 技能实数等级域 
+    // 技能实数等级域 全伤害范围 ('fak4')
 	constant abilityreallevelfield ABILITY_RLF_FULL_DAMAGE_RADIUS_FAK4 = ConvertAbilityRealLevelField('fak4')
-    // 技能实数等级域 
+    // 技能实数等级域 中伤害范围 ('fak5')
 	constant abilityreallevelfield ABILITY_RLF_HALF_DAMAGE_RADIUS_FAK5 = ConvertAbilityRealLevelField('fak5')
-    // 技能实数等级域 
+    // 技能实数等级域 额外每秒伤害 ('liq1')
 	constant abilityreallevelfield ABILITY_RLF_EXTRA_DAMAGE_PER_SECOND = ConvertAbilityRealLevelField('liq1')
-    // 技能实数等级域 
+    // 技能实数等级域 移动速度减少 ('liq2')
 	constant abilityreallevelfield ABILITY_RLF_MOVEMENT_SPEED_REDUCTION_LIQ2 = ConvertAbilityRealLevelField('liq2')
-    // 技能实数等级域 
+    // 技能实数等级域 攻击速度减少 ('liq3')
 	constant abilityreallevelfield ABILITY_RLF_ATTACK_SPEED_REDUCTION_LIQ3 = ConvertAbilityRealLevelField('liq3')
-    // 技能实数等级域 
+    // 技能实数等级域 魔法伤害参数 ('mim1')
 	constant abilityreallevelfield ABILITY_RLF_MAGIC_DAMAGE_FACTOR = ConvertAbilityRealLevelField('mim1')
-    // 技能实数等级域 
+    // 技能实数等级域 单位 - 每点魔法造成的伤害 ('mfl1')
 	constant abilityreallevelfield ABILITY_RLF_UNIT_DAMAGE_PER_MANA_POINT = ConvertAbilityRealLevelField('mfl1')
-    // 技能实数等级域 
+    // 技能实数等级域 英雄 - 每点魔法造成的伤害 ('mfl2')
 	constant abilityreallevelfield ABILITY_RLF_HERO_DAMAGE_PER_MANA_POINT = ConvertAbilityRealLevelField('mfl2')
-    // 技能实数等级域 
+    // 技能实数等级域 单位 - 最大伤害 ('mfl3')
 	constant abilityreallevelfield ABILITY_RLF_UNIT_MAXIMUM_DAMAGE = ConvertAbilityRealLevelField('mfl3')
-    // 技能实数等级域 
+    // 技能实数等级域 英雄 - 最大伤害 ('mfl3')
 	constant abilityreallevelfield ABILITY_RLF_HERO_MAXIMUM_DAMAGE = ConvertAbilityRealLevelField('mfl4')
-    // 技能实数等级域 
+    // 技能实数等级域 护甲增加 ('mfl5')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_COOLDOWN = ConvertAbilityRealLevelField('mfl5')
-    // 技能实数等级域 
+    // 技能实数等级域 分布伤害参数 ('spl1')
 	constant abilityreallevelfield ABILITY_RLF_DISTRIBUTED_DAMAGE_FACTOR_SPL1 = ConvertAbilityRealLevelField('spl1')
-    // 技能实数等级域 
+    // 技能实数等级域 生命回复 ('irl1')
 	constant abilityreallevelfield ABILITY_RLF_LIFE_REGENERATED = ConvertAbilityRealLevelField('irl1')
-    // 技能实数等级域 
+    // 技能实数等级域 魔法回复 ('irl2')
 	constant abilityreallevelfield ABILITY_RLF_MANA_REGENERATED = ConvertAbilityRealLevelField('irl2')
-    // 技能实数等级域 
+    // 技能实数等级域 每个单位魔法损耗 ('idc1')
 	constant abilityreallevelfield ABILITY_RLF_MANA_LOSS_PER_UNIT_IDC1 = ConvertAbilityRealLevelField('idc1')
-    // 技能实数等级域 
+    // 技能实数等级域 对召唤单位伤害 ('idc2')
 	constant abilityreallevelfield ABILITY_RLF_SUMMONED_UNIT_DAMAGE_IDC2 = ConvertAbilityRealLevelField('idc2')
-    // 技能实数等级域 
+    // 技能实数等级域 激活延迟 ('imo2')
 	constant abilityreallevelfield ABILITY_RLF_ACTIVATION_DELAY_IMO2 = ConvertAbilityRealLevelField('imo2')
-    // 技能实数等级域 
+    // 技能实数等级域 引诱间隔 ('imo3')
 	constant abilityreallevelfield ABILITY_RLF_LURE_INTERVAL_SECONDS = ConvertAbilityRealLevelField('imo3')
-    // 技能实数等级域 
+    // 技能实数等级域 伤害奖励 ('isr1')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_BONUS_ISR1 = ConvertAbilityRealLevelField('isr1')
-    // 技能实数等级域 
+    // 技能实数等级域 魔法伤害减少 ('isr2')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_REDUCTION_ISR2 = ConvertAbilityRealLevelField('isr2')
-    // 技能实数等级域 
+    // 技能实数等级域 伤害奖励 ('ipv1')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_BONUS_IPV1 = ConvertAbilityRealLevelField('ipv1')
-    // 技能实数等级域 
+    // 技能实数等级域 生命偷取值 ('ipv2')
 	constant abilityreallevelfield ABILITY_RLF_LIFE_STEAL_AMOUNT = ConvertAbilityRealLevelField('ipv2')
-    // 技能实数等级域 
+    // 技能实数等级域 生命回复参数 ('ast1')
 	constant abilityreallevelfield ABILITY_RLF_LIFE_RESTORED_FACTOR = ConvertAbilityRealLevelField('ast1')
-    // 技能实数等级域 
+    // 技能实数等级域 魔法回复参数 ('ast2')
 	constant abilityreallevelfield ABILITY_RLF_MANA_RESTORED_FACTOR = ConvertAbilityRealLevelField('ast2')
-    // 技能实数等级域 
+    // 技能实数等级域 附加延迟 ('gra1')
 	constant abilityreallevelfield ABILITY_RLF_ATTACH_DELAY = ConvertAbilityRealLevelField('gra1')
-    // 技能实数等级域 
+    // 技能实数等级域 移除延迟 ('gra2')
 	constant abilityreallevelfield ABILITY_RLF_REMOVE_DELAY = ConvertAbilityRealLevelField('gra2')
-    // 技能实数等级域 
+    // 技能实数等级域 英雄回复延迟 ('Nsa2')
 	constant abilityreallevelfield ABILITY_RLF_HERO_REGENERATION_DELAY = ConvertAbilityRealLevelField('Nsa2')
-    // 技能实数等级域 
+    // 技能实数等级域 单位回复延迟 ('Nsa3')
 	constant abilityreallevelfield ABILITY_RLF_UNIT_REGENERATION_DELAY = ConvertAbilityRealLevelField('Nsa3')
-    // 技能实数等级域 
+    // 技能实数等级域 魔法伤害参数 ('Nsa4')
 	constant abilityreallevelfield ABILITY_RLF_MAGIC_DAMAGE_REDUCTION_NSA4 = ConvertAbilityRealLevelField('Nsa4')
-    // 技能实数等级域 
+    // 技能实数等级域 每秒生命恢复 ('Nsa5')
 	constant abilityreallevelfield ABILITY_RLF_HIT_POINTS_PER_SECOND_NSA5 = ConvertAbilityRealLevelField('Nsa5')
-    // 技能实数等级域 
+    // 技能实数等级域 对召唤单位伤害 ('Ixs1')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_TO_SUMMONED_UNITS_IXS1 = ConvertAbilityRealLevelField('Ixs1')
-    // 技能实数等级域 
+    // 技能实数等级域 魔法伤害减少 ('Ixs2')
 	constant abilityreallevelfield ABILITY_RLF_MAGIC_DAMAGE_REDUCTION_IXS2 = ConvertAbilityRealLevelField('Ixs2')
-    // 技能实数等级域 
+    // 技能实数等级域 召唤单位持续时间 ('Npa6')
 	constant abilityreallevelfield ABILITY_RLF_SUMMONED_UNIT_DURATION = ConvertAbilityRealLevelField('Npa6')
-    // 技能实数等级域 
+    // 技能实数等级域 护盾CD间隔 ('Nse1')
 	constant abilityreallevelfield ABILITY_RLF_SHIELD_COOLDOWN_TIME = ConvertAbilityRealLevelField('Nse1')
-    // 技能实数等级域 
+    // 技能实数等级域 每秒伤害 ('Ndo1')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_PER_SECOND_NDO1 = ConvertAbilityRealLevelField('Ndo1')
-    // 技能实数等级域 
+    // 技能实数等级域 召唤单位持续时间 ('Ndo3')
 	constant abilityreallevelfield ABILITY_RLF_SUMMONED_UNIT_DURATION_SECONDS_NDO3 = ConvertAbilityRealLevelField('Ndo3')
-    // 技能实数等级域 
+    // 技能实数等级域 小伤害范围 ('flk1')
 	constant abilityreallevelfield ABILITY_RLF_MEDIUM_DAMAGE_RADIUS_FLK1 = ConvertAbilityRealLevelField('flk1')
-    // 技能实数等级域 
+    // 技能实数等级域 中伤害范围 ('flk2')
 	constant abilityreallevelfield ABILITY_RLF_SMALL_DAMAGE_RADIUS_FLK2 = ConvertAbilityRealLevelField('flk2')
-    // 技能实数等级域 
+    // 技能实数等级域 全伤害数值 ('flk3')
 	constant abilityreallevelfield ABILITY_RLF_FULL_DAMAGE_AMOUNT_FLK3 = ConvertAbilityRealLevelField('flk3')
-    // 技能实数等级域 
+    // 技能实数等级域 中伤害数值 ('flk4')
 	constant abilityreallevelfield ABILITY_RLF_MEDIUM_DAMAGE_AMOUNT = ConvertAbilityRealLevelField('flk4')
-    // 技能实数等级域 
+    // 技能实数等级域 小伤害数值 ('flk5')
 	constant abilityreallevelfield ABILITY_RLF_SMALL_DAMAGE_AMOUNT = ConvertAbilityRealLevelField('flk5')
-    // 技能实数等级域 
+    // 技能实数等级域 移动速度减少（%） ('Hbn1')
 	constant abilityreallevelfield ABILITY_RLF_MOVEMENT_SPEED_REDUCTION_PERCENT_HBN1 = ConvertAbilityRealLevelField('Hbn1')
-    // 技能实数等级域 
+    // 技能实数等级域 攻击速度减少（%） ('Hbn2')
 	constant abilityreallevelfield ABILITY_RLF_ATTACK_SPEED_REDUCTION_PERCENT_HBN2 = ConvertAbilityRealLevelField('Hbn2')
-    // 技能实数等级域 
+    // 技能实数等级域 最大损耗魔法 - 单位 ('fbk1')
 	constant abilityreallevelfield ABILITY_RLF_MAX_MANA_DRAINED_UNITS = ConvertAbilityRealLevelField('fbk1')
-    // 技能实数等级域 
+    // 技能实数等级域 伤害比率 - 单位('fbk2')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_RATIO_UNITS_PERCENT = ConvertAbilityRealLevelField('fbk2')
-    // 技能实数等级域 
+    // 技能实数等级域 最大损耗魔法 - 英雄 ('fbk3')
 	constant abilityreallevelfield ABILITY_RLF_MAX_MANA_DRAINED_HEROS = ConvertAbilityRealLevelField('fbk3')
-    // 技能实数等级域 
+    // 技能实数等级域 伤害比率 - 英雄 ('fbk4')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_RATIO_HEROS_PERCENT = ConvertAbilityRealLevelField('fbk4')
-    // 技能实数等级域 
+    // 技能实数等级域 对召唤单位伤害 ('fbk5')
 	constant abilityreallevelfield ABILITY_RLF_SUMMONED_DAMAGE = ConvertAbilityRealLevelField('fbk5')
-    // 技能实数等级域 
+    // 技能实数等级域 分裂伤害参数 ('nca1')
 	constant abilityreallevelfield ABILITY_RLF_DISTRIBUTED_DAMAGE_FACTOR_NCA1 = ConvertAbilityRealLevelField('nca1')
-    // 技能实数等级域 
+    // 技能实数等级域 初始伤害 ('pxf1')
 	constant abilityreallevelfield ABILITY_RLF_INITIAL_DAMAGE_PXF1 = ConvertAbilityRealLevelField('pxf1')
-    // 技能实数等级域 
+    // 技能实数等级域 每秒伤害 ('pxf2')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_PER_SECOND_PXF2 = ConvertAbilityRealLevelField('pxf2')
-    // 技能实数等级域 
+    // 技能实数等级域 每秒伤害 ('mls1')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_PER_SECOND_MLS1 = ConvertAbilityRealLevelField('mls1')
-    // 技能实数等级域 
+    // 技能实数等级域 野兽碰撞范围 ('Nst2')
 	constant abilityreallevelfield ABILITY_RLF_BEAST_COLLISION_RADIUS = ConvertAbilityRealLevelField('Nst2')
-    // 技能实数等级域 
+    // 技能实数等级域 伤害数值 ('Nst3')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_AMOUNT_NST3 = ConvertAbilityRealLevelField('Nst3')
-    // 技能实数等级域 
+    // 技能实数等级域 伤害范围 ('Nst4')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_RADIUS = ConvertAbilityRealLevelField('Nst4')
-    // 技能实数等级域 
+    // 技能实数等级域 伤害延迟 ('Nst5')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_DELAY = ConvertAbilityRealLevelField('Nst5')
-    // 技能实数等级域 
+    // 技能实数等级域 施法持续时间 ('Ncl1')
 	constant abilityreallevelfield ABILITY_RLF_FOLLOW_THROUGH_TIME = ConvertAbilityRealLevelField('Ncl1')
-    // 技能实数等级域 
+    // 技能实数等级域 动作持续时间 ('Ncl4')
 	constant abilityreallevelfield ABILITY_RLF_ART_DURATION = ConvertAbilityRealLevelField('Ncl4')
-    // 技能实数等级域 
+    // 技能实数等级域 移动速度增加（%） ('Nab1')
 	constant abilityreallevelfield ABILITY_RLF_MOVEMENT_SPEED_REDUCTION_PERCENT_NAB1 = ConvertAbilityRealLevelField('Nab1')
-    // 技能实数等级域 
+    // 技能实数等级域 攻击速度增加（%） ('Nab2')
 	constant abilityreallevelfield ABILITY_RLF_ATTACK_SPEED_REDUCTION_PERCENT_NAB2 = ConvertAbilityRealLevelField('Nab2')
-    // 技能实数等级域 
+    // 技能实数等级域 目标持续伤害数值 ('Nab4')
 	constant abilityreallevelfield ABILITY_RLF_PRIMARY_DAMAGE = ConvertAbilityRealLevelField('Nab4')
-    // 技能实数等级域 
+    // 技能实数等级域 范围持续伤害数值 ('Nab5')
 	constant abilityreallevelfield ABILITY_RLF_SECONDARY_DAMAGE = ConvertAbilityRealLevelField('Nab5')
-    // 技能实数等级域 
+    // 技能实数等级域 伤害间隔 ('Nab6')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_INTERVAL_NAB6 = ConvertAbilityRealLevelField('Nab6')
-    // 技能实数等级域 
+    // 技能实数等级域 黄金奖励参数 ('Ntm1')
 	constant abilityreallevelfield ABILITY_RLF_GOLD_COST_FACTOR = ConvertAbilityRealLevelField('Ntm1')
-    // 技能实数等级域 
+    // 技能实数等级域 木材奖励参数 ('Ntm2')
 	constant abilityreallevelfield ABILITY_RLF_LUMBER_COST_FACTOR = ConvertAbilityRealLevelField('Ntm2')
-    // 技能实数等级域 
+    // 技能实数等级域 移动速度奖励 ('Neg1')
 	constant abilityreallevelfield ABILITY_RLF_MOVE_SPEED_BONUS_NEG1 = ConvertAbilityRealLevelField('Neg1')
-    // 技能实数等级域 
+    // 技能实数等级域 攻击奖励 ('Neg2')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_BONUS_NEG2 = ConvertAbilityRealLevelField('Neg2')
-    // 技能实数等级域 
+    // 技能实数等级域 伤害数值 ('Ncs1')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_AMOUNT_NCS1 = ConvertAbilityRealLevelField('Ncs1')
-    // 技能实数等级域 
+    // 技能实数等级域 伤害间隔 ('Ncs2')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_INTERVAL_NCS2 = ConvertAbilityRealLevelField('Ncs2')
-    // 技能实数等级域 
+    // 技能实数等级域 最高输出伤害 ('Ncs4')
 	constant abilityreallevelfield ABILITY_RLF_MAX_DAMAGE_NCS4 = ConvertAbilityRealLevelField('Ncs4')
-    // 技能实数等级域 
+    // 技能实数等级域 建筑物伤害参数 ('Ncs5')
 	constant abilityreallevelfield ABILITY_RLF_BUILDING_DAMAGE_FACTOR_NCS5 = ConvertAbilityRealLevelField('Ncs5')
-    // 技能实数等级域 
+    // 技能实数等级域 技能持续时间 ('Ncs6')
 	constant abilityreallevelfield ABILITY_RLF_EFFECT_DURATION = ConvertAbilityRealLevelField('Ncs6')
-    // 技能实数等级域 
+    // 技能实数等级域 生产单位间隔 ('Nsy1')
 	constant abilityreallevelfield ABILITY_RLF_SPAWN_INTERVAL_NSY1 = ConvertAbilityRealLevelField('Nsy1')
-    // 技能实数等级域 
+    // 技能实数等级域 生产单位持续时间 ('Nsy3')
 	constant abilityreallevelfield ABILITY_RLF_SPAWN_UNIT_DURATION = ConvertAbilityRealLevelField('Nsy3')
-    // 技能实数等级域 
+    // 技能实数等级域 产生单位位移 ('Nsy4')
 	constant abilityreallevelfield ABILITY_RLF_SPAWN_UNIT_OFFSET = ConvertAbilityRealLevelField('Nsy4')
-    // 技能实数等级域 
+    // 技能实数等级域 约束范围 ('Nsy5')
 	constant abilityreallevelfield ABILITY_RLF_LEASH_RANGE_NSY5 = ConvertAbilityRealLevelField('Nsy5')
-    // 技能实数等级域 
+    // 技能实数等级域 生产单位间隔 ('Nfy1')
 	constant abilityreallevelfield ABILITY_RLF_SPAWN_INTERVAL_NFY1 = ConvertAbilityRealLevelField('Nfy1')
-    // 技能实数等级域 
+    // 技能实数等级域 约束范围 ('Nfy2')
 	constant abilityreallevelfield ABILITY_RLF_LEASH_RANGE_NFY2 = ConvertAbilityRealLevelField('Nfy2')
-    // 技能实数等级域 
+    // 技能实数等级域 粉碎几率 ('Nde1')
 	constant abilityreallevelfield ABILITY_RLF_CHANCE_TO_DEMOLISH = ConvertAbilityRealLevelField('Nde1')
-    // 技能实数等级域 
+    // 技能实数等级域 伤害倍乘（建筑物） ('Nde2')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_MULTIPLIER_BUILDINGS = ConvertAbilityRealLevelField('Nde2')
-    // 技能实数等级域 
+    // 技能实数等级域 伤害倍乘（单位） ('Nde3')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_MULTIPLIER_UNITS = ConvertAbilityRealLevelField('Nde3')
-    // 技能实数等级域 
+    // 技能实数等级域 伤害倍乘（英雄） ('Nde4')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_MULTIPLIER_HEROES = ConvertAbilityRealLevelField('Nde4')
-    // 技能实数等级域 
+    // 技能实数等级域 燃灰伤害值奖励 ('Nic1')
 	constant abilityreallevelfield ABILITY_RLF_BONUS_DAMAGE_MULTIPLIER = ConvertAbilityRealLevelField('Nic1')
-    // 技能实数等级域 
+    // 技能实数等级域 死亡伤害 - 全伤害 ('Nic2')
 	constant abilityreallevelfield ABILITY_RLF_DEATH_DAMAGE_FULL_AMOUNT = ConvertAbilityRealLevelField('Nic2')
-    // 技能实数等级域 
+    // 技能实数等级域 死亡伤害 - 全伤害范围 ('Nic3')
 	constant abilityreallevelfield ABILITY_RLF_DEATH_DAMAGE_FULL_AREA = ConvertAbilityRealLevelField('Nic3')
-    // 技能实数等级域 
+    // 技能实数等级域 死亡伤害 - 半伤害 ('Nic4')
 	constant abilityreallevelfield ABILITY_RLF_DEATH_DAMAGE_HALF_AMOUNT = ConvertAbilityRealLevelField('Nic4')
-    // 技能实数等级域 
+    // 技能实数等级域 死亡伤害 - 半伤害范围 ('Nic5')
 	constant abilityreallevelfield ABILITY_RLF_DEATH_DAMAGE_HALF_AREA = ConvertAbilityRealLevelField('Nic5')
-    // 技能实数等级域 
+    // 技能实数等级域 死亡伤害 - 延迟 ('Nic6')
 	constant abilityreallevelfield ABILITY_RLF_DEATH_DAMAGE_DELAY = ConvertAbilityRealLevelField('Nic6')
-    // 技能实数等级域 
+    // 技能实数等级域 伤害值 ('Nso1')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_AMOUNT_NSO1 = ConvertAbilityRealLevelField('Nso1')
-    // 技能实数等级域 
+    // 技能实数等级域 伤害周期 ('Nso2')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_PERIOD = ConvertAbilityRealLevelField('Nso2')
-    // 技能实数等级域 
+    // 技能实数等级域 攻击减少 ('Nso3')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_PENALTY = ConvertAbilityRealLevelField('Nso3')
-    // 技能实数等级域 
+    // 技能实数等级域 移动速度减少（%） ('Nso4')
 	constant abilityreallevelfield ABILITY_RLF_MOVEMENT_SPEED_REDUCTION_PERCENT_NSO4 = ConvertAbilityRealLevelField('Nso4')
-    // 技能实数等级域 
+    // 技能实数等级域 攻击速度减少（%） ('Nso5')
 	constant abilityreallevelfield ABILITY_RLF_ATTACK_SPEED_REDUCTION_PERCENT_NSO5 = ConvertAbilityRealLevelField('Nso5')
-    // 技能实数等级域 
+    // 技能实数等级域 分裂延迟 ('Nlm2')
 	constant abilityreallevelfield ABILITY_RLF_SPLIT_DELAY = ConvertAbilityRealLevelField('Nlm2')
-    // 技能实数等级域 
+    // 技能实数等级域 最大生命值参数 ('Nlm4')
 	constant abilityreallevelfield ABILITY_RLF_MAX_HITPOINT_FACTOR = ConvertAbilityRealLevelField('Nlm4')
-    // 技能实数等级域 
+    // 技能实数等级域 分裂生命周期奖励 ('Nlm5')
 	constant abilityreallevelfield ABILITY_RLF_LIFE_DURATION_SPLIT_BONUS = ConvertAbilityRealLevelField('Nlm5')
-    // 技能实数等级域 
+    // 技能实数等级域 波间隔时间 ('Nvc3')
 	constant abilityreallevelfield ABILITY_RLF_WAVE_INTERVAL = ConvertAbilityRealLevelField('Nvc3')
-    // 技能实数等级域 
+    // 技能实数等级域 建筑伤害参数（%） ('Nvc4')
 	constant abilityreallevelfield ABILITY_RLF_BUILDING_DAMAGE_FACTOR_NVC4 = ConvertAbilityRealLevelField('Nvc4')
-    // 技能实数等级域 
+    // 技能实数等级域 全伤害数值 ('Nvc5')
 	constant abilityreallevelfield ABILITY_RLF_FULL_DAMAGE_AMOUNT_NVC5 = ConvertAbilityRealLevelField('Nvc5')
-    // 技能实数等级域 
+    // 技能实数等级域 半伤害参数 ('Nvc6')
 	constant abilityreallevelfield ABILITY_RLF_HALF_DAMAGE_FACTOR = ConvertAbilityRealLevelField('Nvc6')
-    // 技能实数等级域 
+    // 技能实数等级域 增量间隔 ('Tau5')
 	constant abilityreallevelfield ABILITY_RLF_INTERVAL_BETWEEN_PULSES = ConvertAbilityRealLevelField('Tau5')
 	
     // 技能布尔值等级域 百分比奖励 ('Hab2')
@@ -3707,11 +3707,11 @@ globals
 	constant itembooleanfield ITEM_BF_INCLUDE_AS_RANDOM_CHOICE = ConvertItemBooleanField('iprn')
 	// 物品布尔值域 拾取时自动使用 ('ipow')
 	constant itembooleanfield ITEM_BF_USE_AUTOMATICALLY_WHEN_ACQUIRED = ConvertItemBooleanField('ipow')
-  // 物品布尔值域 可以出售给商店 ('ipaw')
+    // 物品布尔值域 可以出售给商店 ('ipaw')
 	constant itembooleanfield ITEM_BF_CAN_BE_SOLD_TO_MERCHANTS = ConvertItemBooleanField('ipaw')
-  // 物品布尔值域 主动使用 ('iusa')
+    // 物品布尔值域 主动使用 ('iusa')
 	constant itembooleanfield ITEM_BF_ACTIVELY_USED = ConvertItemBooleanField('iusa')
-  // 物品字符串域 使用模型 ('ifil')
+    // 物品字符串域 使用模型 ('ifil')
 	constant itemstringfield ITEM_SF_MODEL_USED = ConvertItemStringField('ifil')
 	
 	// Unit
@@ -3984,7 +3984,7 @@ globals
 	
 	// defense type
 	// defense type
-	// 防御类型 轻型/小型，在低版本为 small ，没有 light
+	// 防御类型 轻型/小型，在低版本似乎为 small ，并没有 light
  constant defensetype DEFENSE_TYPE_LIGHT = ConvertDefenseType(0)
 	// 防御类型 中型
 	constant defensetype DEFENSE_TYPE_MEDIUM = ConvertDefenseType(1)
@@ -4136,8 +4136,8 @@ native R2I takes real r returns integer
 native I2S takes integer i returns string
 // 转换实数为字符串
 native R2S takes real r returns string
-// 转换实数为字符串（指定保留的小数位数）
-//@param precision
+// 转换实数为字符串
+//@param precision指定保留的小数位数
 native R2SW takes real r, integer width, integer precision returns string
 // 转换字串符为整数
 native S2I takes string s returns integer
@@ -4158,7 +4158,10 @@ native StringCase takes string source, boolean upper returns string
 // 转换字符串为哈希码，在AI脚本中似乎只返回 null
 native StringHash takes string s returns integer
 
-// 获取（外部文件的）本地字符串 [R]，从Globalstrings.fdf文件获取查询内容对应的翻译文本，不同语言返回不同的值，当字符串不存在时（是当前版本不存在查询的字符串本身，不是字符串已存在但没有翻译文本），会原封不动返回查询内容（英语也附带翻译，该翻译文本仅首字母大写，但所有字符串都是大写且使用下划线替代空格，故翻译文本和字符串绝对不会相等），利用该命令可得知游戏大致版本号（如1.27，1.30等），该命令不能在AI脚本使用，因为脚本无法获取外部内容，只返回 null
+// 获取（外部文件的）本地字符串 [R]
+// 从Globalstrings.fdf文件获取查询内容对应的翻译文本，不同语言返回不同的值
+// 当字符串不存在时（是当前版本不存在查询的字符串本身，不是字符串已存在但没有翻译文本），会原封不动返回查询内容（英语也附带翻译，该翻译文本仅首字母大写，但所有字符串都是大写且使用下划线替代空格，故翻译文本和字符串绝对不会相等），利用该命令可得知游戏大致版本号（如1.27，1.30等）
+// 该命令不能在AI脚本使用，因为脚本无法获取外部内容，只返回 null
 native GetLocalizedString takes string source returns string
 // 获取本地热键
 native GetLocalizedHotkey takes string source returns integer
@@ -4183,9 +4186,13 @@ native SetPlayers takes integer playercount returns nothing
 native DefineStartLocation takes integer whichStartLoc, real x, real y returns nothing
 // 默认开始点（指定点）
 native DefineStartLocationLoc takes integer whichStartLoc, location whichLocation returns nothing
-// 设置开始点优先级（指定玩家槽）
+// 设置开始点优先级（指定点）
 native SetStartLocPrioCount takes integer whichStartLoc, integer prioSlotCount returns nothing
-// 设置开始点优先级（指定玩家槽、第一开始点、第二开始点、优先级系数）
+// 设置开始点优先级
+// @param whichStartLoc第一开始点
+// @param prioSlotIndex指定玩家槽
+// @param otherStartLocIndex其他开始点（仅在允许玩家变更开始点时有效）
+// @param priority优先级系数
 native SetStartLocPrio takes integer whichStartLoc, integer prioSlotIndex, integer otherStartLocIndex, startlocprio priority returns nothing
 // 获取开始点优先级（指定玩家槽）
 native GetStartLocPrioSlot takes integer whichStartLoc, integer prioSlotIndex returns integer
@@ -4193,7 +4200,11 @@ native GetStartLocPrioSlot takes integer whichStartLoc, integer prioSlotIndex re
 native GetStartLocPrio takes integer whichStartLoc, integer prioSlotIndex returns startlocprio
 // 设置敌人开始点（指定玩家槽）
 native SetEnemyStartLocPrioCount takes integer whichStartLoc, integer prioSlotCount returns nothing
-// 设置敌人开始点优先级（指定玩家槽、第一开始点、第二开始点、优先级系数）
+// 设置敌人开始点优先级
+// @param whichStartLoc第一开始点
+// @param prioSlotIndex指定敌方玩家槽
+// @param otherStartLocIndex其他开始点（仅在允许玩家变更开始点时有效）
+// @param priority优先级系数
 native SetEnemyStartLocPrio takes integer whichStartLoc, integer prioSlotIndex, integer otherStartLocIndex, startlocprio priority returns nothing
 // 设置游戏类型支持
 native SetGameTypeSupported takes gametype whichGameType, boolean value returns nothing
@@ -4231,11 +4242,14 @@ constant native GetGameDifficulty takes nothing returns gamedifficulty
 constant native GetResourceDensity takes nothing returns mapdensity
 // 获取单位密度
 constant native GetCreatureDensity takes nothing returns mapdensity
-// 获取指定开始点的 X 轴坐标，理论上带入0~23的玩家编号即可返回指定玩家的开始点
+// 获取指定开始点的 X 轴坐标
+// 理论上带入0~11/23的玩家编号即可返回指定玩家的开始点
 constant native GetStartLocationX takes integer whichStartLocation returns real
-// 获取指定开始点的 Y 轴坐标，理论上带入0~23的玩家编号即可返回指定玩家的开始点
+// 获取指定开始点的 Y 轴坐标
+// 理论上带入0~11/23的玩家编号即可返回指定玩家的开始点
 constant native GetStartLocationY takes integer whichStartLocation returns real
-// 获取指定开始点的坐标，理论上带入0~23的玩家编号即可返回指定玩家的开始点
+// 获取指定开始点的坐标
+// 理论上带入0~11/23的玩家编号即可返回指定玩家的开始点
 constant native GetStartLocationLoc takes integer whichStartLocation returns location
 
 
@@ -4295,7 +4309,7 @@ native CreateTimer takes nothing returns timer
 // 删除计时器 [R]
 native DestroyTimer takes timer whichTimer returns nothing
 // 运行计时器 [C]
-// @param whichTimer 计时器对象
+// @param whichTimer 计时器
 // @param timeout 超时
 // @param periodic 是否循环
 native TimerStart takes timer whichTimer, real timeout, boolean periodic, code handlerFunc returns nothing
@@ -4338,40 +4352,40 @@ native BlzGroupGetSize takes group whichGroup returns integer
 // 获取单位组中下标的单位
 native BlzGroupUnitAt takes group whichGroup, integer index returns unit
 // 将指定单位类型的单位加入单位组
-// 可用filter附加选择单位的额外条件，不建议使用在AI脚本中，即filter写成null
+// @param filter附加选择单位的额外条件，不建议使用在AI脚本中，即filter写成null
 native GroupEnumUnitsOfType takes group whichGroup, string unitname, boolexpr filter returns nothing
 // 将指定玩家匹的单位加入单位组
-// 可用filter附加选择单位的额外条件，不建议使用在AI脚本中，即filter写成null
+// @param filter附加选择单位的额外条件，不建议使用在AI脚本中，即filter写成null
 native GroupEnumUnitsOfPlayer takes group whichGroup, player whichPlayer, boolexpr filter returns nothing
 // 将指定单位类型的单位加入单位组，同时指定添加单位的数量上限
-// 可用filter附加选择单位的额外条件，不建议使用在AI脚本中，即filter写成null
+// @param filter附加选择单位的额外条件，不建议使用在AI脚本中，即filter写成null
 // @param countLimit 数量上限
 native GroupEnumUnitsOfTypeCounted takes group whichGroup, string unitname, boolexpr filter, integer countLimit returns nothing
 // 将指定方形区域的的单位加入单位组
-// 可用filter附加选择单位的额外条件，不建议使用在AI脚本中，即filter写成null
+// @param filter附加选择单位的额外条件，不建议使用在AI脚本中，即filter写成null
 native GroupEnumUnitsInRect takes group whichGroup, rect r, boolexpr filter returns nothing
 // 将指定方形区域的的单位加入单位组，同时指定添加单位的数量上限
-// 可用filter附加选择单位的额外条件，不建议使用在AI脚本中，即filter写成null
+// @param filter附加选择单位的额外条件，不建议使用在AI脚本中，即filter写成null
 // @param countLimit 数量上限
 native GroupEnumUnitsInRectCounted takes group whichGroup, rect r, boolexpr filter, integer countLimit returns nothing
 // 将圆形区域的单位添加到单位组（指定圆心坐标）
-// 可用filter附加选择单位的额外条件，不建议使用在AI脚本中，即filter写成null
+// @param filter附加选择单位的额外条件，不建议使用在AI脚本中，即filter写成null
 native GroupEnumUnitsInRange takes group whichGroup, real x, real y, real radius, boolexpr filter returns nothing
 // 将圆形区域的单位添加到单位组（指定圆心坐标）
-// 可用filter附加选择单位的额外条件，不建议使用在AI脚本中，即filter写成null
+// @param filter附加选择单位的额外条件，不建议使用在AI脚本中，即filter写成null
 native GroupEnumUnitsInRangeOfLoc takes group whichGroup, location whichLocation, real radius, boolexpr filter returns nothing
 // 【弃用】将圆形区域的单位添加到单位组（指定圆心坐标），同时指定添加单位的数量上限
-// 可用filter附加选择单位的额外条件，不建议使用在AI脚本中，即filter写成null
+// @param filter附加选择单位的额外条件，不建议使用在AI脚本中，即filter写成null
 // @deprecated
 // @param countLimit 数量上限
 native GroupEnumUnitsInRangeCounted takes group whichGroup, real x, real y, real radius, boolexpr filter, integer countLimit returns nothing
 // 【弃用】将圆形区域的单位添加到单位组（指定圆心坐标），同时指定添加单位的数量上限
-// 可用filter附加选择单位的额外条件，不建议使用在AI脚本中，即filter写成null
+// @param filter附加选择单位的额外条件，不建议使用在AI脚本中，即filter写成null
 // @deprecated
 // @param countLimit 数量上限
 native GroupEnumUnitsInRangeOfLocCounted takes group whichGroup, location whichLocation, real radius, boolexpr filter, integer countLimit returns nothing
 // 将指定玩家的单位添加到单位组
-// 可用filter附加选择单位的额外条件，不建议使用在AI脚本中，即filter写成null
+// @param filter附加选择单位的额外条件，不建议使用在AI脚本中，即filter写成null
 native GroupEnumUnitsSelected takes group whichGroup, player whichPlayer, boolexpr filter returns nothing
 
 // 发送单位组命令（无目标）
@@ -4493,11 +4507,11 @@ native GetLocationY takes location whichLocation returns real
 // 获取点 Z 轴高度 [R]
 native GetLocationZ takes location whichLocation returns real
 
-// 单位检查
+// 单位是否在区域内
 native IsUnitInRegion takes region whichRegion, unit whichUnit returns boolean
-// 是否包含坐标
+// 坐标是否在区域内
 native IsPointInRegion takes region whichRegion, real x, real y returns boolean
-// 是否包含点
+// 点是否在区域内
 native IsLocationInRegion takes region whichRegion, location whichLocation returns boolean
 
 // Returns full map bounds, including unplayable borders, in world coordinates
@@ -4526,27 +4540,27 @@ native TriggerWaitOnSleeps takes trigger whichTrigger, boolean flag returns noth
 // 触发是否挂起
 native IsTriggerWaitOnSleeps takes trigger whichTrigger returns boolean
 
-// 匹配的单位
+// 获取匹配的单位
 constant native GetFilterUnit takes nothing returns unit
-// 选取的单位
+// 获取选取的单位
 constant native GetEnumUnit takes nothing returns unit
 
-// 匹配的可毁坏物
+// 获取匹配的可毁坏物
 constant native GetFilterDestructable takes nothing returns destructable
-// 选取的可毁坏物
+// 获取选取的可毁坏物
 constant native GetEnumDestructable takes nothing returns destructable
 
-// 匹配的物品
+// 获取匹配的物品
 constant native GetFilterItem takes nothing returns item
-// 选取的物品
+// 获取选取的物品
 constant native GetEnumItem takes nothing returns item
 
-// 解析tags
+// 解析标签tags
 constant native ParseTags takes string taggedString returns string
 
-// 匹配的玩家
+// 获取匹配的玩家
 constant native GetFilterPlayer takes nothing returns player
-// 选取的玩家
+// 获取选取的玩家
 constant native GetEnumPlayer takes nothing returns player
 
 // 当前触发器
@@ -4571,7 +4585,7 @@ native And takes boolexpr operandA, boolexpr operandB returns boolexpr
 native Or takes boolexpr operandA, boolexpr operandB returns boolexpr
 // not 不是/否
 native Not takes boolexpr operand returns boolexpr
-// 限制条件为
+// 限制条件
 native Condition takes code func returns conditionfunc
 // 销毁条件
 native DestroyCondition takes conditionfunc c returns nothing
@@ -4618,7 +4632,7 @@ constant native GetEventGameState takes nothing returns gamestate
 native TriggerRegisterGameEvent takes trigger whichTrigger, gameevent whichGameEvent returns event
 
 // EVENT_GAME_VICTORY
-// 过去胜利玩家
+// 获取胜利玩家
 constant native GetWinningPlayer takes nothing returns player
 
 
@@ -4626,16 +4640,16 @@ constant native GetWinningPlayer takes nothing returns player
 native TriggerRegisterEnterRegion takes trigger whichTrigger, region whichRegion, boolexpr filter returns event
 
 // EVENT_GAME_ENTER_REGION
-// 触发区域 [R]
+// 获取触发区域 [R]
 constant native GetTriggeringRegion takes nothing returns region
-// 正在进入的单位
+// 获取正在进入的单位
 constant native GetEnteringUnit takes nothing returns unit
 
 // EVENT_GAME_LEAVE_REGION
 
 // 单位离开不规则区域(指定条件) [R]
 native TriggerRegisterLeaveRegion takes trigger whichTrigger, region whichRegion, boolexpr filter returns event
-// 正在离开的单位
+// 获取正在离开的单位
 constant native GetLeavingUnit takes nothing returns unit
 
 // 鼠标点击可追踪物 [R]
@@ -7412,7 +7426,7 @@ native BlzDisplayChatMessage takes player whichPlayer, integer recipient, string
 native BlzPauseUnitEx takes unit whichUnit, boolean flag returns nothing
 // native BlzFourCC2S                                 takes integer value returns string
 // native BlzS2FourCC                                 takes string value returns integer
-// 设置单位朝向度
+// 设置单位朝向（角度）
 native BlzSetUnitFacingEx takes unit whichUnit, real facingAngle returns nothing
 // 创建技能按钮特效
 native CreateCommandButtonEffect takes integer abilityId, string order returns commandbuttoneffect
@@ -7501,7 +7515,7 @@ native BlzRemoveAbilityStringLevelArrayField takes ability whichAbility, ability
 
 // Item 
 // 获取物品技能
-// @param index 0-5
+// @param 引索为 0-5
 native BlzGetItemAbilityByIndex takes item whichItem, integer index returns ability
 // 获取物品技能
 native BlzGetItemAbility takes item whichItem, integer abilCode returns ability

--- a/static/common.j
+++ b/static/common.j
@@ -1489,13 +1489,13 @@ globals
 	
 	// Camera Margin constants for use with GetCameraMargin
 	
-	// 镜头空白 左
+	// 镜头空白 左，似乎恒为512
 	constant integer CAMERA_MARGIN_LEFT = 0
-	// 镜头空白 右
+	// 镜头空白 右，似乎恒为512
 	constant integer CAMERA_MARGIN_RIGHT = 1
-	// 镜头空白 顶部
+	// 镜头空白 顶部，似乎恒为256
 	constant integer CAMERA_MARGIN_TOP = 2
-	// 镜头空白 底部
+	// 镜头空白 底部，似乎恒为256
 	constant integer CAMERA_MARGIN_BOTTOM = 3
 	
 	
@@ -1535,7 +1535,7 @@ globals
 	constant originframetype ORIGIN_FRAME_HERO_HP_BAR = ConvertOriginFrameType(4)
 	// 原生UI 英雄按钮下的魔法条，与 HeroButtons 关联
 	constant originframetype ORIGIN_FRAME_HERO_MANA_BAR = ConvertOriginFrameType(5)
-	// 原生UI 英雄获得新技能点时，英雄按钮发光; 与 HeroButtons 关联。当英雄新技能点时，即使所有原生UI都被隐藏，闪光也会出现
+	// 原生UI 英雄获得新技能点时，英雄按钮发出的光; 与 HeroButtons 关联。当英雄新技能点时，即使所有原生UI都被隐藏，闪光也会出现
 	constant originframetype ORIGIN_FRAME_HERO_BUTTON_INDICATOR = ConvertOriginFrameType(6)
 	// 原生UI 物品栏格按钮（共6格）。当其父级可见时，每次选择物品时它会重新出现/更新
 	constant originframetype ORIGIN_FRAME_ITEM_BUTTON = ConvertOriginFrameType(7)
@@ -4499,7 +4499,7 @@ native RemoveUnit takes unit whichUnit returns nothing
 native ShowUnit takes unit whichUnit, boolean show returns nothing
 
 // 设置单位属性 [R]
-// @param whichUnitState [UNIT_STATE_LIFE, UNIT_STATE_MAX_LIFE, UNIT_STATE_MANA, UNIT_STATE_MAX_MANA]
+// @param whichUnitState 可选 UNIT_STATE_LIFE, UNIT_STATE_MAX_LIFE, UNIT_STATE_MANA, UNIT_STATE_MAX_MANA
 native SetUnitState takes unit whichUnit, unitstate whichUnitState, real newVal returns nothing
 // 设置单位的 X 坐标 [R]
 native SetUnitX takes unit whichUnit, real newX returns nothing
@@ -5041,9 +5041,9 @@ native CachePlayerHeroData takes player whichPlayer returns nothing
 // Fog of War API
 // 设置地图迷雾(矩形区域) [R]
 native SetFogStateRect takes player forWhichPlayer, fogstate whichState, rect where, boolean useSharedVision returns nothing
-// 设置地图迷雾(圆范围) [R]
+// 设置地图迷雾(圆范围) （指定坐标）[R]
 native SetFogStateRadius takes player forWhichPlayer, fogstate whichState, real centerx, real centerY, real radius, boolean useSharedVision returns nothing
-// 设置地图迷雾(圆范围) [R]
+// 设置地图迷雾(圆范围)（指定点） [R]
 native SetFogStateRadiusLoc takes player forWhichPlayer, fogstate whichState, location center, real radius, boolean useSharedVision returns nothing
 // 启用/禁用黑色阴影 [R]
 native FogMaskEnable takes boolean enable returns nothing
@@ -5074,7 +5074,7 @@ native FogModifierStop takes fogmodifier whichFogModifier returns nothing
 native VersionGet takes nothing returns version
 // 当前游戏版本是否指定版本（版本指混乱之治或冰封王座，并非补丁号）
 native VersionCompatible takes version whichVersion returns boolean
-// 当前版本支持是否指定版本（版本指混乱之治或冰封王座，并非补丁号）
+// 当前版本是否支持指定版本（版本指混乱之治或冰封王座，并非补丁号）
 native VersionSupported takes version whichVersion returns boolean
 
 // 结束游戏
@@ -5600,7 +5600,7 @@ native GetAllyColorFilterState takes nothing returns integer
 native SetAllyColorFilterState takes integer state returns nothing
 // 野生单位显示是开启的
 native GetCreepCampFilterState takes nothing returns boolean
-// 显示/隐藏野生生物图标在小地图
+// 显示/隐藏 小地图野生生物图标（是否在小地图显示中立敌对玩家的单位）
 native SetCreepCampFilterState takes boolean state returns nothing
 // 允许/禁止小地图按钮
 native EnableMinimapFilterButtons takes boolean enableAlly, boolean enableCreep returns nothing

--- a/static/common.j
+++ b/static/common.j
@@ -347,7 +347,8 @@ globals
  constant boolean FALSE = false
     // 真 true
 	constant boolean TRUE = true
-	// 数组最大值，1.28及以下版本该值是8192
+	// 数组最大值，默认值32768
+	// 注：1.28及以下版本，默认值是8192
 	constant integer JASS_MAX_ARRAY_SIZE = 32768
 	// 中立被动玩家
 	constant integer PLAYER_NEUTRAL_PASSIVE = GetPlayerNeutralPassive()
@@ -421,25 +422,25 @@ globals
 	constant playergameresult PLAYER_GAME_RESULT_TIE = ConvertPlayerGameResult(2)
 	// 玩家游戏结果 不确定
 	constant playergameresult PLAYER_GAME_RESULT_NEUTRAL = ConvertPlayerGameResult(3)
-	// 被动联盟
+	// 联盟类型 被动联盟（结盟不侵略）
 	constant alliancetype ALLIANCE_PASSIVE = ConvertAllianceType(0)
-	// 联盟帮助要求
+	// 联盟类型 帮助请求
 	constant alliancetype ALLIANCE_HELP_REQUEST = ConvertAllianceType(1)
-	// 联盟帮助响应
+	// 联盟类型 帮助回答
 	constant alliancetype ALLIANCE_HELP_RESPONSE = ConvertAllianceType(2)
-	// 联盟共享优先权
+	// 联盟类型 共享经验值
 	constant alliancetype ALLIANCE_SHARED_XP = ConvertAllianceType(3)
-	// 盟友法术锁定
+	// 联盟类型 盟友魔法锁定
 	constant alliancetype ALLIANCE_SHARED_SPELLS = ConvertAllianceType(4)
-	// 联盟共享视野
+	// 联盟类型 共享视野
 	constant alliancetype ALLIANCE_SHARED_VISION = ConvertAllianceType(5)
-	// 联盟共享控制
+	// 联盟类型 共享单位
 	constant alliancetype ALLIANCE_SHARED_CONTROL = ConvertAllianceType(6)
-	// 联盟共享高级控制
+	// 联盟类型 完全共享单位
 	constant alliancetype ALLIANCE_SHARED_ADVANCED_CONTROL = ConvertAllianceType(7)
-	// 联盟可营救
+	// 联盟类型 可营救
 	constant alliancetype ALLIANCE_RESCUABLE = ConvertAllianceType(8)
-	// 联盟势力共享视野
+	// 联盟类型 被迫共享视野
 	constant alliancetype ALLIANCE_SHARED_VISION_FORCED = ConvertAllianceType(9)
 	// 游戏版本 混乱之治
 	constant version VERSION_REIGN_OF_CHAOS = ConvertVersion(0)
@@ -464,27 +465,27 @@ globals
 	constant damagetype DAMAGE_TYPE_UNKNOWN = ConvertDamageType(0)
 	// 伤害类型 普通
 	constant damagetype DAMAGE_TYPE_NORMAL = ConvertDamageType(4)
-	// 伤害类型 增强
+	// 伤害类型 强化
 	constant damagetype DAMAGE_TYPE_ENHANCED = ConvertDamageType(5)
 	// 伤害类型 火焰
 	constant damagetype DAMAGE_TYPE_FIRE = ConvertDamageType(8)
-	// 伤害类型 寒冰
+	// 伤害类型 冰冻
 	constant damagetype DAMAGE_TYPE_COLD = ConvertDamageType(9)
 	// 伤害类型 闪电
 	constant damagetype DAMAGE_TYPE_LIGHTNING = ConvertDamageType(10)
-	// 伤害类型 毒
+	// 伤害类型 毒药
 	constant damagetype DAMAGE_TYPE_POISON = ConvertDamageType(11)
-	// 伤害类型 瘟疫
+	// 伤害类型 疾病
 	constant damagetype DAMAGE_TYPE_DISEASE = ConvertDamageType(12)
 	// 伤害类型 神圣
 	constant damagetype DAMAGE_TYPE_DIVINE = ConvertDamageType(13)
 	// 伤害类型 魔法
 	constant damagetype DAMAGE_TYPE_MAGIC = ConvertDamageType(14)
-	// 伤害类型 声波
+	// 伤害类型 声音
 	constant damagetype DAMAGE_TYPE_SONIC = ConvertDamageType(15)
 	// 伤害类型 酸性
 	constant damagetype DAMAGE_TYPE_ACID = ConvertDamageType(16)
-	// 伤害类型 势力
+	// 伤害类型 力量
 	constant damagetype DAMAGE_TYPE_FORCE = ConvertDamageType(17)
 	// 伤害类型 死亡
 	constant damagetype DAMAGE_TYPE_DEATH = ConvertDamageType(18)
@@ -500,7 +501,7 @@ globals
 	constant damagetype DAMAGE_TYPE_SLOW_POISON = ConvertDamageType(23)
 	// 伤害类型 灵魂锁链
 	constant damagetype DAMAGE_TYPE_SPIRIT_LINK = ConvertDamageType(24)
-	// 伤害类型 暗影打击
+	// 伤害类型 暗影突袭
 	constant damagetype DAMAGE_TYPE_SHADOW_STRIKE = ConvertDamageType(25)
 	// 伤害类型 通用
 	constant damagetype DAMAGE_TYPE_UNIVERSAL = ConvertDamageType(26)
@@ -765,9 +766,9 @@ globals
 	constant mapflag MAP_LOCK_RESOURCE_TRADING = ConvertMapFlag(256)
 	// 地图-容许联盟资源交易
 	constant mapflag MAP_RESOURCE_TRADING_ALLIES_ONLY = ConvertMapFlag(512)
-	// 地图-禁止改变联盟状态
+	// 地图-禁止改变联盟类型
 	constant mapflag MAP_LOCK_ALLIANCE_CHANGES = ConvertMapFlag(1024)
-	// 地图-隐藏联盟状态改变
+	// 地图-隐藏联盟类型改变
 	constant mapflag MAP_ALLIANCE_CHANGES_HIDDEN = ConvertMapFlag(2048)
 	// 地图-允许作弊码
 	constant mapflag MAP_CHEATS = ConvertMapFlag(4096)
@@ -886,11 +887,11 @@ globals
 	constant playerstate PLAYER_STATE_GAME_RESULT = ConvertPlayerState(0)
 	
 	// current resource levels
-	// 玩家黄金数量
+	// 玩家当前的黄金数量
 	constant playerstate PLAYER_STATE_RESOURCE_GOLD = ConvertPlayerState(1)
-	// 玩家木材数量
+	// 玩家当前的木材数量
 	constant playerstate PLAYER_STATE_RESOURCE_LUMBER = ConvertPlayerState(2)
-	// 玩家英雄数量
+	// 玩家当前的英雄数量
 	constant playerstate PLAYER_STATE_RESOURCE_HERO_TOKENS = ConvertPlayerState(3)
     // 玩家可用人口数（默认为人口建筑提供的数量）
 	constant playerstate PLAYER_STATE_RESOURCE_FOOD_CAP = ConvertPlayerState(4)
@@ -898,17 +899,17 @@ globals
 	constant playerstate PLAYER_STATE_RESOURCE_FOOD_USED = ConvertPlayerState(5)
 	// 玩家人口上限数（平衡常数或触发限制的最大数量），默认为100
 	constant playerstate PLAYER_STATE_FOOD_CAP_CEILING = ConvertPlayerState(6)
-	// 玩家状态-给予奖励
+	// 玩家状态 - 给予奖励
 	constant playerstate PLAYER_STATE_GIVES_BOUNTY = ConvertPlayerState(7)
-	// 玩家状态-联盟胜利
+	// 玩家状态 - 联盟胜利
 	constant playerstate PLAYER_STATE_ALLIED_VICTORY = ConvertPlayerState(8)
-	// 玩家状态-放置
+	// 玩家状态 - 放置
 	constant playerstate PLAYER_STATE_PLACED = ConvertPlayerState(9)
-	// 玩家状态-默认为观看者
+	// 玩家状态 - 默认为观看者
 	constant playerstate PLAYER_STATE_OBSERVER_ON_DEATH = ConvertPlayerState(10)
-	// 玩家状态-观看者
+	// 玩家状态 - 观看者
 	constant playerstate PLAYER_STATE_OBSERVER = ConvertPlayerState(11)
-	// 玩家状态-不可跟随
+	// 玩家状态 - 不可跟随
 	constant playerstate PLAYER_STATE_UNFOLLOWABLE = ConvertPlayerState(12)
 	
 	// taxation rate for each resource
@@ -918,11 +919,11 @@ globals
 	constant playerstate PLAYER_STATE_LUMBER_UPKEEP_RATE = ConvertPlayerState(14)
 	
 	// cumulative resources collected by the player during the mission
-	// 玩家状态-已收集金钱
+	// 玩家状态 - 已收集的金钱数量
 	constant playerstate PLAYER_STATE_GOLD_GATHERED = ConvertPlayerState(15)
-	// 玩家状态-已收集木材
+	// 玩家状态 - 已收集的木材数量
 	constant playerstate PLAYER_STATE_LUMBER_GATHERED = ConvertPlayerState(16)
-	// 玩家状态-野生生物不睡眠
+	// 玩家状态 - 野生生物（中立敌对玩家的单位）不睡眠
 	constant playerstate PLAYER_STATE_NO_CREEP_SLEEP = ConvertPlayerState(25)
 	
 	// 当前生命值
@@ -933,62 +934,62 @@ globals
 	constant unitstate UNIT_STATE_MANA = ConvertUnitState(2)
 	// 最大法力值
 	constant unitstate UNIT_STATE_MAX_MANA = ConvertUnitState(3)
-	// AI难度-简单
+	// AI难度 - 简单
 	constant aidifficulty AI_DIFFICULTY_NEWBIE = ConvertAIDifficulty(0)
-	// AI难度-普通
+	// AI难度 - 普通
 	constant aidifficulty AI_DIFFICULTY_NORMAL = ConvertAIDifficulty(1)
-    // AI难度-困难
+    // AI难度 - 困难
 	constant aidifficulty AI_DIFFICULTY_INSANE = ConvertAIDifficulty(2)
 	
-	// 玩家积分-训练单位数量 player score values
+	// 玩家积分 - 训练单位数量 player score values
  constant playerscore PLAYER_SCORE_UNITS_TRAINED = ConvertPlayerScore(0)
-    // 玩家积分-消灭单位数量
+    // 玩家积分 - 消灭单位数量
 	constant playerscore PLAYER_SCORE_UNITS_KILLED = ConvertPlayerScore(1)
-	// 玩家积分-已建造建筑数量
+	// 玩家积分 - 已建造建筑数量
 	constant playerscore PLAYER_SCORE_STRUCT_BUILT = ConvertPlayerScore(2)
-	// 玩家积分-被毁建筑数量
+	// 玩家积分 - 被毁建筑数量
 	constant playerscore PLAYER_SCORE_STRUCT_RAZED = ConvertPlayerScore(3)
-	// 玩家积分-科技百分比
+	// 玩家积分 - 科技百分比
 	constant playerscore PLAYER_SCORE_TECH_PERCENT = ConvertPlayerScore(4)
-	// 玩家积分-最大可用人口数量
+	// 玩家积分 - 最大可用人口数量
 	constant playerscore PLAYER_SCORE_FOOD_MAXPROD = ConvertPlayerScore(5)
-	// 玩家积分-最大使用人口数量
+	// 玩家积分 - 最大使用人口数量
 	constant playerscore PLAYER_SCORE_FOOD_MAXUSED = ConvertPlayerScore(6)
-	// 玩家积分-杀死英雄
+	// 玩家积分 - 杀死英雄
 	constant playerscore PLAYER_SCORE_HEROES_KILLED = ConvertPlayerScore(7)
-	// 玩家积分-获得物品
+	// 玩家积分 - 获得物品
 	constant playerscore PLAYER_SCORE_ITEMS_GAINED = ConvertPlayerScore(8)
-	// 玩家积分-雇佣兵
+	// 玩家积分 - 雇佣兵
 	constant playerscore PLAYER_SCORE_MERCS_HIRED = ConvertPlayerScore(9)
-	// 玩家积分-采集到的黄金数量(全部)
+	// 玩家积分 - 采集到的黄金数量(全部)
 	constant playerscore PLAYER_SCORE_GOLD_MINED_TOTAL = ConvertPlayerScore(10)
-	// 玩家积分-采集到的黄金数量(带有维修）
+	// 玩家积分 - 采集到的黄金数量(带有维修）
 	constant playerscore PLAYER_SCORE_GOLD_MINED_UPKEEP = ConvertPlayerScore(11)
-	// 玩家积分-由于维修费而损失的黄金数量
+	// 玩家积分 - 由于维修费而损失的黄金数量
 	constant playerscore PLAYER_SCORE_GOLD_LOST_UPKEEP = ConvertPlayerScore(12)
-	// 玩家积分-由于税而损失的黄金数量
+	// 玩家积分 - 由于税而损失的黄金数量
 	constant playerscore PLAYER_SCORE_GOLD_LOST_TAX = ConvertPlayerScore(13)
-	// 玩家积分-给予盟友的黄金数量
+	// 玩家积分 - 给予盟友的黄金数量
 	constant playerscore PLAYER_SCORE_GOLD_GIVEN = ConvertPlayerScore(14)
-	// 玩家积分-从盟友那里收到的黄金数量
+	// 玩家积分 - 从盟友那里收到的黄金数量
 	constant playerscore PLAYER_SCORE_GOLD_RECEIVED = ConvertPlayerScore(15)
-	// 玩家积分-采集到的木材数量
+	// 玩家积分 - 采集到的木材数量
 	constant playerscore PLAYER_SCORE_LUMBER_TOTAL = ConvertPlayerScore(16)
-	// 玩家积分-由于维修费而损失的木材数量
+	// 玩家积分 - 由于维修费而损失的木材数量
 	constant playerscore PLAYER_SCORE_LUMBER_LOST_UPKEEP = ConvertPlayerScore(17)
-	// 玩家积分-由于税而损失的木材数量
+	// 玩家积分 - 由于税而损失的木材数量
 	constant playerscore PLAYER_SCORE_LUMBER_LOST_TAX = ConvertPlayerScore(18)
-	// 玩家积分-给予盟友的木材数量
+	// 玩家积分 - 给予盟友的木材数量
 	constant playerscore PLAYER_SCORE_LUMBER_GIVEN = ConvertPlayerScore(19)
-	// 玩家积分-从盟友那里收到的木材数量
+	// 玩家积分 - 从盟友那里收到的木材数量
 	constant playerscore PLAYER_SCORE_LUMBER_RECEIVED = ConvertPlayerScore(20)
-	// 玩家积分-总的单位得分
+	// 玩家积分 - 总的单位得分
 	constant playerscore PLAYER_SCORE_UNIT_TOTAL = ConvertPlayerScore(21)
-	// 玩家积分-总的英雄得分
+	// 玩家积分 - 总的英雄得分
 	constant playerscore PLAYER_SCORE_HERO_TOTAL = ConvertPlayerScore(22)
-	// 玩家积分-总的资源得分
+	// 玩家积分 - 总的资源得分
 	constant playerscore PLAYER_SCORE_RESOURCE_TOTAL = ConvertPlayerScore(23)
-	// 玩家积分-总的整体得分
+	// 玩家积分 - 总的整体得分
 	constant playerscore PLAYER_SCORE_TOTAL = ConvertPlayerScore(24)
 	
 	
@@ -1036,7 +1037,7 @@ globals
 	// For use with TriggerRegisterPlayerEvent
 	// 玩家状态限制
  constant playerevent EVENT_PLAYER_STATE_LIMIT = ConvertPlayerEvent(11)
-	// 玩家联盟状态变更
+	// 玩家联盟类型变更
 	constant playerevent EVENT_PLAYER_ALLIANCE_CHANGED = ConvertPlayerEvent(12)
 	// 玩家失败
 	constant playerevent EVENT_PLAYER_DEFEAT = ConvertPlayerEvent(13)
@@ -1118,7 +1119,7 @@ globals
 	constant playerunitevent EVENT_PLAYER_HERO_REVIVE_CANCEL = ConvertPlayerUnitEvent(45)
 	// 玩家英雄完成复活
 	constant playerunitevent EVENT_PLAYER_HERO_REVIVE_FINISH = ConvertPlayerUnitEvent(46)
-	// 玩家反召唤建筑（亡灵卖建筑）
+	// 玩家召唤事件
 	constant playerunitevent EVENT_PLAYER_UNIT_SUMMON = ConvertPlayerUnitEvent(47)
 	// 玩家单位物品掉落事件
 	constant playerunitevent EVENT_PLAYER_UNIT_DROP_ITEM = ConvertPlayerUnitEvent(48)
@@ -1208,7 +1209,7 @@ globals
 	constant unitevent EVENT_UNIT_HERO_REVIVE_CANCEL = ConvertUnitEvent(82)
 	// 英雄完成复活
 	constant unitevent EVENT_UNIT_HERO_REVIVE_FINISH = ConvertUnitEvent(83)
-	// 建筑反召唤（亡灵卖建筑）
+	// 召唤事件
 	constant unitevent EVENT_UNIT_SUMMON = ConvertUnitEvent(84)
 	// 单位掉落物品事件
 	constant unitevent EVENT_UNIT_DROP_ITEM = ConvertUnitEvent(85)
@@ -1218,7 +1219,7 @@ globals
 	constant unitevent EVENT_UNIT_USE_ITEM = ConvertUnitEvent(87)
 	// 单位被装载事件
 	constant unitevent EVENT_UNIT_LOADED = ConvertUnitEvent(88)
-	// 地表装饰物死亡事件
+	// 目标物死亡事件
 	constant widgetevent EVENT_WIDGET_DEATH = ConvertWidgetEvent(89)
 	// 对话框按钮点击事件
 	constant dialogevent EVENT_DIALOG_BUTTON_CLICK = ConvertDialogEvent(90)
@@ -2580,7 +2581,7 @@ globals
 	constant abilityintegerlevelfield ABILITY_ILF_SUMMONED_UNIT_TYPE_NDOU = ConvertAbilityIntegerLevelField('Ndou')
     // 技能整数等级域 变化形态单位 ('Emeu')
 	constant abilityintegerlevelfield ABILITY_ILF_ALTERNATE_FORM_UNIT_EMEU = ConvertAbilityIntegerLevelField('Emeu')
-    // 技能整数等级域 瘟疫守卫单位类型 ('Aplu')
+    // 技能整数等级域 疾病守卫单位类型 ('Aplu')
 	constant abilityintegerlevelfield ABILITY_ILF_PLAGUE_WARD_UNIT_TYPE = ConvertAbilityIntegerLevelField('Aplu')
     // 技能整数等级域 允许单位类型 ('Btl1')
 	constant abilityintegerlevelfield ABILITY_ILF_ALLOWED_UNIT_TYPE_BTL1 = ConvertAbilityIntegerLevelField('Btl1')
@@ -2833,11 +2834,11 @@ globals
 	constant abilityreallevelfield ABILITY_RLF_SUMMONED_UNIT_DAMAGE_AMS1 = ConvertAbilityRealLevelField('Ams1')
     // 技能实数等级域 魔法伤害减少（无效） ('Ams2')
 	constant abilityreallevelfield ABILITY_RLF_MAGIC_DAMAGE_REDUCTION_AMS2 = ConvertAbilityRealLevelField('Ams2')
-    // 技能实数等级域 瘟疫效果持续时间 ('Apl1')
+    // 技能实数等级域 疾病效果持续时间 ('Apl1')
 	constant abilityreallevelfield ABILITY_RLF_AURA_DURATION = ConvertAbilityRealLevelField('Apl1')
     // 技能实数等级域 每秒伤害 ('Apl2')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_PER_SECOND_APL2 = ConvertAbilityRealLevelField('Apl2')
-    // 技能实数等级域 瘟疫守卫持续时间 ('Apl3')
+    // 技能实数等级域 疾病守卫持续时间 ('Apl3')
 	constant abilityreallevelfield ABILITY_RLF_DURATION_OF_PLAGUE_WARD = ConvertAbilityRealLevelField('Apl3')
     // 技能实数等级域 每秒生命恢复 ('Oar1')
 	constant abilityreallevelfield ABILITY_RLF_AMOUNT_OF_HIT_POINTS_REGENERATED = ConvertAbilityRealLevelField('Oar1')
@@ -4073,7 +4074,7 @@ globals
 	constant pathingflag PATHING_FLAG_UNBUILDABLE = ConvertPathingFlag(8)
 	// 放置要求 工人可采集
 	constant pathingflag PATHING_FLAG_UNPEONHARVEST = ConvertPathingFlag(16)
-	// 放置要求 不是荒芜之地
+	// 放置要求 不是荒芜地表
 	constant pathingflag PATHING_FLAG_BLIGHTED = ConvertPathingFlag(32)
 	// 放置要求 海面可通行
 	constant pathingflag PATHING_FLAG_UNFLOATABLE = ConvertPathingFlag(64)
@@ -4251,7 +4252,7 @@ native SetPlayerStartLocation takes player whichPlayer, integer startLocIndex re
 native ForcePlayerStartLocation takes player whichPlayer, integer startLocIndex returns nothing
 // 改变玩家颜色 [R]
 native SetPlayerColor takes player whichPlayer, playercolor color returns nothing
-// 设置联盟状态(指定项目) [R]
+// 设置联盟类型(指定项目) [R]
 native SetPlayerAlliance takes player sourcePlayer, player otherPlayer, alliancetype whichAllianceSetting, boolean value returns nothing
 // 设置税率 [R]
 native SetPlayerTaxRate takes player sourcePlayer, player otherPlayer, playerstate whichResource, integer rate returns nothing
@@ -4319,43 +4320,58 @@ native GetExpiredTimer takes nothing returns timer
 native CreateGroup takes nothing returns group
 // 删除单位组 [R]
 native DestroyGroup takes group whichGroup returns nothing
-// 为指定单位组添加添加指定单位 [R]
+// 将指定单位添加到单位组中 [R]
 native GroupAddUnit takes group whichGroup, unit whichUnit returns boolean
-// 为指定单位组移除指定单位 [R]
+// 将指定单位移出单位组 [R]
 native GroupRemoveUnit takes group whichGroup, unit whichUnit returns boolean
-// 单位组添加单位组 [快速的]
+// 往 addGroup单位组 添加 whichGroup单位组 的单位 [快速]
+// @version 1.33
 native BlzGroupAddGroupFast takes group whichGroup, group addGroup returns integer
-// 单位组移除单位组 [快速的]
+// 从 removeGroup单位组 中移除 whichGroup单位组 的单位 [快速]
+// @version 1.33
 native BlzGroupRemoveGroupFast takes group whichGroup, group removeGroup returns integer
-// 清空单位组，排泄需要使用删除单位组 CreateGroup，而非清空
+// 清空单位组
+// 排泄需要使用删除单位组 CreateGroup，而非清空
 native GroupClear takes group whichGroup returns nothing
 // 获取单位组尺寸（组内的单位数量）
 native BlzGroupGetSize takes group whichGroup returns integer
 // 获取单位组中下标的单位
 native BlzGroupUnitAt takes group whichGroup, integer index returns unit
-// 通过单位类型匹配单位
+// 将指定单位类型的单位加入单位组
+// 可用filter附加选择单位的额外条件，不建议使用在AI脚本中，即filter写成null
 native GroupEnumUnitsOfType takes group whichGroup, string unitname, boolexpr filter returns nothing
-// 通过玩家匹配单位
+// 将指定玩家匹的单位加入单位组
+// 可用filter附加选择单位的额外条件，不建议使用在AI脚本中，即filter写成null
 native GroupEnumUnitsOfPlayer takes group whichGroup, player whichPlayer, boolexpr filter returns nothing
-// 通过单位类型匹配单位（指定数量上限）
-// @param countLimit
+// 将指定单位类型的单位加入单位组，同时指定添加单位的数量上限
+// 可用filter附加选择单位的额外条件，不建议使用在AI脚本中，即filter写成null
+// @param countLimit 数量上限
 native GroupEnumUnitsOfTypeCounted takes group whichGroup, string unitname, boolexpr filter, integer countLimit returns nothing
-// 匹配范围单位
+// 将指定方形区域的的单位加入单位组
+// 可用filter附加选择单位的额外条件，不建议使用在AI脚本中，即filter写成null
 native GroupEnumUnitsInRect takes group whichGroup, rect r, boolexpr filter returns nothing
-// 匹配范围单位（指定数量上限）
-// @param countLimit
+// 将指定方形区域的的单位加入单位组，同时指定添加单位的数量上限
+// 可用filter附加选择单位的额外条件，不建议使用在AI脚本中，即filter写成null
+// @param countLimit 数量上限
 native GroupEnumUnitsInRectCounted takes group whichGroup, rect r, boolexpr filter, integer countLimit returns nothing
-// 选取指定坐标点指定范围内的单位添加到指定单位组(可用filter附加选择单位的额外条件，在AI脚本中，filter建议使用null)
+// 将圆形区域的单位添加到单位组（指定圆心坐标）
+// 可用filter附加选择单位的额外条件，不建议使用在AI脚本中，即filter写成null
 native GroupEnumUnitsInRange takes group whichGroup, real x, real y, real radius, boolexpr filter returns nothing
-// 选取指定点指定范围内的单位添加到指定单位组(可用filter附加选择单位的额外条件，在AI脚本中，filter建议使用null)
+// 将圆形区域的单位添加到单位组（指定圆心坐标）
+// 可用filter附加选择单位的额外条件，不建议使用在AI脚本中，即filter写成null
 native GroupEnumUnitsInRangeOfLoc takes group whichGroup, location whichLocation, real radius, boolexpr filter returns nothing
-// 选取指定坐标点指定范围内的单位添加到指定单位组(可用filter附加选择单位的额外条件，在AI脚本中，filter建议使用null)(不建议使用)
+// 【弃用】将圆形区域的单位添加到单位组（指定圆心坐标），同时指定添加单位的数量上限
+// 可用filter附加选择单位的额外条件，不建议使用在AI脚本中，即filter写成null
 // @deprecated
+// @param countLimit 数量上限
 native GroupEnumUnitsInRangeCounted takes group whichGroup, real x, real y, real radius, boolexpr filter, integer countLimit returns nothing
-// 选取指定点指定范围内的单位添加到指定单位组(可用filter附加选择单位的额外条件，在AI脚本中，filter建议使用null)(不建议使用)
+// 【弃用】将圆形区域的单位添加到单位组（指定圆心坐标），同时指定添加单位的数量上限
+// 可用filter附加选择单位的额外条件，不建议使用在AI脚本中，即filter写成null
 // @deprecated
+// @param countLimit 数量上限
 native GroupEnumUnitsInRangeOfLocCounted takes group whichGroup, location whichLocation, real radius, boolexpr filter, integer countLimit returns nothing
-// 选取指定玩家的单位添加到指定单位组(可用filter附加选择单位的额外条件，在AI脚本中，filter建议使用null)
+// 将指定玩家的单位添加到单位组
+// 可用filter附加选择单位的额外条件，不建议使用在AI脚本中，即filter写成null
 native GroupEnumUnitsSelected takes group whichGroup, player whichPlayer, boolexpr filter returns nothing
 
 // 发送单位组命令（无目标）
@@ -4874,7 +4890,7 @@ constant native GetSpellTargetItem takes nothing returns item
 // 获取被释放技能目标单位
 constant native GetSpellTargetUnit takes nothing returns unit
 
-// 注册玩家联盟状态改变事件(特殊)
+// 注册玩家联盟类型改变事件(特殊)
 native TriggerRegisterPlayerAllianceChange takes trigger whichTrigger, player whichPlayer, alliancetype whichAlliance returns event
 // 注册玩家属性事件
 native TriggerRegisterPlayerStateEvent takes trigger whichTrigger, player whichPlayer, playerstate whichState, limitop opcode, real limitval returns event
@@ -5011,15 +5027,15 @@ native TriggerSyncReady takes nothing returns nothing
 
 
 // Widget API
-// 获取地表装饰物的生命值
+// 获取目标的生命值
 native GetWidgetLife takes widget whichWidget returns real
-// 设置地表装饰物的生命值
+// 设置目标的生命值
 native SetWidgetLife takes widget whichWidget, real newLife returns nothing
-// 获取地表装饰物的 X 轴坐标
+// 获取目标的 X 轴坐标
 native GetWidgetX takes widget whichWidget returns real
-// 获取地表装饰物的 Y 轴坐标
+// 获取目标的 Y 轴坐标
 native GetWidgetY takes widget whichWidget returns real
-// 获取触发的地表装饰物
+// 获取触发的目标
 constant native GetTriggerWidget takes nothing returns widget
 
 
@@ -5913,7 +5929,7 @@ native SaveBoolean takes hashtable table, integer parentKey, integer childKey, b
 native SaveStr takes hashtable table, integer parentKey, integer childKey, string value returns boolean
 // <1.24> 保存玩家 [C]
 native SavePlayerHandle takes hashtable table, integer parentKey, integer childKey, player whichPlayer returns boolean
-// <1.24> 保存地表装饰物 [C]
+// <1.24> 保存目标 [C]
 native SaveWidgetHandle takes hashtable table, integer parentKey, integer childKey, widget whichWidget returns boolean
 // <1.24> 保存可破坏物 [C]
 native SaveDestructableHandle takes hashtable table, integer parentKey, integer childKey, destructable whichDestructable returns boolean
@@ -6003,7 +6019,7 @@ native LoadBoolean takes hashtable table, integer parentKey, integer childKey re
 native LoadStr takes hashtable table, integer parentKey, integer childKey returns string
 // <1.24> 从哈希表提取玩家 [C]
 native LoadPlayerHandle takes hashtable table, integer parentKey, integer childKey returns player
-// <1.24> 从哈希表提取地表装饰物 [C]
+// <1.24> 从哈希表提取目标[C]
 native LoadWidgetHandle takes hashtable table, integer parentKey, integer childKey returns widget
 // <1.24> 从哈希表提取可破坏物 [C]
 native LoadDestructableHandle takes hashtable table, integer parentKey, integer childKey returns destructable
@@ -6187,7 +6203,7 @@ native ShowInterface takes boolean flag, real fadeDuration returns nothing
 native PauseGame takes boolean flag returns nothing
 // 添加闪动指示器(指定单位) [R]
 native UnitAddIndicator takes unit whichUnit, integer red, integer green, integer blue, integer alpha returns nothing
-// 添加闪动指示器(指定地表装饰物)
+// 添加闪动指示器(指定目标)
 native AddIndicator takes widget whichWidget, integer red, integer green, integer blue, integer alpha returns nothing
 // 小地图信号(所有玩家) [R]
 native PingMinimap takes real x, real y, real duration returns nothing
@@ -6607,21 +6623,21 @@ constant native GetCameraBoundMinY takes nothing returns real
 constant native GetCameraBoundMaxX takes nothing returns real
 // 获取可用镜头范围的最大 Y 坐标
 constant native GetCameraBoundMaxY takes nothing returns real
-// 获取当前摄象机的指定属性值
+// 获取当前镜头的指定属性值
 constant native GetCameraField takes camerafield whichField returns real
-// 获取当前摄象机目标的 X 坐标
+// 获取当前镜头目标的 X 坐标
 constant native GetCameraTargetPositionX takes nothing returns real
-// 获取当前摄象机目标的 Y 坐标
+// 获取当前镜头目标的 Y 坐标
 constant native GetCameraTargetPositionY takes nothing returns real
-// 获取当前摄象机目标的 Z 坐标
+// 获取当前镜头目标的 Z 坐标
 constant native GetCameraTargetPositionZ takes nothing returns real
-// 获取当前摄象机目标点（返回点）
+// 获取当前镜头目标点（返回点）
 constant native GetCameraTargetPositionLoc takes nothing returns location
-// 获取当前摄象机观察位置的 X 坐标
+// 获取当前镜头观察位置的 X 坐标
 constant native GetCameraEyePositionX takes nothing returns real
-// 获取当前摄象机位置的 Y 坐标
+// 获取当前镜头位置的 Y 坐标
 constant native GetCameraEyePositionY takes nothing returns real
-// 获取当前摄象机观察位置的 Z 坐标
+// 获取当前镜头观察位置的 Z 坐标
 constant native GetCameraEyePositionZ takes nothing returns real
 // 获取当前照相机的观察位置（返回点）
 constant native GetCameraEyePositionLoc takes nothing returns location
@@ -6882,17 +6898,17 @@ native SetUbersplatRenderAlways takes ubersplat whichSplat, boolean flag returns
 
 // Blight API
 //
-// 创建/删除荒芜地表(圆范围)(指定坐标) [R]
+// 创建/删除荒芜地表（不死族）(圆范围)(指定坐标) [R]
 native SetBlight takes player whichPlayer, real x, real y, real radius, boolean addBlight returns nothing
-// 创建/删除荒芜地表(矩形区域) [R]
+// 创建/删除荒芜地表（不死族）(矩形区域) [R]
 native SetBlightRect takes player whichPlayer, rect r, boolean addBlight returns nothing
-// 设置荒芜地表（指定坐标）
+// 设置荒芜地表（不死族）（指定坐标）
 native SetBlightPoint takes player whichPlayer, real x, real y, boolean addBlight returns nothing
-// 设置荒芜地表（圆范围）（指定点）
+// 设置荒芜地表（不死族）（圆范围）（指定点）
 native SetBlightLoc takes player whichPlayer, location whichLocation, real radius, boolean addBlight returns nothing
 // 新建不死族金矿 [R]
 native CreateBlightedGoldmine takes player id, real x, real y, real face returns unit
-// 坐标点被荒芜地表覆盖 [R]
+// 指定坐标是否被荒芜地表（不死族）覆盖 [R]
 native IsPointBlighted takes real x, real y returns boolean
 
 

--- a/static/common.j
+++ b/static/common.j
@@ -2208,40 +2208,43 @@ globals
 	
 	
 	// Ability
-	// 技能按钮位置 x 坐标（常规状态） ('abpx')
+	// 技能整数域 技能按钮位置 x 坐标（常规状态） ('abpx')
  constant abilityintegerfield ABILITY_IF_BUTTON_POSITION_NORMAL_X = ConvertAbilityIntegerField('abpx')
-	// 技能按钮位置 y 坐标（常规状态） ('abpy')
+	// 技能整数域 技能按钮位置 y 坐标（常规状态） ('abpy')
 	constant abilityintegerfield ABILITY_IF_BUTTON_POSITION_NORMAL_Y = ConvertAbilityIntegerField('abpy')
-	// 技能按钮位置 x 坐标（激活状态） ('aubx')
+	// 技能整数域 技能按钮位置 x 坐标（激活状态） ('aubx')
 	constant abilityintegerfield ABILITY_IF_BUTTON_POSITION_ACTIVATED_X = ConvertAbilityIntegerField('aubx')
-	// 技能按钮位置 y 坐标（激活状态） ('auby')
+	// 技能整数域 技能按钮位置 y 坐标（激活状态） ('auby')
 	constant abilityintegerfield ABILITY_IF_BUTTON_POSITION_ACTIVATED_Y = ConvertAbilityIntegerField('auby')
-	// 技能按钮位置 x 坐标（研究状态） ('arpx')
+	// 技能整数域 技能按钮位置 x 坐标（研究状态） ('arpx')
 	constant abilityintegerfield ABILITY_IF_BUTTON_POSITION_RESEARCH_X = ConvertAbilityIntegerField('arpx')
-	// 技能按钮位置 y 坐标（研究状态） ('arpy')
+	// 技能整数域 技能按钮位置 y 坐标（研究状态） ('arpy')
 	constant abilityintegerfield ABILITY_IF_BUTTON_POSITION_RESEARCH_Y = ConvertAbilityIntegerField('arpy')
-	// 技能弹道速度 ('amsp')
+	// 技能整数域 技能弹道速度 ('amsp')
 	constant abilityintegerfield ABILITY_IF_MISSILE_SPEED = ConvertAbilityIntegerField('amsp')
-	// 技能目标附加 ('atac')
+	// 技能整数域 技能目标附加 ('atac')
 	constant abilityintegerfield ABILITY_IF_TARGET_ATTACHMENTS = ConvertAbilityIntegerField('atac')
-	// 技能施法单位附加 ('acac')
+	// 技能整数域 技能施法单位附加 ('acac')
 	constant abilityintegerfield ABILITY_IF_CASTER_ATTACHMENTS = ConvertAbilityIntegerField('acac')
-	// 技能优先权 ('apri')
+	// 技能整数域 技能优先权 ('apri')
 	constant abilityintegerfield ABILITY_IF_PRIORITY = ConvertAbilityIntegerField('apri')
-	// 技能等级 ('alev')
+	// 技能整数域 技能等级 ('alev')
 	constant abilityintegerfield ABILITY_IF_LEVELS = ConvertAbilityIntegerField('alev')
-	// 技能需求等级 ('arlv')
+	// 技能整数域 技能需求等级 ('arlv')
 	constant abilityintegerfield ABILITY_IF_REQUIRED_LEVEL = ConvertAbilityIntegerField('arlv')
-	// 技能学习等级需求 ('alsk')
-	constant abilityintegerfield ABILITY_IF_LEVEL_SKIP_REQUIREMENT = ConvertAbilityIntegerField('alsk') 
-	// 技能状态-英雄技能 ('aher')
+	// 技能整数域 技能学习等级需求 ('alsk')
+	constant abilityintegerfield ABILITY_IF_LEVEL_SKIP_REQUIREMENT = ConvertAbilityIntegerField('alsk')
+
+	// 技能布尔值域 技能状态-英雄技能 ('aher')
 	constant abilitybooleanfield ABILITY_BF_HERO_ABILITY = ConvertAbilityBooleanField('aher') // Get only
-	// 技能状态-物品技能 ('aite')
+	// 技能布尔值域 技能状态-物品技能 ('aite')
 	constant abilitybooleanfield ABILITY_BF_ITEM_ABILITY = ConvertAbilityBooleanField('aite')
-	// 技能状态-检查依赖 ('achd')
+	// 技能布尔值域 技能状态-检查依赖 ('achd')
 	constant abilitybooleanfield ABILITY_BF_CHECK_DEPENDENCIES = ConvertAbilityBooleanField('achd')
+
 	// 技能实数域 弹道曲率 ('amac')
 	constant abilityrealfield ABILITY_RF_ARF_MISSILE_ARC = ConvertAbilityRealField('amac')
+
 	// 技能字串符域 名字 ('anam')
 	constant abilitystringfield ABILITY_SF_NAME = ConvertAbilityStringField('anam') // Get Only
 	// 技能字串符域 图标（关闭） ('auar')
@@ -2253,669 +2256,1331 @@ globals
 	// 技能字串符域 音效（循环） ('aefl')
 	constant abilitystringfield ABILITY_SF_EFFECT_SOUND_LOOPING = ConvertAbilityStringField('aefl')
 	
+    // 技能整数等级域 魔法消耗 ('amcs')
 	constant abilityintegerlevelfield ABILITY_ILF_MANA_COST = ConvertAbilityIntegerLevelField('amcs')
+    // 技能整数等级域 波次数量 ('Hbz1')
 	constant abilityintegerlevelfield ABILITY_ILF_NUMBER_OF_WAVES = ConvertAbilityIntegerLevelField('Hbz1')
+    // 技能整数等级域 碎片数量 ('Hbz3')
 	constant abilityintegerlevelfield ABILITY_ILF_NUMBER_OF_SHARDS = ConvertAbilityIntegerLevelField('Hbz3')
+    // 技能整数等级域 传送单位数量 ('Hmt1')
 	constant abilityintegerlevelfield ABILITY_ILF_NUMBER_OF_UNITS_TELEPORTED = ConvertAbilityIntegerLevelField('Hmt1')
+    // 技能整数等级域 召唤单位数量 ('Hwe2')
 	constant abilityintegerlevelfield ABILITY_ILF_SUMMONED_UNIT_COUNT_HWE2 = ConvertAbilityIntegerLevelField('Hwe2')
+    // 技能整数等级域 镜像数量 ('Omi1')
 	constant abilityintegerlevelfield ABILITY_ILF_NUMBER_OF_IMAGES = ConvertAbilityIntegerLevelField('Omi1')
+    // 技能整数等级域 复活死尸数量 ('Uan1')
 	constant abilityintegerlevelfield ABILITY_ILF_NUMBER_OF_CORPSES_RAISED_UAN1 = ConvertAbilityIntegerLevelField('Uan1')
+    // 技能整数等级域 变化参数 ('Eme2')
 	constant abilityintegerlevelfield ABILITY_ILF_MORPHING_FLAGS = ConvertAbilityIntegerLevelField('Eme2')
+    // 技能整数等级域 力量奖励 ('Nrg5')
 	constant abilityintegerlevelfield ABILITY_ILF_STRENGTH_BONUS_NRG5 = ConvertAbilityIntegerLevelField('Nrg5')
+    // 技能整数等级域 防御奖励 ('Nrg6')
 	constant abilityintegerlevelfield ABILITY_ILF_DEFENSE_BONUS_NRG6 = ConvertAbilityIntegerLevelField('Nrg6')
+    // 技能整数等级域 最大目标数量 ('Ocl2')
 	constant abilityintegerlevelfield ABILITY_ILF_NUMBER_OF_TARGETS_HIT = ConvertAbilityIntegerLevelField('Ocl2')
+    // 技能整数等级域 侦察类型 ('Ofs1')
 	constant abilityintegerlevelfield ABILITY_ILF_DETECTION_TYPE_OFS1 = ConvertAbilityIntegerLevelField('Ofs1')
+    // 技能整数等级域 召唤单位数量 ('Osf2')
 	constant abilityintegerlevelfield ABILITY_ILF_NUMBER_OF_SUMMONED_UNITS_OSF2 = ConvertAbilityIntegerLevelField('Osf2')
+    // 技能整数等级域 召唤单位数量 ('Efn1')
 	constant abilityintegerlevelfield ABILITY_ILF_NUMBER_OF_SUMMONED_UNITS_EFN1 = ConvertAbilityIntegerLevelField('Efn1')
+    // 技能整数等级域 复活单位数量 ('Hre1')
 	constant abilityintegerlevelfield ABILITY_ILF_NUMBER_OF_CORPSES_RAISED_HRE1 = ConvertAbilityIntegerLevelField('Hre1')
+    // 技能整数等级域 叠加参数 ('Hca4')
 	constant abilityintegerlevelfield ABILITY_ILF_STACK_FLAGS = ConvertAbilityIntegerLevelField('Hca4')
+    // 技能整数等级域 最小单位数 ('Ndp2')
 	constant abilityintegerlevelfield ABILITY_ILF_MINIMUM_NUMBER_OF_UNITS = ConvertAbilityIntegerLevelField('Ndp2')
+    // 技能整数等级域 最大单位数 ('Ndp3')
 	constant abilityintegerlevelfield ABILITY_ILF_MAXIMUM_NUMBER_OF_UNITS_NDP3 = ConvertAbilityIntegerLevelField('Ndp3')
+    // 技能整数等级域 创建单位数 ('Nrc2')
 	constant abilityintegerlevelfield ABILITY_ILF_NUMBER_OF_UNITS_CREATED_NRC2 = ConvertAbilityIntegerLevelField('Nrc2')
+    // 技能整数等级域 护盾生命值 ('Ams3')
 	constant abilityintegerlevelfield ABILITY_ILF_SHIELD_LIFE = ConvertAbilityIntegerLevelField('Ams3')
+    // 技能整数等级域 魔法损耗 ('Ams4')
 	constant abilityintegerlevelfield ABILITY_ILF_MANA_LOSS_AMS4 = ConvertAbilityIntegerLevelField('Ams4')
+    // 技能整数等级域 采集黄金数/间隔 ('Bgm1')
 	constant abilityintegerlevelfield ABILITY_ILF_GOLD_PER_INTERVAL_BGM1 = ConvertAbilityIntegerLevelField('Bgm1')
+    // 技能整数等级域 最大矿工数量 ('Bgm3')
 	constant abilityintegerlevelfield ABILITY_ILF_MAX_NUMBER_OF_MINERS = ConvertAbilityIntegerLevelField('Bgm3')
+    // 技能整数等级域 装载容量 ('Car1')
 	constant abilityintegerlevelfield ABILITY_ILF_CARGO_CAPACITY = ConvertAbilityIntegerLevelField('Car1')
+    // 技能整数等级域 最大目标中立等级 ('Dev3')
 	constant abilityintegerlevelfield ABILITY_ILF_MAXIMUM_CREEP_LEVEL_DEV3 = ConvertAbilityIntegerLevelField('Dev3')
+    // 技能整数等级域 最大目标中立等级 ('Dev1')
 	constant abilityintegerlevelfield ABILITY_ILF_MAX_CREEP_LEVEL_DEV1 = ConvertAbilityIntegerLevelField('Dev1')
+    // 技能整数等级域 采集黄金数/间隔 ('Fae1')
 	constant abilityintegerlevelfield ABILITY_ILF_GOLD_PER_INTERVAL_EGM1 = ConvertAbilityIntegerLevelField('Egm1')
+    // 技能整数等级域 防御减少 ('Fae1')
 	constant abilityintegerlevelfield ABILITY_ILF_DEFENSE_REDUCTION = ConvertAbilityIntegerLevelField('Fae1')
+    // 技能整数等级域 侦察类型 ('Fla1')
 	constant abilityintegerlevelfield ABILITY_ILF_DETECTION_TYPE_FLA1 = ConvertAbilityIntegerLevelField('Fla1')
+    // 技能整数等级域 闪光弹数量 ('Fla3')
 	constant abilityintegerlevelfield ABILITY_ILF_FLARE_COUNT = ConvertAbilityIntegerLevelField('Fla3')
+    // 技能整数等级域 最大黄金数量 ('Gld1')
 	constant abilityintegerlevelfield ABILITY_ILF_MAX_GOLD = ConvertAbilityIntegerLevelField('Gld1')
+    // 技能整数等级域 最大矿工容量 ('Gld3')
 	constant abilityintegerlevelfield ABILITY_ILF_MINING_CAPACITY = ConvertAbilityIntegerLevelField('Gld3')
+    // 技能整数等级域 最大尸体数量 ('Gyd1')
 	constant abilityintegerlevelfield ABILITY_ILF_MAXIMUM_NUMBER_OF_CORPSES_GYD1 = ConvertAbilityIntegerLevelField('Gyd1')
+    // 技能整数等级域 对树伤害 ('Har1')
 	constant abilityintegerlevelfield ABILITY_ILF_DAMAGE_TO_TREE = ConvertAbilityIntegerLevelField('Har1')
+    // 技能整数等级域 （单次采集最大）木材容量 ('Har2')
 	constant abilityintegerlevelfield ABILITY_ILF_LUMBER_CAPACITY = ConvertAbilityIntegerLevelField('Har2')
+    // 技能整数等级域 （单次采集最大）黄金容量 ('Har3')
 	constant abilityintegerlevelfield ABILITY_ILF_GOLD_CAPACITY = ConvertAbilityIntegerLevelField('Har3')
+    // 技能整数等级域 防御增加 ('Inf2')
 	constant abilityintegerlevelfield ABILITY_ILF_DEFENSE_INCREASE_INF2 = ConvertAbilityIntegerLevelField('Inf2')
+    // 技能整数等级域 选择单位类型 ('Neu2')
 	constant abilityintegerlevelfield ABILITY_ILF_INTERACTION_TYPE = ConvertAbilityIntegerLevelField('Neu2')
+    // 技能整数等级域 黄金消耗 ('Ndt1')
 	constant abilityintegerlevelfield ABILITY_ILF_GOLD_COST_NDT1 = ConvertAbilityIntegerLevelField('Ndt1')
+    // 技能整数等级域 木材消耗 ('Ndt2')
 	constant abilityintegerlevelfield ABILITY_ILF_LUMBER_COST_NDT2 = ConvertAbilityIntegerLevelField('Ndt2')
+    // 技能整数等级域 侦察类型 ('Ndt3')
 	constant abilityintegerlevelfield ABILITY_ILF_DETECTION_TYPE_NDT3 = ConvertAbilityIntegerLevelField('Ndt3')
+    // 技能整数等级域 叠加类型 ('Poi4')
 	constant abilityintegerlevelfield ABILITY_ILF_STACKING_TYPE_POI4 = ConvertAbilityIntegerLevelField('Poi4')
+    // 技能整数等级域 叠加类型 ('Poa5')
 	constant abilityintegerlevelfield ABILITY_ILF_STACKING_TYPE_POA5 = ConvertAbilityIntegerLevelField('Poa5')
+    // 技能整数等级域 最大目标中立生物等级 ('Ply1')
 	constant abilityintegerlevelfield ABILITY_ILF_MAXIMUM_CREEP_LEVEL_PLY1 = ConvertAbilityIntegerLevelField('Ply1')
+    // 技能整数等级域 最大目标中立生物等级 ('Pos1')
 	constant abilityintegerlevelfield ABILITY_ILF_MAXIMUM_CREEP_LEVEL_POS1 = ConvertAbilityIntegerLevelField('Pos1')
+    // 技能整数等级域 移动速度更新次数 ('Prg1')
 	constant abilityintegerlevelfield ABILITY_ILF_MOVEMENT_UPDATE_FREQUENCY_PRG1 = ConvertAbilityIntegerLevelField('Prg1')
+    // 技能整数等级域 攻击速度更新次数 ('Prg2')
 	constant abilityintegerlevelfield ABILITY_ILF_ATTACK_UPDATE_FREQUENCY_PRG2 = ConvertAbilityIntegerLevelField('Prg2')
+    // 技能整数等级域 魔法损耗 ('Prg6')
 	constant abilityintegerlevelfield ABILITY_ILF_MANA_LOSS_PRG6 = ConvertAbilityIntegerLevelField('Prg6')
+    // 技能整数等级域 单位召唤数量1 ('Rai1')
 	constant abilityintegerlevelfield ABILITY_ILF_UNITS_SUMMONED_TYPE_ONE = ConvertAbilityIntegerLevelField('Rai1')
+    // 技能整数等级域 单位召唤数量1 ('Rai2')
 	constant abilityintegerlevelfield ABILITY_ILF_UNITS_SUMMONED_TYPE_TWO = ConvertAbilityIntegerLevelField('Rai2')
+    // 技能整数等级域 最大召唤数量 ('Ucb5')
 	constant abilityintegerlevelfield ABILITY_ILF_MAX_UNITS_SUMMONED = ConvertAbilityIntegerLevelField('Ucb5')
+    // 技能整数等级域 选项完整时可用 ('Rej3')
 	constant abilityintegerlevelfield ABILITY_ILF_ALLOW_WHEN_FULL_REJ3 = ConvertAbilityIntegerLevelField('Rej3')
+    // 技能整数等级域 最多消耗魔法倍数 ('Rpb5')
 	constant abilityintegerlevelfield ABILITY_ILF_MAXIMUM_UNITS_CHARGED_TO_CASTER = ConvertAbilityIntegerLevelField('Rpb5')
+    // 技能整数等级域 最多可影响到的单位数量('Rpb6')
 	constant abilityintegerlevelfield ABILITY_ILF_MAXIMUM_UNITS_AFFECTED = ConvertAbilityIntegerLevelField('Rpb6')
+    // 技能整数等级域 防御增加 ('Roa2')
 	constant abilityintegerlevelfield ABILITY_ILF_DEFENSE_INCREASE_ROA2 = ConvertAbilityIntegerLevelField('Roa2')
+    // 技能整数等级域 最大单位数量 ('Roa7')
 	constant abilityintegerlevelfield ABILITY_ILF_MAX_UNITS_ROA7 = ConvertAbilityIntegerLevelField('Roa7')
+    // 技能整数等级域 扎根攻击模式 ('Roo1')
 	constant abilityintegerlevelfield ABILITY_ILF_ROOTED_WEAPONS = ConvertAbilityIntegerLevelField('Roo1')
+    // 技能整数等级域 拔起攻击模式 ('Roo2')
 	constant abilityintegerlevelfield ABILITY_ILF_UPROOTED_WEAPONS = ConvertAbilityIntegerLevelField('Roo2')
+    // 技能整数等级域 拔起防御模式 ('Roo4')
 	constant abilityintegerlevelfield ABILITY_ILF_UPROOTED_DEFENSE_TYPE = ConvertAbilityIntegerLevelField('Roo4')
+    // 技能整数等级域 积聚等级 ('Sal2')
 	constant abilityintegerlevelfield ABILITY_ILF_ACCUMULATION_STEP = ConvertAbilityIntegerLevelField('Sal2')
+    // 技能整数等级域 猫头鹰数量 ('Esn4')
 	constant abilityintegerlevelfield ABILITY_ILF_NUMBER_OF_OWLS = ConvertAbilityIntegerLevelField('Esn4')
+    // 技能整数等级域 叠加类型 ('Spo4')
 	constant abilityintegerlevelfield ABILITY_ILF_STACKING_TYPE_SPO4 = ConvertAbilityIntegerLevelField('Spo4')
+    // 技能整数等级域 单位数量 ('Sod1')
 	constant abilityintegerlevelfield ABILITY_ILF_NUMBER_OF_UNITS = ConvertAbilityIntegerLevelField('Sod1')
+    // 技能整数等级域 蜘蛛数量 ('Spa1')
 	constant abilityintegerlevelfield ABILITY_ILF_SPIDER_CAPACITY = ConvertAbilityIntegerLevelField('Spa1')
+    // 技能整数等级域 间隔时间 ('Wha2')
 	constant abilityintegerlevelfield ABILITY_ILF_INTERVALS_BEFORE_CHANGING_TREES = ConvertAbilityIntegerLevelField('Wha2')
+    // 技能整数等级域 敏捷奖励 ('Iagi')
 	constant abilityintegerlevelfield ABILITY_ILF_AGILITY_BONUS = ConvertAbilityIntegerLevelField('Iagi')
+    // 技能整数等级域 智力奖励 ('Iint')
 	constant abilityintegerlevelfield ABILITY_ILF_INTELLIGENCE_BONUS = ConvertAbilityIntegerLevelField('Iint')
+    // 技能整数等级域 力量奖励 ('Istr')
 	constant abilityintegerlevelfield ABILITY_ILF_STRENGTH_BONUS_ISTR = ConvertAbilityIntegerLevelField('Istr')
+    // 技能整数等级域 攻击奖励 ('Iatt')
 	constant abilityintegerlevelfield ABILITY_ILF_ATTACK_BONUS = ConvertAbilityIntegerLevelField('Iatt')
+    // 技能整数等级域 防御奖励 ('Idef')
 	constant abilityintegerlevelfield ABILITY_ILF_DEFENSE_BONUS_IDEF = ConvertAbilityIntegerLevelField('Idef')
+    // 技能整数等级域 召唤单位数量1 ('Isn1')
 	constant abilityintegerlevelfield ABILITY_ILF_SUMMON_1_AMOUNT = ConvertAbilityIntegerLevelField('Isn1')
+    // 技能整数等级域 召唤单位数量2 ('Isn2')
 	constant abilityintegerlevelfield ABILITY_ILF_SUMMON_2_AMOUNT = ConvertAbilityIntegerLevelField('Isn2')
+    // 技能整数等级域 取得经验值 ('Ixpg')
 	constant abilityintegerlevelfield ABILITY_ILF_EXPERIENCE_GAINED = ConvertAbilityIntegerLevelField('Ixpg')
+    // 技能整数等级域 生命值恢复 ('Ihpg')
 	constant abilityintegerlevelfield ABILITY_ILF_HIT_POINTS_GAINED_IHPG = ConvertAbilityIntegerLevelField('Ihpg')
+    // 技能整数等级域 魔法值恢复 ('Impg')
 	constant abilityintegerlevelfield ABILITY_ILF_MANA_POINTS_GAINED_IMPG = ConvertAbilityIntegerLevelField('Impg')
+    // 技能整数等级域 治疗生命值 ('Ihp2')
 	constant abilityintegerlevelfield ABILITY_ILF_HIT_POINTS_GAINED_IHP2 = ConvertAbilityIntegerLevelField('Ihp2')
+    // 技能整数等级域 魔法值获取 ('Imp2')
 	constant abilityintegerlevelfield ABILITY_ILF_MANA_POINTS_GAINED_IMP2 = ConvertAbilityIntegerLevelField('Imp2')
+    // 技能整数等级域 攻击奖励 ('Idic')
 	constant abilityintegerlevelfield ABILITY_ILF_DAMAGE_BONUS_DICE = ConvertAbilityIntegerLevelField('Idic')
+    // 技能整数等级域 目标防御降低 ('Iarp')
 	constant abilityintegerlevelfield ABILITY_ILF_ARMOR_PENALTY_IARP = ConvertAbilityIntegerLevelField('Iarp')
+    // 技能整数等级域 允许攻击引索 ('Iob5')
 	constant abilityintegerlevelfield ABILITY_ILF_ENABLED_ATTACK_INDEX_IOB5 = ConvertAbilityIntegerLevelField('Iob5')
+    // 技能整数等级域 等级提升 ('Ilev')
 	constant abilityintegerlevelfield ABILITY_ILF_LEVELS_GAINED = ConvertAbilityIntegerLevelField('Ilev')
+    // 技能整数等级域 增加最大生命值 ('Ilif')
 	constant abilityintegerlevelfield ABILITY_ILF_MAX_LIFE_GAINED = ConvertAbilityIntegerLevelField('Ilif')
+    // 技能整数等级域 增加最大魔法值 ('Iman')
 	constant abilityintegerlevelfield ABILITY_ILF_MAX_MANA_GAINED = ConvertAbilityIntegerLevelField('Iman')
+    // 技能整数等级域 获得金钱 ('Igol')
 	constant abilityintegerlevelfield ABILITY_ILF_GOLD_GIVEN = ConvertAbilityIntegerLevelField('Igol')
+    // 技能整数等级域 获得木材 ('Ilum')
 	constant abilityintegerlevelfield ABILITY_ILF_LUMBER_GIVEN = ConvertAbilityIntegerLevelField('Ilum')
+    // 技能整数等级域 侦察类型 ('Ifa1')
 	constant abilityintegerlevelfield ABILITY_ILF_DETECTION_TYPE_IFA1 = ConvertAbilityIntegerLevelField('Ifa1')
+    // 技能整数等级域 最大目标中立生物等级 ('Icre')
 	constant abilityintegerlevelfield ABILITY_ILF_MAXIMUM_CREEP_LEVEL_ICRE = ConvertAbilityIntegerLevelField('Icre')
+    // 技能整数等级域 移动速度奖励 ('Imvb')
 	constant abilityintegerlevelfield ABILITY_ILF_MOVEMENT_SPEED_BONUS = ConvertAbilityIntegerLevelField('Imvb')
+    // 技能整数等级域 每秒生命恢复 ('Ihpr')
 	constant abilityintegerlevelfield ABILITY_ILF_HIT_POINTS_REGENERATED_PER_SECOND = ConvertAbilityIntegerLevelField('Ihpr')
+    // 技能整数等级域 视野范围奖励 ('Isib')
 	constant abilityintegerlevelfield ABILITY_ILF_SIGHT_RANGE_BONUS = ConvertAbilityIntegerLevelField('Isib')
+    // 技能整数等级域 伤害/间隔 ('Icfd')
 	constant abilityintegerlevelfield ABILITY_ILF_DAMAGE_PER_DURATION = ConvertAbilityIntegerLevelField('Icfd')
+    // 技能整数等级域 每秒消耗魔法值 ('Icfm')
 	constant abilityintegerlevelfield ABILITY_ILF_MANA_USED_PER_SECOND = ConvertAbilityIntegerLevelField('Icfm')
+    // 技能整数等级域 额外魔法需求 ('Icfx')
 	constant abilityintegerlevelfield ABILITY_ILF_EXTRA_MANA_REQUIRED = ConvertAbilityIntegerLevelField('Icfx')
+    // 技能整数等级域 侦察范围 ('Idet')
 	constant abilityintegerlevelfield ABILITY_ILF_DETECTION_RADIUS_IDET = ConvertAbilityIntegerLevelField('Idet')
+    // 技能整数等级域 每个单位魔法损耗 ('Idim')
 	constant abilityintegerlevelfield ABILITY_ILF_MANA_LOSS_PER_UNIT_IDIM = ConvertAbilityIntegerLevelField('Idim')
+    // 技能整数等级域 对召唤单位伤害 ('Idid')
 	constant abilityintegerlevelfield ABILITY_ILF_DAMAGE_TO_SUMMONED_UNITS_IDID = ConvertAbilityIntegerLevelField('Idid')
+    // 技能整数等级域 最大单位数 ('Irec')
 	constant abilityintegerlevelfield ABILITY_ILF_MAXIMUM_NUMBER_OF_UNITS_IREC = ConvertAbilityIntegerLevelField('Irec')
+    // 技能整数等级域 重生延迟 ('Ircd')
 	constant abilityintegerlevelfield ABILITY_ILF_DELAY_AFTER_DEATH_SECONDS = ConvertAbilityIntegerLevelField('Ircd')
+    // 技能整数等级域 生命值回复 ('irc2')
 	constant abilityintegerlevelfield ABILITY_ILF_RESTORED_LIFE = ConvertAbilityIntegerLevelField('irc2')
+    // 技能整数等级域 魔法值回复 ('irc3')
 	constant abilityintegerlevelfield ABILITY_ILF_RESTORED_MANA__1_FOR_CURRENT = ConvertAbilityIntegerLevelField('irc3')
+    // 技能整数等级域 生命值回复 ('Ihps')
 	constant abilityintegerlevelfield ABILITY_ILF_HIT_POINTS_RESTORED = ConvertAbilityIntegerLevelField('Ihps')
+    // 技能整数等级域 魔法值回复 ('Imps')
 	constant abilityintegerlevelfield ABILITY_ILF_MANA_POINTS_RESTORED = ConvertAbilityIntegerLevelField('Imps')
+    // 技能整数等级域 最大单位数 ('Itpm')
 	constant abilityintegerlevelfield ABILITY_ILF_MAXIMUM_NUMBER_OF_UNITS_ITPM = ConvertAbilityIntegerLevelField('Itpm')
+    // 技能整数等级域 复活死尸数量 ('Cad1')
 	constant abilityintegerlevelfield ABILITY_ILF_NUMBER_OF_CORPSES_RAISED_CAD1 = ConvertAbilityIntegerLevelField('Cad1')
+    // 技能整数等级域 地形变形持续时间（毫秒） ('Wrs3')
 	constant abilityintegerlevelfield ABILITY_ILF_TERRAIN_DEFORMATION_DURATION_MS = ConvertAbilityIntegerLevelField('Wrs3')
+    // 技能整数等级域 传送单位数量 ('Uds1')
 	constant abilityintegerlevelfield ABILITY_ILF_MAXIMUM_UNITS = ConvertAbilityIntegerLevelField('Uds1')
+    // 技能整数等级域 侦察类型 ('Det1')
 	constant abilityintegerlevelfield ABILITY_ILF_DETECTION_TYPE_DET1 = ConvertAbilityIntegerLevelField('Det1')
+    // 技能整数等级域 每次建造的金钱消耗 ('Nsp1')
 	constant abilityintegerlevelfield ABILITY_ILF_GOLD_COST_PER_STRUCTURE = ConvertAbilityIntegerLevelField('Nsp1')
+    // 技能整数等级域 每次使用的木材消耗 ('Nsp2')
 	constant abilityintegerlevelfield ABILITY_ILF_LUMBER_COST_PER_USE = ConvertAbilityIntegerLevelField('Nsp2')
+    // 技能整数等级域 侦察类型 ('Nsp3')
 	constant abilityintegerlevelfield ABILITY_ILF_DETECTION_TYPE_NSP3 = ConvertAbilityIntegerLevelField('Nsp3')
+    // 技能整数等级域 蝗虫群数量 ('Uls1')
 	constant abilityintegerlevelfield ABILITY_ILF_NUMBER_OF_SWARM_UNITS = ConvertAbilityIntegerLevelField('Uls1')
+    // 技能整数等级域 每个目标最大蝗虫数量 ('Uls3')
 	constant abilityintegerlevelfield ABILITY_ILF_MAX_SWARM_UNITS_PER_TARGET = ConvertAbilityIntegerLevelField('Uls3')
+    // 技能整数等级域 召唤单位数量 ('Nba2')
 	constant abilityintegerlevelfield ABILITY_ILF_NUMBER_OF_SUMMONED_UNITS_NBA2 = ConvertAbilityIntegerLevelField('Nba2')
+    // 技能整数等级域 最大目标中立生物等级 ('Nch1')
 	constant abilityintegerlevelfield ABILITY_ILF_MAXIMUM_CREEP_LEVEL_NCH1 = ConvertAbilityIntegerLevelField('Nch1')
+    // 技能整数等级域 禁止类型 ('Nsi1')
 	constant abilityintegerlevelfield ABILITY_ILF_ATTACKS_PREVENTED = ConvertAbilityIntegerLevelField('Nsi1')
+    // 技能整数等级域 最大目标数 ('Efk3')
 	constant abilityintegerlevelfield ABILITY_ILF_MAXIMUM_NUMBER_OF_TARGETS_EFK3 = ConvertAbilityIntegerLevelField('Efk3')
+    // 技能整数等级域 召唤单位数量 ('Esv1')
 	constant abilityintegerlevelfield ABILITY_ILF_NUMBER_OF_SUMMONED_UNITS_ESV1 = ConvertAbilityIntegerLevelField('Esv1')
+    // 技能整数等级域 最大尸体数量 ('exh1')
 	constant abilityintegerlevelfield ABILITY_ILF_MAXIMUM_NUMBER_OF_CORPSES_EXH1 = ConvertAbilityIntegerLevelField('exh1')
+    // 技能整数等级域 物品容量 ('inv1')
 	constant abilityintegerlevelfield ABILITY_ILF_ITEM_CAPACITY = ConvertAbilityIntegerLevelField('inv1')
+    // 技能整数等级域 最大目标数 ('spl2')
 	constant abilityintegerlevelfield ABILITY_ILF_MAXIMUM_NUMBER_OF_TARGETS_SPL2 = ConvertAbilityIntegerLevelField('spl2')
+    // 技能整数等级域 选项完整时可用 ('irl3')
 	constant abilityintegerlevelfield ABILITY_ILF_ALLOW_WHEN_FULL_IRL3 = ConvertAbilityIntegerLevelField('irl3')
+    // 技能整数等级域 最大驱散单位数量 ('idc3')
 	constant abilityintegerlevelfield ABILITY_ILF_MAXIMUM_DISPELLED_UNITS = ConvertAbilityIntegerLevelField('idc3')
+    // 技能整数等级域 陷阱数量 ('imo1')
 	constant abilityintegerlevelfield ABILITY_ILF_NUMBER_OF_LURES = ConvertAbilityIntegerLevelField('imo1')
+    // 技能整数等级域 设置游戏时间 - 时 ('ict1')
 	constant abilityintegerlevelfield ABILITY_ILF_NEW_TIME_OF_DAY_HOUR = ConvertAbilityIntegerLevelField('ict1')
+    // 技能整数等级域 设置游戏时间 - 分 ('ict2')
 	constant abilityintegerlevelfield ABILITY_ILF_NEW_TIME_OF_DAY_MINUTE = ConvertAbilityIntegerLevelField('ict2')
+    // 技能整数等级域 创建单位数量 ('mec1')
 	constant abilityintegerlevelfield ABILITY_ILF_NUMBER_OF_UNITS_CREATED_MEC1 = ConvertAbilityIntegerLevelField('mec1')
+    // 技能整数等级域 最小法术数量 ('spb3')
 	constant abilityintegerlevelfield ABILITY_ILF_MINIMUM_SPELLS = ConvertAbilityIntegerLevelField('spb3')
+    // 技能整数等级域 最大法术数量 ('spb4')
 	constant abilityintegerlevelfield ABILITY_ILF_MAXIMUM_SPELLS = ConvertAbilityIntegerLevelField('spb4')
+    // 技能整数等级域 禁止攻击引索 ('gra3')
 	constant abilityintegerlevelfield ABILITY_ILF_DISABLED_ATTACK_INDEX = ConvertAbilityIntegerLevelField('gra3')
+    // 技能整数等级域 允许攻击引索 ('gra4')
 	constant abilityintegerlevelfield ABILITY_ILF_ENABLED_ATTACK_INDEX_GRA4 = ConvertAbilityIntegerLevelField('gra4')
+    // 技能整数等级域 最大攻击次数 ('gra5')
 	constant abilityintegerlevelfield ABILITY_ILF_MAXIMUM_ATTACKS = ConvertAbilityIntegerLevelField('gra5')
+    // 技能整数等级域 建筑类型允许 ('Npr1')
 	constant abilityintegerlevelfield ABILITY_ILF_BUILDING_TYPES_ALLOWED_NPR1 = ConvertAbilityIntegerLevelField('Npr1')
+    // 技能整数等级域 建筑类型允许 ('Nsa1')
 	constant abilityintegerlevelfield ABILITY_ILF_BUILDING_TYPES_ALLOWED_NSA1 = ConvertAbilityIntegerLevelField('Nsa1')
+    // 技能整数等级域 攻击增加 ('Iaa1')
 	constant abilityintegerlevelfield ABILITY_ILF_ATTACK_MODIFICATION = ConvertAbilityIntegerLevelField('Iaa1')
+    // 技能整数等级域 召唤单位数量 ('Npa5')
 	constant abilityintegerlevelfield ABILITY_ILF_SUMMONED_UNIT_COUNT_NPA5 = ConvertAbilityIntegerLevelField('Npa5')
+    // 技能整数等级域 科技升级等级 ('Igl1')
 	constant abilityintegerlevelfield ABILITY_ILF_UPGRADE_LEVELS = ConvertAbilityIntegerLevelField('Igl1')
+    // 技能整数等级域 召唤单位数量 ('Ndo2')
 	constant abilityintegerlevelfield ABILITY_ILF_NUMBER_OF_SUMMONED_UNITS_NDO2 = ConvertAbilityIntegerLevelField('Ndo2')
+    // 技能整数等级域 每秒野怪数量 ('Nst1')
 	constant abilityintegerlevelfield ABILITY_ILF_BEASTS_PER_SECOND = ConvertAbilityIntegerLevelField('Nst1')
+    // 技能整数等级域 目标类型 ('Ncl2')
 	constant abilityintegerlevelfield ABILITY_ILF_TARGET_TYPE = ConvertAbilityIntegerLevelField('Ncl2')
+    // 技能整数等级域 选项 ('Ncl3')
 	constant abilityintegerlevelfield ABILITY_ILF_OPTIONS = ConvertAbilityIntegerLevelField('Ncl3')
+    // 技能整数等级域 护甲减少 ('Nab3')
 	constant abilityintegerlevelfield ABILITY_ILF_ARMOR_PENALTY_NAB3 = ConvertAbilityIntegerLevelField('Nab3')
+    // 技能整数等级域 医疗波次 ('Nhs6')
 	constant abilityintegerlevelfield ABILITY_ILF_WAVE_COUNT_NHS6 = ConvertAbilityIntegerLevelField('Nhs6')
+    // 技能整数等级域 最大目标中立生物等级 ('Ntm3')
 	constant abilityintegerlevelfield ABILITY_ILF_MAX_CREEP_LEVEL_NTM3 = ConvertAbilityIntegerLevelField('Ntm3')
+    // 技能整数等级域 导弹数量 ('Ncs3')
 	constant abilityintegerlevelfield ABILITY_ILF_MISSILE_COUNT = ConvertAbilityIntegerLevelField('Ncs3')
+    // 技能整数等级域 分裂所需攻击次数 ('Nlm3')
 	constant abilityintegerlevelfield ABILITY_ILF_SPLIT_ATTACK_COUNT = ConvertAbilityIntegerLevelField('Nlm3')
+    // 技能整数等级域 分裂代数 ('Nlm6')
 	constant abilityintegerlevelfield ABILITY_ILF_GENERATION_COUNT = ConvertAbilityIntegerLevelField('Nlm6')
+    // 技能整数等级域 岩石数 ('Nvc1')
 	constant abilityintegerlevelfield ABILITY_ILF_ROCK_RING_COUNT = ConvertAbilityIntegerLevelField('Nvc1')
+    // 技能整数等级域 波数 ('Nvc2')
 	constant abilityintegerlevelfield ABILITY_ILF_WAVE_COUNT_NVC2 = ConvertAbilityIntegerLevelField('Nvc2')
+    // 技能整数等级域 影响敌方数量 ('Tau1')
 	constant abilityintegerlevelfield ABILITY_ILF_PREFER_HOSTILES_TAU1 = ConvertAbilityIntegerLevelField('Tau1')
+    // 技能整数等级域 影响友军数量 ('Tau2')
 	constant abilityintegerlevelfield ABILITY_ILF_PREFER_FRIENDLIES_TAU2 = ConvertAbilityIntegerLevelField('Tau2')
+    // 技能整数等级域 最大单位数量 ('Tau3')
 	constant abilityintegerlevelfield ABILITY_ILF_MAX_UNITS_TAU3 = ConvertAbilityIntegerLevelField('Tau3')
+    // 技能整数等级域 增加数量 ('Tau4')
 	constant abilityintegerlevelfield ABILITY_ILF_NUMBER_OF_PULSES = ConvertAbilityIntegerLevelField('Tau4')
+    // 技能整数等级域 召唤单位类型 ('Hwe1')
 	constant abilityintegerlevelfield ABILITY_ILF_SUMMONED_UNIT_TYPE_HWE1 = ConvertAbilityIntegerLevelField('Hwe1')
+    // 技能整数等级域 召唤单位类型 ('Uin4')
 	constant abilityintegerlevelfield ABILITY_ILF_SUMMONED_UNIT_UIN4 = ConvertAbilityIntegerLevelField('Uin4')
+    // 技能整数等级域 召唤单位类型 ('Osf1')
 	constant abilityintegerlevelfield ABILITY_ILF_SUMMONED_UNIT_OSF1 = ConvertAbilityIntegerLevelField('Osf1')
+    // 技能整数等级域 召唤单位类型 ('Efnu')
 	constant abilityintegerlevelfield ABILITY_ILF_SUMMONED_UNIT_TYPE_EFNU = ConvertAbilityIntegerLevelField('Efnu')
+    // 技能整数等级域 召唤单位类型 ('Nbau')
 	constant abilityintegerlevelfield ABILITY_ILF_SUMMONED_UNIT_TYPE_NBAU = ConvertAbilityIntegerLevelField('Nbau')
+    // 技能整数等级域 召唤单位类型 ('Ntou')
 	constant abilityintegerlevelfield ABILITY_ILF_SUMMONED_UNIT_TYPE_NTOU = ConvertAbilityIntegerLevelField('Ntou')
+    // 技能整数等级域 召唤单位类型 ('Esvu')
 	constant abilityintegerlevelfield ABILITY_ILF_SUMMONED_UNIT_TYPE_ESVU = ConvertAbilityIntegerLevelField('Esvu')
+    // 技能整数等级域 召唤单位类型 ('Nef1')
 	constant abilityintegerlevelfield ABILITY_ILF_SUMMONED_UNIT_TYPES = ConvertAbilityIntegerLevelField('Nef1')
+    // 技能整数等级域 召唤单位类型 ('Ndou')
 	constant abilityintegerlevelfield ABILITY_ILF_SUMMONED_UNIT_TYPE_NDOU = ConvertAbilityIntegerLevelField('Ndou')
+    // 技能整数等级域 变化形态单位 ('Emeu')
 	constant abilityintegerlevelfield ABILITY_ILF_ALTERNATE_FORM_UNIT_EMEU = ConvertAbilityIntegerLevelField('Emeu')
+    // 技能整数等级域 瘟疫守卫单位类型 ('Aplu')
 	constant abilityintegerlevelfield ABILITY_ILF_PLAGUE_WARD_UNIT_TYPE = ConvertAbilityIntegerLevelField('Aplu')
+    // 技能整数等级域 允许单位类型 ('Btl1')
 	constant abilityintegerlevelfield ABILITY_ILF_ALLOWED_UNIT_TYPE_BTL1 = ConvertAbilityIntegerLevelField('Btl1')
+    // 技能整数等级域 替换单位类型 ('Cha1')
 	constant abilityintegerlevelfield ABILITY_ILF_NEW_UNIT_TYPE = ConvertAbilityIntegerLevelField('Cha1')
+    // 技能整数等级域 新单位类型 ('ent1')
 	constant abilityintegerlevelfield ABILITY_ILF_RESULTING_UNIT_TYPE_ENT1 = ConvertAbilityIntegerLevelField('ent1')
+    // 技能整数等级域 尸体单位类型 ('Gydu')
 	constant abilityintegerlevelfield ABILITY_ILF_CORPSE_UNIT_TYPE = ConvertAbilityIntegerLevelField('Gydu')
+    // 技能整数等级域 允许单位类型 ('Loa1')
 	constant abilityintegerlevelfield ABILITY_ILF_ALLOWED_UNIT_TYPE_LOA1 = ConvertAbilityIntegerLevelField('Loa1')
+    // 技能整数等级域 单位类型限制检查 ('Raiu')
 	constant abilityintegerlevelfield ABILITY_ILF_UNIT_TYPE_FOR_LIMIT_CHECK = ConvertAbilityIntegerLevelField('Raiu')
+    // 技能整数等级域 守卫单位类型 ('Stau')
 	constant abilityintegerlevelfield ABILITY_ILF_WARD_UNIT_TYPE_STAU = ConvertAbilityIntegerLevelField('Stau')
+    // 技能整数等级域 效果技能 ('Iobu')
 	constant abilityintegerlevelfield ABILITY_ILF_EFFECT_ABILITY = ConvertAbilityIntegerLevelField('Iobu')
+    // 技能整数等级域 变化单位类型 ('Ndc2')
 	constant abilityintegerlevelfield ABILITY_ILF_CONVERSION_UNIT = ConvertAbilityIntegerLevelField('Ndc2')
+    // 技能整数等级域 可被保存单位 ('Nsl1')
 	constant abilityintegerlevelfield ABILITY_ILF_UNIT_TO_PRESERVE = ConvertAbilityIntegerLevelField('Nsl1')
+    // 技能整数等级域 允许单位类型 ('Chl1')
 	constant abilityintegerlevelfield ABILITY_ILF_UNIT_TYPE_ALLOWED = ConvertAbilityIntegerLevelField('Chl1')
+    // 技能整数等级域 蝗虫单位类型 ('Ulsu')
 	constant abilityintegerlevelfield ABILITY_ILF_SWARM_UNIT_TYPE = ConvertAbilityIntegerLevelField('Ulsu')
+    // 技能整数等级域 合成单位类型 ('coau')
 	constant abilityintegerlevelfield ABILITY_ILF_RESULTING_UNIT_TYPE_COAU = ConvertAbilityIntegerLevelField('coau')
+    // 技能整数等级域 尸体单位类型 ('exhu')
 	constant abilityintegerlevelfield ABILITY_ILF_UNIT_TYPE_EXHU = ConvertAbilityIntegerLevelField('exhu')
+    // 技能整数等级域 守卫单位类型 ('hwdu')
 	constant abilityintegerlevelfield ABILITY_ILF_WARD_UNIT_TYPE_HWDU = ConvertAbilityIntegerLevelField('hwdu')
+    // 技能整数等级域 陷阱单位类型 ('imou')
 	constant abilityintegerlevelfield ABILITY_ILF_LURE_UNIT_TYPE = ConvertAbilityIntegerLevelField('imou')
+    // 技能整数等级域 单位类型 ('ipmu')
 	constant abilityintegerlevelfield ABILITY_ILF_UNIT_TYPE_IPMU = ConvertAbilityIntegerLevelField('ipmu')
+    // 技能整数等级域 工厂单位ID ('Nsyu')
 	constant abilityintegerlevelfield ABILITY_ILF_FACTORY_UNIT_ID = ConvertAbilityIntegerLevelField('Nsyu')
+    // 技能整数等级域 生产单位ID ('Nfyu')
 	constant abilityintegerlevelfield ABILITY_ILF_SPAWN_UNIT_ID_NFYU = ConvertAbilityIntegerLevelField('Nfyu')
+    // 技能整数等级域 可破坏物ID ('Nvcu')
 	constant abilityintegerlevelfield ABILITY_ILF_DESTRUCTIBLE_ID = ConvertAbilityIntegerLevelField('Nvcu')
+    // 技能整数等级域 科技类型 ('Iglu')
 	constant abilityintegerlevelfield ABILITY_ILF_UPGRADE_TYPE = ConvertAbilityIntegerLevelField('Iglu')
 	
+    // 技能实数等级域 魔法释放时间 ('acas')
 	constant abilityreallevelfield ABILITY_RLF_CASTING_TIME = ConvertAbilityRealLevelField('acas')
+    // 技能实数等级域 持续时间 - 普通 ('adur')
 	constant abilityreallevelfield ABILITY_RLF_DURATION_NORMAL = ConvertAbilityRealLevelField('adur')
+    // 技能实数等级域 持续时间 - 英雄 ('ahdu')
 	constant abilityreallevelfield ABILITY_RLF_DURATION_HERO = ConvertAbilityRealLevelField('ahdu')
+    // 技能实数等级域 魔法释放时间间隔 ('acdn')
 	constant abilityreallevelfield ABILITY_RLF_COOLDOWN = ConvertAbilityRealLevelField('acdn')
+    // 技能实数等级域 影响区域 ('aare')
 	constant abilityreallevelfield ABILITY_RLF_AREA_OF_EFFECT = ConvertAbilityRealLevelField('aare')
+    // 技能实数等级域 施法距离 ('aran')
 	constant abilityreallevelfield ABILITY_RLF_CAST_RANGE = ConvertAbilityRealLevelField('aran')
+    // 技能实数等级域 每波伤害 ('Hbz2')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_HBZ2 = ConvertAbilityRealLevelField('Hbz2')
+    // 技能实数等级域 建筑伤害参数（%） ('Hbz4')
 	constant abilityreallevelfield ABILITY_RLF_BUILDING_REDUCTION_HBZ4 = ConvertAbilityRealLevelField('Hbz4')
+    // 技能实数等级域 每秒伤害 ('Hbz5')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_PER_SECOND_HBZ5 = ConvertAbilityRealLevelField('Hbz5')
+    // 技能实数等级域 每波最大伤害 ('Hbz6')
 	constant abilityreallevelfield ABILITY_RLF_MAXIMUM_DAMAGE_PER_WAVE = ConvertAbilityRealLevelField('Hbz6')
+    // 技能实数等级域 魔法回复加快 ('Hab1')
 	constant abilityreallevelfield ABILITY_RLF_MANA_REGENERATION_INCREASE = ConvertAbilityRealLevelField('Hab1')
+    // 技能实数等级域 魔法施放延迟 ('Hmt2')
 	constant abilityreallevelfield ABILITY_RLF_CASTING_DELAY = ConvertAbilityRealLevelField('Hmt2')
+    // 技能实数等级域 每秒伤害 ('Oww1')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_PER_SECOND_OWW1 = ConvertAbilityRealLevelField('Oww1')
+    // 技能实数等级域 魔法伤害减少 ('Oww2')
 	constant abilityreallevelfield ABILITY_RLF_MAGIC_DAMAGE_REDUCTION_OWW2 = ConvertAbilityRealLevelField('Oww2')
+    // 技能实数等级域 致命一击几率 ('Ocr1')
 	constant abilityreallevelfield ABILITY_RLF_CHANCE_TO_CRITICAL_STRIKE = ConvertAbilityRealLevelField('Ocr1')
+    // 技能实数等级域 伤害倍数 ('Ocr2')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_MULTIPLIER_OCR2 = ConvertAbilityRealLevelField('Ocr2')
+    // 技能实数等级域 伤害奖励 ('Ocr3')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_BONUS_OCR3 = ConvertAbilityRealLevelField('Ocr3')
+    // 技能实数等级域 闪避几率 ('Ocr4')
 	constant abilityreallevelfield ABILITY_RLF_CHANCE_TO_EVADE_OCR4 = ConvertAbilityRealLevelField('Ocr4')
+    // 技能实数等级域 施加伤害（%） ('Omi2')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_DEALT_PERCENT_OMI2 = ConvertAbilityRealLevelField('Omi2')
+    // 技能实数等级域 所受伤害（%） ('Omi3')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_TAKEN_PERCENT_OMI3 = ConvertAbilityRealLevelField('Omi3')
+    // 技能实数等级域 技能延迟 ('Omi4')
 	constant abilityreallevelfield ABILITY_RLF_ANIMATION_DELAY = ConvertAbilityRealLevelField('Omi4')
+    // 技能实数等级域 转变时间 ('Owk1')
 	constant abilityreallevelfield ABILITY_RLF_TRANSITION_TIME = ConvertAbilityRealLevelField('Owk1')
+    // 技能实数等级域 移动速度增加（%） ('Owk2')
 	constant abilityreallevelfield ABILITY_RLF_MOVEMENT_SPEED_INCREASE_PERCENT_OWK2 = ConvertAbilityRealLevelField('Owk2')
+    // 技能实数等级域 加成伤害 ('Owk3')
 	constant abilityreallevelfield ABILITY_RLF_BACKSTAB_DAMAGE = ConvertAbilityRealLevelField('Owk3')
+    // 技能实数等级域 治疗数值 ('Udc1')
 	constant abilityreallevelfield ABILITY_RLF_AMOUNT_HEALED_DAMAGED_UDC1 = ConvertAbilityRealLevelField('Udc1')
+    // 技能实数等级域 每点生命转换为魔法 ('Udp1')
 	constant abilityreallevelfield ABILITY_RLF_LIFE_CONVERTED_TO_MANA = ConvertAbilityRealLevelField('Udp1')
+    // 技能实数等级域 每点生命转换为生命 ('Udp2')
 	constant abilityreallevelfield ABILITY_RLF_LIFE_CONVERTED_TO_LIFE = ConvertAbilityRealLevelField('Udp2')
+    // 技能实数等级域 移动速率增加（%） ('Uau1')
 	constant abilityreallevelfield ABILITY_RLF_MOVEMENT_SPEED_INCREASE_PERCENT_UAU1 = ConvertAbilityRealLevelField('Uau1')
+    // 技能实数等级域 生命回复增加 ('Uau2')
 	constant abilityreallevelfield ABILITY_RLF_LIFE_REGENERATION_INCREASE_PERCENT = ConvertAbilityRealLevelField('Uau2')
+    // 技能实数等级域 闪避几率 ('Eev1')
 	constant abilityreallevelfield ABILITY_RLF_CHANCE_TO_EVADE_EEV1 = ConvertAbilityRealLevelField('Eev1')
+    // 技能实数等级域 伤害/间隔时间 ('Eim1')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_PER_INTERVAL = ConvertAbilityRealLevelField('Eim1')
+    // 技能实数等级域 每秒魔法消耗 ('Eim2')
 	constant abilityreallevelfield ABILITY_RLF_MANA_DRAINED_PER_SECOND_EIM2 = ConvertAbilityRealLevelField('Eim2')
+    // 技能实数等级域 启动魔法需求 ('Eim3')
 	constant abilityreallevelfield ABILITY_RLF_BUFFER_MANA_REQUIRED = ConvertAbilityRealLevelField('Eim3')
+    // 技能实数等级域 魔法燃烧值 ('Emb1')
 	constant abilityreallevelfield ABILITY_RLF_MAX_MANA_DRAINED = ConvertAbilityRealLevelField('Emb1')
+    // 技能实数等级域 数字显示延迟 ('Emb2')
 	constant abilityreallevelfield ABILITY_RLF_BOLT_DELAY = ConvertAbilityRealLevelField('Emb2')
+    // 技能实数等级域 数字显示持续时间 ('Emb3')
 	constant abilityreallevelfield ABILITY_RLF_BOLT_LIFETIME = ConvertAbilityRealLevelField('Emb3')
+    // 技能实数等级域 高度调整时间 ('Eme3')
 	constant abilityreallevelfield ABILITY_RLF_ALTITUDE_ADJUSTMENT_DURATION = ConvertAbilityRealLevelField('Eme3')
+    // 技能实数等级域 着陆延迟时间 ('Eme4')
 	constant abilityreallevelfield ABILITY_RLF_LANDING_DELAY_TIME = ConvertAbilityRealLevelField('Eme4')
+    // 技能实数等级域 变形生命值奖励 ('Eme5')
 	constant abilityreallevelfield ABILITY_RLF_ALTERNATE_FORM_HIT_POINT_BONUS = ConvertAbilityRealLevelField('Eme5')
+    // 技能实数等级域 移动速度奖励（仅限信息面板） ('Ncr5')
 	constant abilityreallevelfield ABILITY_RLF_MOVE_SPEED_BONUS_INFO_PANEL_ONLY = ConvertAbilityRealLevelField('Ncr5')
+    // 技能实数等级域 攻击速度奖励（仅限信息面板） ('Ncr6')
 	constant abilityreallevelfield ABILITY_RLF_ATTACK_SPEED_BONUS_INFO_PANEL_ONLY = ConvertAbilityRealLevelField('Ncr6')
+    // 技能实数等级域 每秒生命回复 ('ave5')
 	constant abilityreallevelfield ABILITY_RLF_LIFE_REGENERATION_RATE_PER_SECOND = ConvertAbilityRealLevelField('ave5')
+    // 技能实数等级域 无敌时间 ('Usl1')
 	constant abilityreallevelfield ABILITY_RLF_STUN_DURATION_USL1 = ConvertAbilityRealLevelField('Usl1')
+    // 技能实数等级域 近战伤害偷取（%） ('Uav1')
 	constant abilityreallevelfield ABILITY_RLF_ATTACK_DAMAGE_STOLEN_PERCENT = ConvertAbilityRealLevelField('Uav1')
+    // 技能实数等级域 伤害 ('Ucs1')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_UCS1 = ConvertAbilityRealLevelField('Ucs1')
+    // 技能实数等级域 最大伤害 ('Ucs2')
 	constant abilityreallevelfield ABILITY_RLF_MAX_DAMAGE_UCS2 = ConvertAbilityRealLevelField('Ucs2')
+    // 技能实数等级域 距离 ('Ucs3')
 	constant abilityreallevelfield ABILITY_RLF_DISTANCE_UCS3 = ConvertAbilityRealLevelField('Ucs3')
+    // 技能实数等级域 最终区域范围 ('Ucs4')
 	constant abilityreallevelfield ABILITY_RLF_FINAL_AREA_UCS4 = ConvertAbilityRealLevelField('Ucs4')
+    // 技能实数等级域 伤害 ('Uin1')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_UIN1 = ConvertAbilityRealLevelField('Uin1')
+    // 技能实数等级域 单位持续时间 ('Uin2')
 	constant abilityreallevelfield ABILITY_RLF_DURATION = ConvertAbilityRealLevelField('Uin2')
+    // 技能实数等级域 碰撞延迟 ('Uin3')
 	constant abilityreallevelfield ABILITY_RLF_IMPACT_DELAY = ConvertAbilityRealLevelField('Uin3')
+    // 技能实数等级域 伤害 ('Ocl1')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_PER_TARGET_OCL1 = ConvertAbilityRealLevelField('Ocl1')
+    // 技能实数等级域 单位持续时间 ('Ocl3')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_REDUCTION_PER_TARGET = ConvertAbilityRealLevelField('Ocl3')
+    // 技能实数等级域 效果延迟 ('Oeq1')
 	constant abilityreallevelfield ABILITY_RLF_EFFECT_DELAY_OEQ1 = ConvertAbilityRealLevelField('Oeq1')
+    // 技能实数等级域 每秒对建筑伤害 ('Oeq2')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_PER_SECOND_TO_BUILDINGS = ConvertAbilityRealLevelField('Oeq2')
+    // 技能实数等级域 单位减速（%） ('Oeq3')
 	constant abilityreallevelfield ABILITY_RLF_UNITS_SLOWED_PERCENT = ConvertAbilityRealLevelField('Oeq3')
+    // 技能实数等级域 最终区域范围 ('Oeq4')
 	constant abilityreallevelfield ABILITY_RLF_FINAL_AREA_OEQ4 = ConvertAbilityRealLevelField('Oeq4')
+    // 技能实数等级域 每秒伤害 ('Eer1')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_PER_SECOND_EER1 = ConvertAbilityRealLevelField('Eer1')
+    // 技能实数等级域 近战伤害反弹 ('Eah1')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_DEALT_TO_ATTACKERS = ConvertAbilityRealLevelField('Eah1')
+    // 技能实数等级域 治疗生命值 ('Etq1')
 	constant abilityreallevelfield ABILITY_RLF_LIFE_HEALED = ConvertAbilityRealLevelField('Etq1')
+    // 技能实数等级域 治疗间隔 ('Etq2')
 	constant abilityreallevelfield ABILITY_RLF_HEAL_INTERVAL = ConvertAbilityRealLevelField('Etq2')
+    // 技能实数等级域 建筑伤害参数（无效） ('Etq3')
 	constant abilityreallevelfield ABILITY_RLF_BUILDING_REDUCTION_ETQ3 = ConvertAbilityRealLevelField('Etq3')
+    // 技能实数等级域 初始完成CD ('Etq4')
 	constant abilityreallevelfield ABILITY_RLF_INITIAL_IMMUNITY_DURATION = ConvertAbilityRealLevelField('Etq4')
+    // 技能实数等级域 每秒损耗生命百分比 ('Udd1')
 	constant abilityreallevelfield ABILITY_RLF_MAX_LIFE_DRAINED_PER_SECOND_PERCENT = ConvertAbilityRealLevelField('Udd1')
+    // 技能实数等级域 建筑伤害参数（无效） ('Udd2')
 	constant abilityreallevelfield ABILITY_RLF_BUILDING_REDUCTION_UDD2 = ConvertAbilityRealLevelField('Udd2')
+    // 技能实数等级域 护甲持续时间 ('Ufa1')
 	constant abilityreallevelfield ABILITY_RLF_ARMOR_DURATION = ConvertAbilityRealLevelField('Ufa1')
+    // 技能实数等级域 防御奖励 ('Ufa2')
 	constant abilityreallevelfield ABILITY_RLF_ARMOR_BONUS_UFA2 = ConvertAbilityRealLevelField('Ufa2')
+    // 技能实数等级域 范围目标伤害 ('Ufn1')
 	constant abilityreallevelfield ABILITY_RLF_AREA_OF_EFFECT_DAMAGE = ConvertAbilityRealLevelField('Ufn1')
+    // 技能实数等级域 特定目标伤害 ('Ufn2')
 	constant abilityreallevelfield ABILITY_RLF_SPECIFIC_TARGET_DAMAGE_UFN2 = ConvertAbilityRealLevelField('Ufn2')
+    // 技能实数等级域 伤害奖励 ('Hfa1')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_BONUS_HFA1 = ConvertAbilityRealLevelField('Hfa1')
+    // 技能实数等级域 伤害 ('Esf1')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_DEALT_ESF1 = ConvertAbilityRealLevelField('Esf1')
+    // 技能实数等级域 伤害间隔 ('Esf2')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_INTERVAL_ESF2 = ConvertAbilityRealLevelField('Esf2')
+    // 技能实数等级域 建筑伤害参数（%） ('Esf3')
 	constant abilityreallevelfield ABILITY_RLF_BUILDING_REDUCTION_ESF3 = ConvertAbilityRealLevelField('Esf3')
+    // 技能实数等级域 伤害奖励（%） ('Ear1')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_BONUS_PERCENT = ConvertAbilityRealLevelField('Ear1')
+    // 技能实数等级域 防御奖励 ('Hav1')
 	constant abilityreallevelfield ABILITY_RLF_DEFENSE_BONUS_HAV1 = ConvertAbilityRealLevelField('Hav1')
+    // 技能实数等级域 生命值奖励 ('Hav2')
 	constant abilityreallevelfield ABILITY_RLF_HIT_POINT_BONUS = ConvertAbilityRealLevelField('Hav2')
+    // 技能实数等级域 伤害奖励 ('Hav3')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_BONUS_HAV3 = ConvertAbilityRealLevelField('Hav3')
+    // 技能实数等级域 魔法伤害减少（无效） ('Hav4')
 	constant abilityreallevelfield ABILITY_RLF_MAGIC_DAMAGE_REDUCTION_HAV4 = ConvertAbilityRealLevelField('Hav4')
+    // 技能实数等级域 重击几率 ('Hbh1')
 	constant abilityreallevelfield ABILITY_RLF_CHANCE_TO_BASH = ConvertAbilityRealLevelField('Hbh1')
+    // 技能实数等级域 伤害倍数 ('Hbh2')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_MULTIPLIER_HBH2 = ConvertAbilityRealLevelField('Hbh2')
+    // 技能实数等级域 伤害奖励 ('Hbh3')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_BONUS_HBH3 = ConvertAbilityRealLevelField('Hbh3')
+    // 技能实数等级域 未命中率 ('Hbh4')
 	constant abilityreallevelfield ABILITY_RLF_CHANCE_TO_MISS_HBH4 = ConvertAbilityRealLevelField('Hbh4')
+    // 技能实数等级域 伤害 ('Htb1')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_HTB1 = ConvertAbilityRealLevelField('Htb1')
+    // 技能实数等级域 范围伤害 ('Htc1')
 	constant abilityreallevelfield ABILITY_RLF_AOE_DAMAGE = ConvertAbilityRealLevelField('Htc1')
+    // 技能实数等级域 指定目标伤害 ('Htc2')
 	constant abilityreallevelfield ABILITY_RLF_SPECIFIC_TARGET_DAMAGE_HTC2 = ConvertAbilityRealLevelField('Htc2')
+    // 技能实数等级域 移动速度减少（%） ('Htc3')
 	constant abilityreallevelfield ABILITY_RLF_MOVEMENT_SPEED_REDUCTION_PERCENT_HTC3 = ConvertAbilityRealLevelField('Htc3')
+    // 技能实数等级域 攻击速度减少（%） ('Htc4')
 	constant abilityreallevelfield ABILITY_RLF_ATTACK_SPEED_REDUCTION_PERCENT_HTC4 = ConvertAbilityRealLevelField('Htc4')
+    // 技能实数等级域 防御奖励 ('Had1')
 	constant abilityreallevelfield ABILITY_RLF_ARMOR_BONUS_HAD1 = ConvertAbilityRealLevelField('Had1')
+    // 技能实数等级域 治疗数值 ('Hhb1')
 	constant abilityreallevelfield ABILITY_RLF_AMOUNT_HEALED_DAMAGED_HHB1 = ConvertAbilityRealLevelField('Hhb1')
+    // 技能实数等级域 附加伤害 ('Hca1')
 	constant abilityreallevelfield ABILITY_RLF_EXTRA_DAMAGE_HCA1 = ConvertAbilityRealLevelField('Hca1')
+    // 技能实数等级域 移动速度系数（%） ('Hca2')
 	constant abilityreallevelfield ABILITY_RLF_MOVEMENT_SPEED_FACTOR_HCA2 = ConvertAbilityRealLevelField('Hca2')
+    // 技能实数等级域 攻击速度系数（%） ('Hca3')
 	constant abilityreallevelfield ABILITY_RLF_ATTACK_SPEED_FACTOR_HCA3 = ConvertAbilityRealLevelField('Hca3')
+    // 技能实数等级域 移动速度增加（%） ('Oae1')
 	constant abilityreallevelfield ABILITY_RLF_MOVEMENT_SPEED_INCREASE_PERCENT_OAE1 = ConvertAbilityRealLevelField('Oae1')
+    // 技能实数等级域 攻击速度增加（%） ('Oae2')
 	constant abilityreallevelfield ABILITY_RLF_ATTACK_SPEED_INCREASE_PERCENT_OAE2 = ConvertAbilityRealLevelField('Oae2')
+    // 技能实数等级域 重生延迟 ('Ore1')
 	constant abilityreallevelfield ABILITY_RLF_REINCARNATION_DELAY = ConvertAbilityRealLevelField('Ore1')
+    // 技能实数等级域 伤害 ('Osh1')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_OSH1 = ConvertAbilityRealLevelField('Osh1')
+    // 技能实数等级域 最大伤害 ('Osh2')
 	constant abilityreallevelfield ABILITY_RLF_MAXIMUM_DAMAGE_OSH2 = ConvertAbilityRealLevelField('Osh2')
+    // 技能实数等级域 距离 ('Osh3')
 	constant abilityreallevelfield ABILITY_RLF_DISTANCE_OSH3 = ConvertAbilityRealLevelField('Osh3')
+    // 技能实数等级域 最终区域范围 ('Osh4')
 	constant abilityreallevelfield ABILITY_RLF_FINAL_AREA_OSH4 = ConvertAbilityRealLevelField('Osh4')
+    // 技能实数等级域 效果延迟 ('Nfd1')
 	constant abilityreallevelfield ABILITY_RLF_GRAPHIC_DELAY_NFD1 = ConvertAbilityRealLevelField('Nfd1')
+    // 技能实数等级域 效果持续时间 ('Nfd2')
 	constant abilityreallevelfield ABILITY_RLF_GRAPHIC_DURATION_NFD2 = ConvertAbilityRealLevelField('Nfd2')
+    // 技能实数等级域 伤害 ('Nfd3')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_NFD3 = ConvertAbilityRealLevelField('Nfd3')
+    // 技能实数等级域 对召唤单位伤害 ('Ams1')
 	constant abilityreallevelfield ABILITY_RLF_SUMMONED_UNIT_DAMAGE_AMS1 = ConvertAbilityRealLevelField('Ams1')
+    // 技能实数等级域 魔法伤害减少（无效） ('Ams2')
 	constant abilityreallevelfield ABILITY_RLF_MAGIC_DAMAGE_REDUCTION_AMS2 = ConvertAbilityRealLevelField('Ams2')
+    // 技能实数等级域 瘟疫效果持续时间 ('Apl1')
 	constant abilityreallevelfield ABILITY_RLF_AURA_DURATION = ConvertAbilityRealLevelField('Apl1')
+    // 技能实数等级域 每秒伤害 ('Apl2')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_PER_SECOND_APL2 = ConvertAbilityRealLevelField('Apl2')
+    // 技能实数等级域 瘟疫守卫持续时间 ('Apl3')
 	constant abilityreallevelfield ABILITY_RLF_DURATION_OF_PLAGUE_WARD = ConvertAbilityRealLevelField('Apl3')
+    // 技能实数等级域 每秒生命恢复 ('Oar1')
 	constant abilityreallevelfield ABILITY_RLF_AMOUNT_OF_HIT_POINTS_REGENERATED = ConvertAbilityRealLevelField('Oar1')
+    // 技能实数等级域 攻击伤害增加 ('Akb1')
 	constant abilityreallevelfield ABILITY_RLF_ATTACK_DAMAGE_INCREASE_AKB1 = ConvertAbilityRealLevelField('Akb1')
+    // 技能实数等级域 目标魔法损耗 ('Adm1')
 	constant abilityreallevelfield ABILITY_RLF_MANA_LOSS_ADM1 = ConvertAbilityRealLevelField('Adm1')
+    // 技能实数等级域 对召唤单位伤害 ('Adm2')
 	constant abilityreallevelfield ABILITY_RLF_SUMMONED_UNIT_DAMAGE_ADM2 = ConvertAbilityRealLevelField('Adm2')
+    // 技能实数等级域 扩张范围 ('Bli1')
 	constant abilityreallevelfield ABILITY_RLF_EXPANSION_AMOUNT = ConvertAbilityRealLevelField('Bli1')
+    // 技能实数等级域 采集间隔时间 ('Bgm2')
 	constant abilityreallevelfield ABILITY_RLF_INTERVAL_DURATION_BGM2 = ConvertAbilityRealLevelField('Bgm2')
+    // 技能实数等级域 采集环形半径 ('Bgm4')
 	constant abilityreallevelfield ABILITY_RLF_RADIUS_OF_MINING_RING = ConvertAbilityRealLevelField('Bgm4')
+    // 技能实数等级域 攻击速度增加（%） ('Blo1')
 	constant abilityreallevelfield ABILITY_RLF_ATTACK_SPEED_INCREASE_PERCENT_BLO1 = ConvertAbilityRealLevelField('Blo1')
+    // 技能实数等级域 移动速度增加（%） ('Blo2')
 	constant abilityreallevelfield ABILITY_RLF_MOVEMENT_SPEED_INCREASE_PERCENT_BLO2 = ConvertAbilityRealLevelField('Blo2')
+    // 技能实数等级域 模型放大比例 ('Blo3')
 	constant abilityreallevelfield ABILITY_RLF_SCALING_FACTOR = ConvertAbilityRealLevelField('Blo3')
+    // 技能实数等级域 每秒恢复生命 ('Can1')
 	constant abilityreallevelfield ABILITY_RLF_HIT_POINTS_PER_SECOND_CAN1 = ConvertAbilityRealLevelField('Can1')
+    // 技能实数等级域 最大恢复生命 ('Can2')
 	constant abilityreallevelfield ABILITY_RLF_MAX_HIT_POINTS = ConvertAbilityRealLevelField('Can2')
+    // 技能实数等级域 每秒伤害 ('Dev2')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_PER_SECOND_DEV2 = ConvertAbilityRealLevelField('Dev2')
+    // 技能实数等级域 移动速度更新次数 ('Chd1')
 	constant abilityreallevelfield ABILITY_RLF_MOVEMENT_UPDATE_FREQUENCY_CHD1 = ConvertAbilityRealLevelField('Chd1')
+    // 技能实数等级域 攻击速度更新次数 ('Chd2')
 	constant abilityreallevelfield ABILITY_RLF_ATTACK_UPDATE_FREQUENCY_CHD2 = ConvertAbilityRealLevelField('Chd2')
+    // 技能实数等级域 对召唤单位伤害（无效） ('Chd3')
 	constant abilityreallevelfield ABILITY_RLF_SUMMONED_UNIT_DAMAGE_CHD3 = ConvertAbilityRealLevelField('Chd3')
+    // 技能实数等级域 移动速度减少（%） ('Cri1')
 	constant abilityreallevelfield ABILITY_RLF_MOVEMENT_SPEED_REDUCTION_PERCENT_CRI1 = ConvertAbilityRealLevelField('Cri1')
+    // 技能实数等级域 攻击速度减少（%） ('Cri2')
 	constant abilityreallevelfield ABILITY_RLF_ATTACK_SPEED_REDUCTION_PERCENT_CRI2 = ConvertAbilityRealLevelField('Cri2')
+    // 技能实数等级域 伤害减少（%） ('Cri3')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_REDUCTION_CRI3 = ConvertAbilityRealLevelField('Cri3')
+    // 技能实数等级域 未命中率 ('Crs1')
 	constant abilityreallevelfield ABILITY_RLF_CHANCE_TO_MISS_CRS = ConvertAbilityRealLevelField('Crs1')
+    // 技能实数等级域 全伤害范围 ('Dda1')
 	constant abilityreallevelfield ABILITY_RLF_FULL_DAMAGE_RADIUS_DDA1 = ConvertAbilityRealLevelField('Dda1')
+    // 技能实数等级域 全伤害数值 ('Dda2')
 	constant abilityreallevelfield ABILITY_RLF_FULL_DAMAGE_AMOUNT_DDA2 = ConvertAbilityRealLevelField('Dda2')
+    // 技能实数等级域 部分伤害范围 ('Dda3')
 	constant abilityreallevelfield ABILITY_RLF_PARTIAL_DAMAGE_RADIUS = ConvertAbilityRealLevelField('Dda3')
+    // 技能实数等级域 部分伤害数值 ('Dda4')
 	constant abilityreallevelfield ABILITY_RLF_PARTIAL_DAMAGE_AMOUNT = ConvertAbilityRealLevelField('Dda4')
+    // 技能实数等级域 建筑伤害参数 ('Sds1')
 	constant abilityreallevelfield ABILITY_RLF_BUILDING_DAMAGE_FACTOR_SDS1 = ConvertAbilityRealLevelField('Sds1')
+    // 技能实数等级域 最大攻击伤害 ('Uco5')
 	constant abilityreallevelfield ABILITY_RLF_MAX_DAMAGE_UCO5 = ConvertAbilityRealLevelField('Uco5')
+    // 技能实数等级域 移动速度奖励 ('Uco6')
 	constant abilityreallevelfield ABILITY_RLF_MOVE_SPEED_BONUS_UCO6 = ConvertAbilityRealLevelField('Uco6')
+    // 技能实数等级域 所受穿刺伤害（%） ('Def1')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_TAKEN_PERCENT_DEF1 = ConvertAbilityRealLevelField('Def1')
+    // 技能实数等级域 伤害倍乘（%） ('Def2')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_DEALT_PERCENT_DEF2 = ConvertAbilityRealLevelField('Def2')
+    // 技能实数等级域 移动速度系数（%） ('Def3')
 	constant abilityreallevelfield ABILITY_RLF_MOVEMENT_SPEED_FACTOR_DEF3 = ConvertAbilityRealLevelField('Def3')
+    // 技能实数等级域 攻击速度系数（%） ('Def4')
 	constant abilityreallevelfield ABILITY_RLF_ATTACK_SPEED_FACTOR_DEF4 = ConvertAbilityRealLevelField('Def4')
+    // 技能实数等级域 所受魔法伤害（%） ('Def5')
 	constant abilityreallevelfield ABILITY_RLF_MAGIC_DAMAGE_REDUCTION_DEF5 = ConvertAbilityRealLevelField('Def5')
+    // 技能实数等级域 反弹几率 ('Def6')
 	constant abilityreallevelfield ABILITY_RLF_CHANCE_TO_DEFLECT = ConvertAbilityRealLevelField('Def6')
+    // 技能实数等级域 接受反弹攻击伤害（穿刺） ('Def7')
 	constant abilityreallevelfield ABILITY_RLF_DEFLECT_DAMAGE_TAKEN_PIERCING = ConvertAbilityRealLevelField('Def7')
+    // 技能实数等级域 接受反弹攻击伤害（魔法） ('Def8')
 	constant abilityreallevelfield ABILITY_RLF_DEFLECT_DAMAGE_TAKEN_SPELLS = ConvertAbilityRealLevelField('Def8')
+    // 技能实数等级域 技能延迟 ('Eat1')
 	constant abilityreallevelfield ABILITY_RLF_RIP_DELAY = ConvertAbilityRealLevelField('Eat1')
+    // 技能实数等级域 吞食延迟 ('Eat2')
 	constant abilityreallevelfield ABILITY_RLF_EAT_DELAY = ConvertAbilityRealLevelField('Eat2')
+    // 技能实数等级域 总恢复生命值 ('Eat3')
 	constant abilityreallevelfield ABILITY_RLF_HIT_POINTS_GAINED_EAT3 = ConvertAbilityRealLevelField('Eat3')
+    // 技能实数等级域 空中单位坠落时间 ('Ens1')
 	constant abilityreallevelfield ABILITY_RLF_AIR_UNIT_LOWER_DURATION = ConvertAbilityRealLevelField('Ens1')
+    // 技能实数等级域 空中单位高度 ('Ens2')
 	constant abilityreallevelfield ABILITY_RLF_AIR_UNIT_HEIGHT = ConvertAbilityRealLevelField('Ens2')
+    // 技能实数等级域 近战攻击范围 ('Ens3')
 	constant abilityreallevelfield ABILITY_RLF_MELEE_ATTACK_RANGE = ConvertAbilityRealLevelField('Ens3')
+    // 技能实数等级域 间隔时间 ('Egm2')
 	constant abilityreallevelfield ABILITY_RLF_INTERVAL_DURATION_EGM2 = ConvertAbilityRealLevelField('Egm2')
+    // 技能实数等级域 效果延迟 ('Fla2')
 	constant abilityreallevelfield ABILITY_RLF_EFFECT_DELAY_FLA2 = ConvertAbilityRealLevelField('Fla2')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_MINING_DURATION = ConvertAbilityRealLevelField('Gld2')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_RADIUS_OF_GRAVESTONES = ConvertAbilityRealLevelField('Gyd2')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_RADIUS_OF_CORPSES = ConvertAbilityRealLevelField('Gyd3')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_HIT_POINTS_GAINED_HEA1 = ConvertAbilityRealLevelField('Hea1')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_INCREASE_PERCENT_INF1 = ConvertAbilityRealLevelField('Inf1')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_AUTOCAST_RANGE = ConvertAbilityRealLevelField('Inf3')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_LIFE_REGEN_RATE = ConvertAbilityRealLevelField('Inf4')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_GRAPHIC_DELAY_LIT1 = ConvertAbilityRealLevelField('Lit1')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_GRAPHIC_DURATION_LIT2 = ConvertAbilityRealLevelField('Lit2')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_PER_SECOND_LSH1 = ConvertAbilityRealLevelField('Lsh1')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_MANA_GAINED = ConvertAbilityRealLevelField('Mbt1')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_HIT_POINTS_GAINED_MBT2 = ConvertAbilityRealLevelField('Mbt2')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_AUTOCAST_REQUIREMENT = ConvertAbilityRealLevelField('Mbt3')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_WATER_HEIGHT = ConvertAbilityRealLevelField('Mbt4')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_ACTIVATION_DELAY_MIN1 = ConvertAbilityRealLevelField('Min1')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_INVISIBILITY_TRANSITION_TIME = ConvertAbilityRealLevelField('Min2')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_ACTIVATION_RADIUS = ConvertAbilityRealLevelField('Neu1')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_AMOUNT_REGENERATED = ConvertAbilityRealLevelField('Arm1')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_PER_SECOND_POI1 = ConvertAbilityRealLevelField('Poi1')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_ATTACK_SPEED_FACTOR_POI2 = ConvertAbilityRealLevelField('Poi2')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_MOVEMENT_SPEED_FACTOR_POI3 = ConvertAbilityRealLevelField('Poi3')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_EXTRA_DAMAGE_POA1 = ConvertAbilityRealLevelField('Poa1')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_PER_SECOND_POA2 = ConvertAbilityRealLevelField('Poa2')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_ATTACK_SPEED_FACTOR_POA3 = ConvertAbilityRealLevelField('Poa3')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_MOVEMENT_SPEED_FACTOR_POA4 = ConvertAbilityRealLevelField('Poa4')   
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_AMPLIFICATION = ConvertAbilityRealLevelField('Pos2')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_CHANCE_TO_STOMP_PERCENT = ConvertAbilityRealLevelField('War1')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_DEALT_WAR2 = ConvertAbilityRealLevelField('War2')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_FULL_DAMAGE_RADIUS_WAR3 = ConvertAbilityRealLevelField('War3')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_HALF_DAMAGE_RADIUS_WAR4 = ConvertAbilityRealLevelField('War4')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_SUMMONED_UNIT_DAMAGE_PRG3 = ConvertAbilityRealLevelField('Prg3')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_UNIT_PAUSE_DURATION = ConvertAbilityRealLevelField('Prg4')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_HERO_PAUSE_DURATION = ConvertAbilityRealLevelField('Prg5')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_HIT_POINTS_GAINED_REJ1 = ConvertAbilityRealLevelField('Rej1')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_MANA_POINTS_GAINED_REJ2 = ConvertAbilityRealLevelField('Rej2')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_MINIMUM_LIFE_REQUIRED = ConvertAbilityRealLevelField('Rpb3')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_MINIMUM_MANA_REQUIRED = ConvertAbilityRealLevelField('Rpb4')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_REPAIR_COST_RATIO = ConvertAbilityRealLevelField('Rep1')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_REPAIR_TIME_RATIO = ConvertAbilityRealLevelField('Rep2')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_POWERBUILD_COST = ConvertAbilityRealLevelField('Rep3')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_POWERBUILD_RATE = ConvertAbilityRealLevelField('Rep4')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_NAVAL_RANGE_BONUS = ConvertAbilityRealLevelField('Rep5')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_INCREASE_PERCENT_ROA1 = ConvertAbilityRealLevelField('Roa1')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_LIFE_REGENERATION_RATE = ConvertAbilityRealLevelField('Roa3')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_MANA_REGEN = ConvertAbilityRealLevelField('Roa4')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_INCREASE = ConvertAbilityRealLevelField('Nbr1')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_SALVAGE_COST_RATIO = ConvertAbilityRealLevelField('Sal1')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_IN_FLIGHT_SIGHT_RADIUS = ConvertAbilityRealLevelField('Esn1')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_HOVERING_SIGHT_RADIUS = ConvertAbilityRealLevelField('Esn2')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_HOVERING_HEIGHT = ConvertAbilityRealLevelField('Esn3')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_DURATION_OF_OWLS = ConvertAbilityRealLevelField('Esn5')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_FADE_DURATION = ConvertAbilityRealLevelField('Shm1')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_DAY_NIGHT_DURATION = ConvertAbilityRealLevelField('Shm2')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_ACTION_DURATION = ConvertAbilityRealLevelField('Shm3')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_MOVEMENT_SPEED_FACTOR_SLO1 = ConvertAbilityRealLevelField('Slo1')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_ATTACK_SPEED_FACTOR_SLO2 = ConvertAbilityRealLevelField('Slo2')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_PER_SECOND_SPO1 = ConvertAbilityRealLevelField('Spo1')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_MOVEMENT_SPEED_FACTOR_SPO2 = ConvertAbilityRealLevelField('Spo2')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_ATTACK_SPEED_FACTOR_SPO3 = ConvertAbilityRealLevelField('Spo3')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_ACTIVATION_DELAY_STA1 = ConvertAbilityRealLevelField('Sta1')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_DETECTION_RADIUS_STA2 = ConvertAbilityRealLevelField('Sta2')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_DETONATION_RADIUS = ConvertAbilityRealLevelField('Sta3')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_STUN_DURATION_STA4 = ConvertAbilityRealLevelField('Sta4')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_ATTACK_SPEED_BONUS_PERCENT = ConvertAbilityRealLevelField('Uhf1')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_PER_SECOND_UHF2 = ConvertAbilityRealLevelField('Uhf2')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_LUMBER_PER_INTERVAL = ConvertAbilityRealLevelField('Wha1')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_ART_ATTACHMENT_HEIGHT = ConvertAbilityRealLevelField('Wha3')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_TELEPORT_AREA_WIDTH = ConvertAbilityRealLevelField('Wrp1')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_TELEPORT_AREA_HEIGHT = ConvertAbilityRealLevelField('Wrp2')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_LIFE_STOLEN_PER_ATTACK = ConvertAbilityRealLevelField('Ivam')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_BONUS_IDAM = ConvertAbilityRealLevelField('Idam')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_CHANCE_TO_HIT_UNITS_PERCENT = ConvertAbilityRealLevelField('Iob2')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_CHANCE_TO_HIT_HEROS_PERCENT = ConvertAbilityRealLevelField('Iob3')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_CHANCE_TO_HIT_SUMMONS_PERCENT = ConvertAbilityRealLevelField('Iob4')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_DELAY_FOR_TARGET_EFFECT = ConvertAbilityRealLevelField('Idel')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_DEALT_PERCENT_OF_NORMAL = ConvertAbilityRealLevelField('Iild')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_RECEIVED_MULTIPLIER = ConvertAbilityRealLevelField('Iilw')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_MANA_REGENERATION_BONUS_AS_FRACTION_OF_NORMAL = ConvertAbilityRealLevelField('Imrp')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_MOVEMENT_SPEED_INCREASE_ISPI = ConvertAbilityRealLevelField('Ispi')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_PER_SECOND_IDPS = ConvertAbilityRealLevelField('Idps')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_ATTACK_DAMAGE_INCREASE_CAC1 = ConvertAbilityRealLevelField('Cac1')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_PER_SECOND_COR1 = ConvertAbilityRealLevelField('Cor1')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_ATTACK_SPEED_INCREASE_ISX1 = ConvertAbilityRealLevelField('Isx1')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_WRS1 = ConvertAbilityRealLevelField('Wrs1')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_TERRAIN_DEFORMATION_AMPLITUDE = ConvertAbilityRealLevelField('Wrs2')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_CTC1 = ConvertAbilityRealLevelField('Ctc1')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_EXTRA_DAMAGE_TO_TARGET = ConvertAbilityRealLevelField('Ctc2')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_MOVEMENT_SPEED_REDUCTION_CTC3 = ConvertAbilityRealLevelField('Ctc3')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_ATTACK_SPEED_REDUCTION_CTC4 = ConvertAbilityRealLevelField('Ctc4')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_CTB1 = ConvertAbilityRealLevelField('Ctb1')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_CASTING_DELAY_SECONDS = ConvertAbilityRealLevelField('Uds2')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_MANA_LOSS_PER_UNIT_DTN1 = ConvertAbilityRealLevelField('Dtn1')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_TO_SUMMONED_UNITS_DTN2 = ConvertAbilityRealLevelField('Dtn2')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_TRANSITION_TIME_SECONDS = ConvertAbilityRealLevelField('Ivs1')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_MANA_DRAINED_PER_SECOND_NMR1 = ConvertAbilityRealLevelField('Nmr1')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_CHANCE_TO_REDUCE_DAMAGE_PERCENT = ConvertAbilityRealLevelField('Ssk1')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_MINIMUM_DAMAGE = ConvertAbilityRealLevelField('Ssk2')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_IGNORED_DAMAGE = ConvertAbilityRealLevelField('Ssk3')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_FULL_DAMAGE_DEALT = ConvertAbilityRealLevelField('Hfs1')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_FULL_DAMAGE_INTERVAL = ConvertAbilityRealLevelField('Hfs2')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_HALF_DAMAGE_DEALT = ConvertAbilityRealLevelField('Hfs3')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_HALF_DAMAGE_INTERVAL = ConvertAbilityRealLevelField('Hfs4')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_BUILDING_REDUCTION_HFS5 = ConvertAbilityRealLevelField('Hfs5')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_MAXIMUM_DAMAGE_HFS6 = ConvertAbilityRealLevelField('Hfs6')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_MANA_PER_HIT_POINT = ConvertAbilityRealLevelField('Nms1')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_ABSORBED_PERCENT = ConvertAbilityRealLevelField('Nms2')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_WAVE_DISTANCE = ConvertAbilityRealLevelField('Uim1')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_WAVE_TIME_SECONDS = ConvertAbilityRealLevelField('Uim2')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_DEALT_UIM3 = ConvertAbilityRealLevelField('Uim3')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_AIR_TIME_SECONDS_UIM4 = ConvertAbilityRealLevelField('Uim4')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_UNIT_RELEASE_INTERVAL_SECONDS = ConvertAbilityRealLevelField('Uls2')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_RETURN_FACTOR = ConvertAbilityRealLevelField('Uls4')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_RETURN_THRESHOLD = ConvertAbilityRealLevelField('Uls5')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_RETURNED_DAMAGE_FACTOR = ConvertAbilityRealLevelField('Uts1')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_RECEIVED_DAMAGE_FACTOR = ConvertAbilityRealLevelField('Uts2')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_DEFENSE_BONUS_UTS3 = ConvertAbilityRealLevelField('Uts3')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_BONUS_NBA1 = ConvertAbilityRealLevelField('Nba1')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_SUMMONED_UNIT_DURATION_SECONDS_NBA3 = ConvertAbilityRealLevelField('Nba3')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_MANA_PER_SUMMONED_HITPOINT = ConvertAbilityRealLevelField('Cmg2')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_CHARGE_FOR_CURRENT_LIFE = ConvertAbilityRealLevelField('Cmg3')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_HIT_POINTS_DRAINED = ConvertAbilityRealLevelField('Ndr1')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_MANA_POINTS_DRAINED = ConvertAbilityRealLevelField('Ndr2')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_DRAIN_INTERVAL_SECONDS = ConvertAbilityRealLevelField('Ndr3')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_LIFE_TRANSFERRED_PER_SECOND = ConvertAbilityRealLevelField('Ndr4')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_MANA_TRANSFERRED_PER_SECOND = ConvertAbilityRealLevelField('Ndr5')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_BONUS_LIFE_FACTOR = ConvertAbilityRealLevelField('Ndr6')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_BONUS_LIFE_DECAY = ConvertAbilityRealLevelField('Ndr7')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_BONUS_MANA_FACTOR = ConvertAbilityRealLevelField('Ndr8')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_BONUS_MANA_DECAY = ConvertAbilityRealLevelField('Ndr9')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_CHANCE_TO_MISS_PERCENT = ConvertAbilityRealLevelField('Nsi2')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_MOVEMENT_SPEED_MODIFIER = ConvertAbilityRealLevelField('Nsi3')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_ATTACK_SPEED_MODIFIER = ConvertAbilityRealLevelField('Nsi4')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_PER_SECOND_TDG1 = ConvertAbilityRealLevelField('Tdg1')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_MEDIUM_DAMAGE_RADIUS_TDG2 = ConvertAbilityRealLevelField('Tdg2')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_MEDIUM_DAMAGE_PER_SECOND = ConvertAbilityRealLevelField('Tdg3')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_SMALL_DAMAGE_RADIUS_TDG4 = ConvertAbilityRealLevelField('Tdg4')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_SMALL_DAMAGE_PER_SECOND = ConvertAbilityRealLevelField('Tdg5')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_AIR_TIME_SECONDS_TSP1 = ConvertAbilityRealLevelField('Tsp1')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_MINIMUM_HIT_INTERVAL_SECONDS = ConvertAbilityRealLevelField('Tsp2')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_PER_SECOND_NBF5 = ConvertAbilityRealLevelField('Nbf5')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_MAXIMUM_RANGE = ConvertAbilityRealLevelField('Ebl1')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_MINIMUM_RANGE = ConvertAbilityRealLevelField('Ebl2')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_PER_TARGET_EFK1 = ConvertAbilityRealLevelField('Efk1')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_MAXIMUM_TOTAL_DAMAGE = ConvertAbilityRealLevelField('Efk2')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_MAXIMUM_SPEED_ADJUSTMENT = ConvertAbilityRealLevelField('Efk4')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_DECAYING_DAMAGE = ConvertAbilityRealLevelField('Esh1')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_MOVEMENT_SPEED_FACTOR_ESH2 = ConvertAbilityRealLevelField('Esh2')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_ATTACK_SPEED_FACTOR_ESH3 = ConvertAbilityRealLevelField('Esh3')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_DECAY_POWER = ConvertAbilityRealLevelField('Esh4')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_INITIAL_DAMAGE_ESH5 = ConvertAbilityRealLevelField('Esh5')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_MAXIMUM_LIFE_ABSORBED = ConvertAbilityRealLevelField('abs1')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_MAXIMUM_MANA_ABSORBED = ConvertAbilityRealLevelField('abs2')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_MOVEMENT_SPEED_INCREASE_BSK1 = ConvertAbilityRealLevelField('bsk1')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_ATTACK_SPEED_INCREASE_BSK2 = ConvertAbilityRealLevelField('bsk2')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_TAKEN_INCREASE = ConvertAbilityRealLevelField('bsk3')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_LIFE_PER_UNIT = ConvertAbilityRealLevelField('dvm1')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_MANA_PER_UNIT = ConvertAbilityRealLevelField('dvm2')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_LIFE_PER_BUFF = ConvertAbilityRealLevelField('dvm3')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_MANA_PER_BUFF = ConvertAbilityRealLevelField('dvm4')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_SUMMONED_UNIT_DAMAGE_DVM5 = ConvertAbilityRealLevelField('dvm5')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_BONUS_FAK1 = ConvertAbilityRealLevelField('fak1')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_MEDIUM_DAMAGE_FACTOR_FAK2 = ConvertAbilityRealLevelField('fak2')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_SMALL_DAMAGE_FACTOR_FAK3 = ConvertAbilityRealLevelField('fak3')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_FULL_DAMAGE_RADIUS_FAK4 = ConvertAbilityRealLevelField('fak4')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_HALF_DAMAGE_RADIUS_FAK5 = ConvertAbilityRealLevelField('fak5')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_EXTRA_DAMAGE_PER_SECOND = ConvertAbilityRealLevelField('liq1')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_MOVEMENT_SPEED_REDUCTION_LIQ2 = ConvertAbilityRealLevelField('liq2')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_ATTACK_SPEED_REDUCTION_LIQ3 = ConvertAbilityRealLevelField('liq3')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_MAGIC_DAMAGE_FACTOR = ConvertAbilityRealLevelField('mim1')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_UNIT_DAMAGE_PER_MANA_POINT = ConvertAbilityRealLevelField('mfl1')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_HERO_DAMAGE_PER_MANA_POINT = ConvertAbilityRealLevelField('mfl2')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_UNIT_MAXIMUM_DAMAGE = ConvertAbilityRealLevelField('mfl3')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_HERO_MAXIMUM_DAMAGE = ConvertAbilityRealLevelField('mfl4')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_COOLDOWN = ConvertAbilityRealLevelField('mfl5')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_DISTRIBUTED_DAMAGE_FACTOR_SPL1 = ConvertAbilityRealLevelField('spl1')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_LIFE_REGENERATED = ConvertAbilityRealLevelField('irl1')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_MANA_REGENERATED = ConvertAbilityRealLevelField('irl2')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_MANA_LOSS_PER_UNIT_IDC1 = ConvertAbilityRealLevelField('idc1')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_SUMMONED_UNIT_DAMAGE_IDC2 = ConvertAbilityRealLevelField('idc2')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_ACTIVATION_DELAY_IMO2 = ConvertAbilityRealLevelField('imo2')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_LURE_INTERVAL_SECONDS = ConvertAbilityRealLevelField('imo3')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_BONUS_ISR1 = ConvertAbilityRealLevelField('isr1')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_REDUCTION_ISR2 = ConvertAbilityRealLevelField('isr2')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_BONUS_IPV1 = ConvertAbilityRealLevelField('ipv1')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_LIFE_STEAL_AMOUNT = ConvertAbilityRealLevelField('ipv2')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_LIFE_RESTORED_FACTOR = ConvertAbilityRealLevelField('ast1')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_MANA_RESTORED_FACTOR = ConvertAbilityRealLevelField('ast2')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_ATTACH_DELAY = ConvertAbilityRealLevelField('gra1')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_REMOVE_DELAY = ConvertAbilityRealLevelField('gra2')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_HERO_REGENERATION_DELAY = ConvertAbilityRealLevelField('Nsa2')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_UNIT_REGENERATION_DELAY = ConvertAbilityRealLevelField('Nsa3')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_MAGIC_DAMAGE_REDUCTION_NSA4 = ConvertAbilityRealLevelField('Nsa4')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_HIT_POINTS_PER_SECOND_NSA5 = ConvertAbilityRealLevelField('Nsa5')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_TO_SUMMONED_UNITS_IXS1 = ConvertAbilityRealLevelField('Ixs1')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_MAGIC_DAMAGE_REDUCTION_IXS2 = ConvertAbilityRealLevelField('Ixs2')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_SUMMONED_UNIT_DURATION = ConvertAbilityRealLevelField('Npa6')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_SHIELD_COOLDOWN_TIME = ConvertAbilityRealLevelField('Nse1')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_PER_SECOND_NDO1 = ConvertAbilityRealLevelField('Ndo1')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_SUMMONED_UNIT_DURATION_SECONDS_NDO3 = ConvertAbilityRealLevelField('Ndo3')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_MEDIUM_DAMAGE_RADIUS_FLK1 = ConvertAbilityRealLevelField('flk1')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_SMALL_DAMAGE_RADIUS_FLK2 = ConvertAbilityRealLevelField('flk2')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_FULL_DAMAGE_AMOUNT_FLK3 = ConvertAbilityRealLevelField('flk3')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_MEDIUM_DAMAGE_AMOUNT = ConvertAbilityRealLevelField('flk4')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_SMALL_DAMAGE_AMOUNT = ConvertAbilityRealLevelField('flk5')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_MOVEMENT_SPEED_REDUCTION_PERCENT_HBN1 = ConvertAbilityRealLevelField('Hbn1')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_ATTACK_SPEED_REDUCTION_PERCENT_HBN2 = ConvertAbilityRealLevelField('Hbn2')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_MAX_MANA_DRAINED_UNITS = ConvertAbilityRealLevelField('fbk1')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_RATIO_UNITS_PERCENT = ConvertAbilityRealLevelField('fbk2')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_MAX_MANA_DRAINED_HEROS = ConvertAbilityRealLevelField('fbk3')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_RATIO_HEROS_PERCENT = ConvertAbilityRealLevelField('fbk4')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_SUMMONED_DAMAGE = ConvertAbilityRealLevelField('fbk5')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_DISTRIBUTED_DAMAGE_FACTOR_NCA1 = ConvertAbilityRealLevelField('nca1')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_INITIAL_DAMAGE_PXF1 = ConvertAbilityRealLevelField('pxf1')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_PER_SECOND_PXF2 = ConvertAbilityRealLevelField('pxf2')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_PER_SECOND_MLS1 = ConvertAbilityRealLevelField('mls1')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_BEAST_COLLISION_RADIUS = ConvertAbilityRealLevelField('Nst2')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_AMOUNT_NST3 = ConvertAbilityRealLevelField('Nst3')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_RADIUS = ConvertAbilityRealLevelField('Nst4')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_DELAY = ConvertAbilityRealLevelField('Nst5')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_FOLLOW_THROUGH_TIME = ConvertAbilityRealLevelField('Ncl1')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_ART_DURATION = ConvertAbilityRealLevelField('Ncl4')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_MOVEMENT_SPEED_REDUCTION_PERCENT_NAB1 = ConvertAbilityRealLevelField('Nab1')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_ATTACK_SPEED_REDUCTION_PERCENT_NAB2 = ConvertAbilityRealLevelField('Nab2')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_PRIMARY_DAMAGE = ConvertAbilityRealLevelField('Nab4')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_SECONDARY_DAMAGE = ConvertAbilityRealLevelField('Nab5')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_INTERVAL_NAB6 = ConvertAbilityRealLevelField('Nab6')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_GOLD_COST_FACTOR = ConvertAbilityRealLevelField('Ntm1')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_LUMBER_COST_FACTOR = ConvertAbilityRealLevelField('Ntm2')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_MOVE_SPEED_BONUS_NEG1 = ConvertAbilityRealLevelField('Neg1')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_BONUS_NEG2 = ConvertAbilityRealLevelField('Neg2')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_AMOUNT_NCS1 = ConvertAbilityRealLevelField('Ncs1')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_INTERVAL_NCS2 = ConvertAbilityRealLevelField('Ncs2')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_MAX_DAMAGE_NCS4 = ConvertAbilityRealLevelField('Ncs4')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_BUILDING_DAMAGE_FACTOR_NCS5 = ConvertAbilityRealLevelField('Ncs5')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_EFFECT_DURATION = ConvertAbilityRealLevelField('Ncs6')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_SPAWN_INTERVAL_NSY1 = ConvertAbilityRealLevelField('Nsy1')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_SPAWN_UNIT_DURATION = ConvertAbilityRealLevelField('Nsy3')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_SPAWN_UNIT_OFFSET = ConvertAbilityRealLevelField('Nsy4')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_LEASH_RANGE_NSY5 = ConvertAbilityRealLevelField('Nsy5')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_SPAWN_INTERVAL_NFY1 = ConvertAbilityRealLevelField('Nfy1')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_LEASH_RANGE_NFY2 = ConvertAbilityRealLevelField('Nfy2')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_CHANCE_TO_DEMOLISH = ConvertAbilityRealLevelField('Nde1')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_MULTIPLIER_BUILDINGS = ConvertAbilityRealLevelField('Nde2')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_MULTIPLIER_UNITS = ConvertAbilityRealLevelField('Nde3')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_MULTIPLIER_HEROES = ConvertAbilityRealLevelField('Nde4')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_BONUS_DAMAGE_MULTIPLIER = ConvertAbilityRealLevelField('Nic1')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_DEATH_DAMAGE_FULL_AMOUNT = ConvertAbilityRealLevelField('Nic2')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_DEATH_DAMAGE_FULL_AREA = ConvertAbilityRealLevelField('Nic3')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_DEATH_DAMAGE_HALF_AMOUNT = ConvertAbilityRealLevelField('Nic4')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_DEATH_DAMAGE_HALF_AREA = ConvertAbilityRealLevelField('Nic5')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_DEATH_DAMAGE_DELAY = ConvertAbilityRealLevelField('Nic6')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_AMOUNT_NSO1 = ConvertAbilityRealLevelField('Nso1')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_PERIOD = ConvertAbilityRealLevelField('Nso2')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_PENALTY = ConvertAbilityRealLevelField('Nso3')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_MOVEMENT_SPEED_REDUCTION_PERCENT_NSO4 = ConvertAbilityRealLevelField('Nso4')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_ATTACK_SPEED_REDUCTION_PERCENT_NSO5 = ConvertAbilityRealLevelField('Nso5')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_SPLIT_DELAY = ConvertAbilityRealLevelField('Nlm2')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_MAX_HITPOINT_FACTOR = ConvertAbilityRealLevelField('Nlm4')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_LIFE_DURATION_SPLIT_BONUS = ConvertAbilityRealLevelField('Nlm5')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_WAVE_INTERVAL = ConvertAbilityRealLevelField('Nvc3')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_BUILDING_DAMAGE_FACTOR_NVC4 = ConvertAbilityRealLevelField('Nvc4')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_FULL_DAMAGE_AMOUNT_NVC5 = ConvertAbilityRealLevelField('Nvc5')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_HALF_DAMAGE_FACTOR = ConvertAbilityRealLevelField('Nvc6')
+    // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_INTERVAL_BETWEEN_PULSES = ConvertAbilityRealLevelField('Tau5')
 	
+    // 技能布尔值等级域 百分比奖励 ('Hab2')
 	constant abilitybooleanlevelfield ABILITY_BLF_PERCENT_BONUS_HAB2 = ConvertAbilityBooleanLevelField('Hab2')
+    // 技能布尔值等级域 传送单位聚集 ('Hmt3')
 	constant abilitybooleanlevelfield ABILITY_BLF_USE_TELEPORT_CLUSTERING_HMT3 = ConvertAbilityBooleanLevelField('Hmt3')
+    // 技能布尔值等级域 不会丢失 ('Ocr5')
 	constant abilitybooleanlevelfield ABILITY_BLF_NEVER_MISS_OCR5 = ConvertAbilityBooleanLevelField('Ocr5')
+    // 技能布尔值等级域 排除物品伤害 ('Ocr6')
 	constant abilitybooleanlevelfield ABILITY_BLF_EXCLUDE_ITEM_DAMAGE = ConvertAbilityBooleanLevelField('Ocr6')
+    // 技能布尔值等级域 加成伤害 ('Owk4')
 	constant abilitybooleanlevelfield ABILITY_BLF_BACKSTAB_DAMAGE = ConvertAbilityBooleanLevelField('Owk4')
+    // 技能布尔值等级域 继承升级 ('Uan3')
 	constant abilitybooleanlevelfield ABILITY_BLF_INHERIT_UPGRADES_UAN3 = ConvertAbilityBooleanLevelField('Uan3')
+    // 技能布尔值等级域 魔法数值转换 ('Udp3')
 	constant abilitybooleanlevelfield ABILITY_BLF_MANA_CONVERSION_AS_PERCENT = ConvertAbilityBooleanLevelField('Udp3')
+    // 技能布尔值等级域 生命数值转换 ('Udp4')
 	constant abilitybooleanlevelfield ABILITY_BLF_LIFE_CONVERSION_AS_PERCENT = ConvertAbilityBooleanLevelField('Udp4')
+    // 技能布尔值等级域 目标存活 ('Udp5')
 	constant abilitybooleanlevelfield ABILITY_BLF_LEAVE_TARGET_ALIVE = ConvertAbilityBooleanLevelField('Udp5')
+    // 技能布尔值等级域 百分比奖励 ('Uau3')
 	constant abilitybooleanlevelfield ABILITY_BLF_PERCENT_BONUS_UAU3 = ConvertAbilityBooleanLevelField('Uau3')
+    // 技能布尔值等级域 按百分比反弹 ('Eah2')
 	constant abilitybooleanlevelfield ABILITY_BLF_DAMAGE_IS_PERCENT_RECEIVED = ConvertAbilityBooleanLevelField('Eah2')
+    // 技能布尔值等级域 近战奖励 ('Ear2')
 	constant abilitybooleanlevelfield ABILITY_BLF_MELEE_BONUS = ConvertAbilityBooleanLevelField('Ear2')
+    // 技能布尔值等级域 远程奖励 ('Ear3')
 	constant abilitybooleanlevelfield ABILITY_BLF_RANGED_BONUS = ConvertAbilityBooleanLevelField('Ear3')
+    // 技能布尔值等级域 使用指定数值奖励 ('Ear4')
 	constant abilitybooleanlevelfield ABILITY_BLF_FLAT_BONUS = ConvertAbilityBooleanLevelField('Ear4')
+    // 技能布尔值等级域 不会丢失 ('Hbh5')
 	constant abilitybooleanlevelfield ABILITY_BLF_NEVER_MISS_HBH5 = ConvertAbilityBooleanLevelField('Hbh5')
+    // 技能布尔值等级域 百分比奖励 ('Had2')
 	constant abilitybooleanlevelfield ABILITY_BLF_PERCENT_BONUS_HAD2 = ConvertAbilityBooleanLevelField('Had2')
+    // 技能布尔值等级域 可以取消 ('Hds1')
 	constant abilitybooleanlevelfield ABILITY_BLF_CAN_DEACTIVATE = ConvertAbilityBooleanLevelField('Hds1')
+    // 技能布尔值等级域 复活单位是无敌的 ('Hre2')
 	constant abilitybooleanlevelfield ABILITY_BLF_RAISED_UNITS_ARE_INVULNERABLE = ConvertAbilityBooleanLevelField('Hre2')
+    // 技能布尔值等级域 按百分比回复 ('Oar2')
 	constant abilitybooleanlevelfield ABILITY_BLF_PERCENTAGE_OAR2 = ConvertAbilityBooleanLevelField('Oar2')
+    // 技能布尔值等级域 召唤非空闲单位 ('Btl2')
 	constant abilitybooleanlevelfield ABILITY_BLF_SUMMON_BUSY_UNITS = ConvertAbilityBooleanLevelField('Btl2')
+    // 技能布尔值等级域 创建荒芜地表 ('Bli2')
 	constant abilitybooleanlevelfield ABILITY_BLF_CREATES_BLIGHT = ConvertAbilityBooleanLevelField('Bli2')
+    // 技能布尔值等级域 尸体爆炸 ('Sds6')
 	constant abilitybooleanlevelfield ABILITY_BLF_EXPLODES_ON_DEATH = ConvertAbilityBooleanLevelField('Sds6')
+    // 技能布尔值等级域 总是自动施放 ('Fae2')
 	constant abilitybooleanlevelfield ABILITY_BLF_ALWAYS_AUTOCAST_FAE2 = ConvertAbilityBooleanLevelField('Fae2')
+    // 技能布尔值等级域 只能在夜间回复 ('Mbt5')
 	constant abilitybooleanlevelfield ABILITY_BLF_REGENERATE_ONLY_AT_NIGHT = ConvertAbilityBooleanLevelField('Mbt5')
+    // 技能布尔值等级域 显示选择单位按钮 ('Neu3')
 	constant abilitybooleanlevelfield ABILITY_BLF_SHOW_SELECT_UNIT_BUTTON = ConvertAbilityBooleanLevelField('Neu3')
+    // 技能布尔值等级域 显示单位指示器 ('Neu4')
 	constant abilitybooleanlevelfield ABILITY_BLF_SHOW_UNIT_INDICATOR = ConvertAbilityBooleanLevelField('Neu4')
+    // 技能布尔值等级域 向技能拥有者收费 ('Ans6')
 	constant abilitybooleanlevelfield ABILITY_BLF_CHARGE_OWNING_PLAYER = ConvertAbilityBooleanLevelField('Ans6')
+    // 技能布尔值等级域 按百分比回复 ('Arm2')
 	constant abilitybooleanlevelfield ABILITY_BLF_PERCENTAGE_ARM2 = ConvertAbilityBooleanLevelField('Arm2')
+    // 技能布尔值等级域 目标无敌 ('Pos3')
 	constant abilitybooleanlevelfield ABILITY_BLF_TARGET_IS_INVULNERABLE = ConvertAbilityBooleanLevelField('Pos3')
+    // 技能布尔值等级域 目标魔法免疫 ('Pos4')
 	constant abilitybooleanlevelfield ABILITY_BLF_TARGET_IS_MAGIC_IMMUNE = ConvertAbilityBooleanLevelField('Pos4')
+    // 技能布尔值等级域 施法者死亡时杀死召唤单位 ('Ucb6')
 	constant abilitybooleanlevelfield ABILITY_BLF_KILL_ON_CASTER_DEATH = ConvertAbilityBooleanLevelField('Ucb6')
+    // 技能布尔值等级域 只能对自己施放 ('Rej4')
 	constant abilitybooleanlevelfield ABILITY_BLF_NO_TARGET_REQUIRED_REJ4 = ConvertAbilityBooleanLevelField('Rej4')
+    // 技能布尔值等级域 接受黄金 ('Rtn1')
 	constant abilitybooleanlevelfield ABILITY_BLF_ACCEPTS_GOLD = ConvertAbilityBooleanLevelField('Rtn1')
+    // 技能布尔值等级域 接受木材 ('Rtn2')
 	constant abilitybooleanlevelfield ABILITY_BLF_ACCEPTS_LUMBER = ConvertAbilityBooleanLevelField('Rtn2')
+    // 技能布尔值等级域 影响敌方数量 ('Roa5')
 	constant abilitybooleanlevelfield ABILITY_BLF_PREFER_HOSTILES_ROA5 = ConvertAbilityBooleanLevelField('Roa5')
+    // 技能布尔值等级域 影响友方数量 ('Roa6')
 	constant abilitybooleanlevelfield ABILITY_BLF_PREFER_FRIENDLIES_ROA6 = ConvertAbilityBooleanLevelField('Roa6')
+    // 技能布尔值等级域 扎根可转向 ('Roo3')
 	constant abilitybooleanlevelfield ABILITY_BLF_ROOTED_TURNING = ConvertAbilityBooleanLevelField('Roo3')
+    // 技能布尔值等级域 总是自动施放 ('Slo3')
 	constant abilitybooleanlevelfield ABILITY_BLF_ALWAYS_AUTOCAST_SLO3 = ConvertAbilityBooleanLevelField('Slo3')
+    // 技能布尔值等级域 隐藏按钮 ('Ihid')
 	constant abilitybooleanlevelfield ABILITY_BLF_HIDE_BUTTON = ConvertAbilityBooleanLevelField('Ihid')
+    // 技能布尔值等级域 传送单位聚集 ('Itp2')
 	constant abilitybooleanlevelfield ABILITY_BLF_USE_TELEPORT_CLUSTERING_ITP2 = ConvertAbilityBooleanLevelField('Itp2')
+    // 技能布尔值等级域 对变形效果免疫 ('Eth1')
 	constant abilitybooleanlevelfield ABILITY_BLF_IMMUNE_TO_MORPH_EFFECTS = ConvertAbilityBooleanLevelField('Eth1')
+    // 技能布尔值等级域 不妨碍建造 ('Eth2')
 	constant abilitybooleanlevelfield ABILITY_BLF_DOES_NOT_BLOCK_BUILDINGS = ConvertAbilityBooleanLevelField('Eth2')
+    // 技能布尔值等级域 自动获取攻击目标 ('Gho1')
 	constant abilitybooleanlevelfield ABILITY_BLF_AUTO_ACQUIRE_ATTACK_TARGETS = ConvertAbilityBooleanLevelField('Gho1')
+    // 技能布尔值等级域 对变形效果免疫 ('Gho2')
 	constant abilitybooleanlevelfield ABILITY_BLF_IMMUNE_TO_MORPH_EFFECTS_GHO2 = ConvertAbilityBooleanLevelField('Gho2')
+    // 技能布尔值等级域 不妨碍建造 ('Gho3')
 	constant abilitybooleanlevelfield ABILITY_BLF_DO_NOT_BLOCK_BUILDINGS = ConvertAbilityBooleanLevelField('Gho3')
+    // 技能布尔值等级域 远程伤害加成 ('Ssk4')
 	constant abilitybooleanlevelfield ABILITY_BLF_INCLUDE_RANGED_DAMAGE = ConvertAbilityBooleanLevelField('Ssk4')
+    // 技能布尔值等级域 近战伤害加成 ('Ssk5')
 	constant abilitybooleanlevelfield ABILITY_BLF_INCLUDE_MELEE_DAMAGE = ConvertAbilityBooleanLevelField('Ssk5')
+    // 技能布尔值等级域 向目标靠拢 ('coa2')
 	constant abilitybooleanlevelfield ABILITY_BLF_MOVE_TO_PARTNER = ConvertAbilityBooleanLevelField('coa2')
+    // 技能布尔值等级域 可以被驱散 ('cyc1')
 	constant abilitybooleanlevelfield ABILITY_BLF_CAN_BE_DISPELLED = ConvertAbilityBooleanLevelField('cyc1')
+    // 技能布尔值等级域 忽略友军的增益魔法效果 ('dvm6')
 	constant abilitybooleanlevelfield ABILITY_BLF_IGNORE_FRIENDLY_BUFFS = ConvertAbilityBooleanLevelField('dvm6')
+    // 技能布尔值等级域 死亡掉落物品 ('inv2')
 	constant abilitybooleanlevelfield ABILITY_BLF_DROP_ITEMS_ON_DEATH = ConvertAbilityBooleanLevelField('inv2')
+    // 技能布尔值等级域 可以使用物品 ('inv3')
 	constant abilitybooleanlevelfield ABILITY_BLF_CAN_USE_ITEMS = ConvertAbilityBooleanLevelField('inv3')
+    // 技能布尔值等级域 可以取得物品 ('inv4')
 	constant abilitybooleanlevelfield ABILITY_BLF_CAN_GET_ITEMS = ConvertAbilityBooleanLevelField('inv4')
+    // 技能布尔值等级域 可以丢弃物品 ('inv5')
 	constant abilitybooleanlevelfield ABILITY_BLF_CAN_DROP_ITEMS = ConvertAbilityBooleanLevelField('inv5')
+    // 技能布尔值等级域 修理允许 ('liq4')
 	constant abilitybooleanlevelfield ABILITY_BLF_REPAIRS_ALLOWED = ConvertAbilityBooleanLevelField('liq4')
+    // 技能布尔值等级域 仅溅射伤害有魔法单位 ('mfl6')
 	constant abilitybooleanlevelfield ABILITY_BLF_CASTER_ONLY_SPLASH = ConvertAbilityBooleanLevelField('mfl6')
+    // 技能布尔值等级域 只对自己施放 ('irl4')
 	constant abilitybooleanlevelfield ABILITY_BLF_NO_TARGET_REQUIRED_IRL4 = ConvertAbilityBooleanLevelField('irl4')
+    // 技能布尔值等级域 被攻击时驱散效果 ('irl5')
 	constant abilitybooleanlevelfield ABILITY_BLF_DISPEL_ON_ATTACK = ConvertAbilityBooleanLevelField('irl5')
+    // 技能布尔值等级域 使用原始值 ('ipv3')
 	constant abilitybooleanlevelfield ABILITY_BLF_AMOUNT_IS_RAW_VALUE = ConvertAbilityBooleanLevelField('ipv3')
+    // 技能布尔值等级域 共享法术CD间隔 ('spb2')
 	constant abilitybooleanlevelfield ABILITY_BLF_SHARED_SPELL_COOLDOWN = ConvertAbilityBooleanLevelField('spb2')
+    // 技能布尔值等级域 睡眠一次 ('sla1')
 	constant abilitybooleanlevelfield ABILITY_BLF_SLEEP_ONCE = ConvertAbilityBooleanLevelField('sla1')
+    // 技能布尔值等级域 允许任意玩家 ('sla2')
 	constant abilitybooleanlevelfield ABILITY_BLF_ALLOW_ON_ANY_PLAYER_SLOT = ConvertAbilityBooleanLevelField('sla2')
+    // 技能布尔值等级域 使其他技能无效 ('Ncl5')
 	constant abilitybooleanlevelfield ABILITY_BLF_DISABLE_OTHER_ABILITIES = ConvertAbilityBooleanLevelField('Ncl5')
+    // 技能布尔值等级域 附加杀敌奖励 ('Ntm4')
 	constant abilitybooleanlevelfield ABILITY_BLF_ALLOW_BOUNTY = ConvertAbilityBooleanLevelField('Ntm4')
 	
 	// 技能字符串等级域 图标 - 普通 ('aart')

--- a/static/common.j
+++ b/static/common.j
@@ -4352,40 +4352,40 @@ native BlzGroupGetSize takes group whichGroup returns integer
 // 获取单位组中下标的单位
 native BlzGroupUnitAt takes group whichGroup, integer index returns unit
 // 将指定单位类型的单位加入单位组
-// @param filter附加选择单位的额外条件，不建议使用在AI脚本中，即filter写成null
+// @param filter过滤，不建议使用在AI脚本中，即filter写成null
 native GroupEnumUnitsOfType takes group whichGroup, string unitname, boolexpr filter returns nothing
 // 将指定玩家匹的单位加入单位组
-// @param filter附加选择单位的额外条件，不建议使用在AI脚本中，即filter写成null
+// @param filter过滤，不建议使用在AI脚本中，即filter写成null
 native GroupEnumUnitsOfPlayer takes group whichGroup, player whichPlayer, boolexpr filter returns nothing
 // 将指定单位类型的单位加入单位组，同时指定添加单位的数量上限
-// @param filter附加选择单位的额外条件，不建议使用在AI脚本中，即filter写成null
+// @param filter过滤，不建议使用在AI脚本中，即filter写成null
 // @param countLimit 数量上限
 native GroupEnumUnitsOfTypeCounted takes group whichGroup, string unitname, boolexpr filter, integer countLimit returns nothing
 // 将指定方形区域的的单位加入单位组
-// @param filter附加选择单位的额外条件，不建议使用在AI脚本中，即filter写成null
+// @param filter过滤，不建议使用在AI脚本中，即filter写成null
 native GroupEnumUnitsInRect takes group whichGroup, rect r, boolexpr filter returns nothing
 // 将指定方形区域的的单位加入单位组，同时指定添加单位的数量上限
-// @param filter附加选择单位的额外条件，不建议使用在AI脚本中，即filter写成null
+// @param filter过滤，不建议使用在AI脚本中，即filter写成null
 // @param countLimit 数量上限
 native GroupEnumUnitsInRectCounted takes group whichGroup, rect r, boolexpr filter, integer countLimit returns nothing
 // 将圆形区域的单位添加到单位组（指定圆心坐标）
-// @param filter附加选择单位的额外条件，不建议使用在AI脚本中，即filter写成null
+// @param filter过滤，不建议使用在AI脚本中，即filter写成null
 native GroupEnumUnitsInRange takes group whichGroup, real x, real y, real radius, boolexpr filter returns nothing
 // 将圆形区域的单位添加到单位组（指定圆心坐标）
-// @param filter附加选择单位的额外条件，不建议使用在AI脚本中，即filter写成null
+// @param filter过滤，不建议使用在AI脚本中，即filter写成null
 native GroupEnumUnitsInRangeOfLoc takes group whichGroup, location whichLocation, real radius, boolexpr filter returns nothing
 // 【弃用】将圆形区域的单位添加到单位组（指定圆心坐标），同时指定添加单位的数量上限
-// @param filter附加选择单位的额外条件，不建议使用在AI脚本中，即filter写成null
+// @param filter过滤，不建议使用在AI脚本中，即filter写成null
 // @deprecated
 // @param countLimit 数量上限
 native GroupEnumUnitsInRangeCounted takes group whichGroup, real x, real y, real radius, boolexpr filter, integer countLimit returns nothing
 // 【弃用】将圆形区域的单位添加到单位组（指定圆心坐标），同时指定添加单位的数量上限
-// @param filter附加选择单位的额外条件，不建议使用在AI脚本中，即filter写成null
+// @param filter过滤，不建议使用在AI脚本中，即filter写成null
 // @deprecated
 // @param countLimit 数量上限
 native GroupEnumUnitsInRangeOfLocCounted takes group whichGroup, location whichLocation, real radius, boolexpr filter, integer countLimit returns nothing
 // 将指定玩家的单位添加到单位组
-// @param filter附加选择单位的额外条件，不建议使用在AI脚本中，即filter写成null
+// @param filter过滤，不建议使用在AI脚本中，即filter写成null
 native GroupEnumUnitsSelected takes group whichGroup, player whichPlayer, boolexpr filter returns nothing
 
 // 发送单位组命令（无目标）
@@ -4412,6 +4412,7 @@ native GroupTargetOrderById takes group whichGroup, integer order, widget target
 // 选取指定单位组做多个动作
 native ForGroup takes group whichGroup, code callback returns nothing
 // 获取单位组中第一个单位
+// 在单位组内单位未发生变化时（添加或移除单位），单位的排序不会发生变化，即每次获取的都是同一个单位
 native FirstOfGroup takes group whichGroup returns unit
 
 
@@ -4427,18 +4428,18 @@ native ForceAddPlayer takes force whichForce, player whichPlayer returns nothing
 native ForceRemovePlayer takes force whichForce, player whichPlayer returns nothing
 // 玩家是否存在
 native BlzForceHasPlayer takes force whichForce, player whichPlayer returns boolean
-// 清除玩家
+// 清除玩家组
 native ForceClear takes force whichForce returns nothing
-// 匹配玩家
+// 匹配玩家组
 native ForceEnumPlayers takes force whichForce, boolexpr filter returns nothing
-// 匹配玩家（指定上限）
-// @param countLimit
+// 在指定的玩家组中匹配玩家（指定匹配的数量）
+// @param countLimit玩家数量
 native ForceEnumPlayersCounted takes force whichForce, boolexpr filter, integer countLimit returns nothing
-// 匹配联盟
+// 在指定的玩家组中匹配联盟玩家
 native ForceEnumAllies takes force whichForce, player whichPlayer, boolexpr filter returns nothing
-// 匹配敌对
+// 在指定的玩家组中匹配敌对玩家
 native ForceEnumEnemies takes force whichForce, player whichPlayer, boolexpr filter returns nothing
-// 选取所有玩家在玩家组做动作(单一的)
+// 选取所有玩家在玩家组做动作(单个动作)
 native ForForce takes force whichForce, code callback returns nothing
 
 
@@ -4456,7 +4457,7 @@ native SetRect takes rect whichRect, real minx, real miny, real maxx, real maxy 
 native SetRectFromLoc takes rect whichRect, location min, location max returns nothing
 // 移动矩形区域(指定坐标) [R]
 native MoveRectTo takes rect whichRect, real newCenterX, real newCenterY returns nothing
-// 移动区域
+// 移动区域（指定新的中心点）
 native MoveRectToLoc takes rect whichRect, location newCenterLoc returns nothing
 
 // 获取区域中心的 X 坐标
@@ -4491,7 +4492,7 @@ native RegionClearCell takes region whichRegion, real x, real y returns nothing
 // 移除点(指定区域) [R]
 native RegionClearCellAtLoc takes region whichRegion, location whichLocation returns nothing
 
-// 转换坐标到点
+// 将坐标转换成点
 native Location takes real x, real y returns location
 // 清除点 [R]
 native RemoveLocation takes location whichLocation returns nothing
@@ -4516,7 +4517,7 @@ native IsLocationInRegion takes region whichRegion, location whichLocation retur
 
 // Returns full map bounds, including unplayable borders, in world coordinates
 // Returns full map bounds, including unplayable borders, in world coordinates
-// 获取可用地图范围
+// 获取可用地图区域
 native GetWorldBounds takes nothing returns rect
 
 
@@ -4555,7 +4556,7 @@ constant native GetFilterItem takes nothing returns item
 // 获取选取的物品
 constant native GetEnumItem takes nothing returns item
 
-// 解析标签tags
+// 解析标签 tags
 constant native ParseTags takes string taggedString returns string
 
 // 获取匹配的玩家
@@ -4565,7 +4566,7 @@ constant native GetEnumPlayer takes nothing returns player
 
 // 当前触发器
 constant native GetTriggeringTrigger takes nothing returns trigger
-// 获取触发ID
+// 获取触发事件ID
 constant native GetTriggerEventId takes nothing returns eventid
 // 触发器赋值统计
 constant native GetTriggerEvalCount takes trigger whichTrigger returns integer
@@ -4590,6 +4591,8 @@ native Condition takes code func returns conditionfunc
 // 销毁条件
 native DestroyCondition takes conditionfunc c returns nothing
 // 过滤
+// 可理解为条件/布尔值，用于选取/匹配时指定具体的筛选条件
+// 使用后需要使用（DestroyFilter）排泄，并set null，因此不建议在AI脚本中使用
 native Filter takes code func returns filterfunc
 // 销毁过滤
 native DestroyFilter takes filterfunc f returns nothing
@@ -4636,7 +4639,7 @@ native TriggerRegisterGameEvent takes trigger whichTrigger, gameevent whichGameE
 constant native GetWinningPlayer takes nothing returns player
 
 
-// 单位进入不规则区域(指定条件) [R]
+// 单位进入不规则区域(过滤) [R]
 native TriggerRegisterEnterRegion takes trigger whichTrigger, region whichRegion, boolexpr filter returns event
 
 // EVENT_GAME_ENTER_REGION
@@ -4647,7 +4650,7 @@ constant native GetEnteringUnit takes nothing returns unit
 
 // EVENT_GAME_LEAVE_REGION
 
-// 单位离开不规则区域(指定条件) [R]
+// 单位离开不规则区域(过滤) [R]
 native TriggerRegisterLeaveRegion takes trigger whichTrigger, region whichRegion, boolexpr filter returns event
 // 获取正在离开的单位
 constant native GetLeavingUnit takes nothing returns unit
@@ -5056,13 +5059,13 @@ constant native GetTriggerWidget takes nothing returns widget
 // Destructable Object API
 // Facing arguments are specified in degrees
 // Facing arguments are specified in degrees
-// 新建可破坏物（非死亡的）（指定类型、X坐标，Y坐标，朝向度，尺寸，样式）
+// 新建可破坏物（非毁坏的）（指定类型、X坐标，Y坐标，朝向度，尺寸，样式）
 native CreateDestructable takes integer objectid, real x, real y, real face, real scale, integer variation returns destructable
-// 新建可破坏物 [R]（非死亡的）（指定类型、X坐标，Y坐标，朝向度，尺寸，样式）
+// 新建可破坏物 [R]（非毁坏的）（指定类型、X坐标，Y坐标，朝向度，尺寸，样式）
 native CreateDestructableZ takes integer objectid, real x, real y, real z, real face, real scale, integer variation returns destructable
-// 新建可破坏物(死亡的，如砍伐完的树，毁坏的门/柱)（指定类型、X坐标，Y坐标，朝向度，尺寸，样式）
+// 新建可破坏物(毁坏的，如砍伐完的树，毁坏的门/柱)（指定类型、X坐标，Y坐标，朝向度，尺寸，样式）
 native CreateDeadDestructable takes integer objectid, real x, real y, real face, real scale, integer variation returns destructable
-// 新建可破坏物(死亡的，如砍伐完的树，毁坏的门/柱) [R]（指定类型、X坐标，Y坐标，朝向度，尺寸，样式）
+// 新建可破坏物(毁坏的，如砍伐完的树，毁坏的门/柱) [R]（指定类型、X坐标，Y坐标，朝向度，尺寸，样式）
 native CreateDeadDestructableZ takes integer objectid, real x, real y, real z, real face, real scale, integer variation returns destructable
 // 删除可破坏物
 native RemoveDestructable takes destructable d returns nothing
@@ -5072,7 +5075,7 @@ native KillDestructable takes destructable d returns nothing
 native SetDestructableInvulnerable takes destructable d, boolean flag returns nothing
 // 获取可破坏物的可见状态
 native IsDestructableInvulnerable takes destructable d returns boolean
-// 选取指定区域的指定条件（filter用于指定条件）的可破坏物执行指定动作（actionFunc可指定动作）
+// 选取指定区域的过滤（filter用于过滤）的可破坏物执行指定动作（actionFunc可指定动作）
 native EnumDestructablesInRect takes rect r, boolexpr filter, code actionFunc returns nothing
 // 可破坏物的类型
 native GetDestructableTypeId takes destructable d returns integer
@@ -5153,7 +5156,10 @@ native IsItemIdPowerup takes integer itemId returns boolean
 native IsItemIdSellable takes integer itemId returns boolean
 // 物品是否可以抵押
 native IsItemIdPawnable takes integer itemId returns boolean
-// 选取 区域内 所有物品 做动作 r = 区域 ， filter = 条件 ， actionFunc = 动作
+// 选取 区域内 所有物品 做动作
+// @param r区域
+// @param filter过滤
+// @param actionFunc动作
 native EnumItemsInRect takes rect r, boolexpr filter, code actionFunc returns nothing
 // 获取物品等级
 native GetItemLevel takes item whichItem returns integer
@@ -5316,7 +5322,9 @@ native SuspendHeroXP takes unit whichHero, boolean flag returns nothing
 native IsSuspendedXP takes unit whichHero returns boolean
 // 命令英雄学习技能
 native SelectHeroSkill takes unit whichHero, integer abilcode returns nothing
-// 获取单位技能等级 [R] ，此命令在AI脚本中似乎只返回0，不论技能是否存在
+// 获取单位技能等级 [R] 
+// 对于触发器添加的技能，此命令在AI脚本中似乎只返回0，不论技能是否存在
+// 某些技能本身的等级为0，但在AI脚本中，只要单位拥有技能，也会返回等级大于0，比如'Apit'
 native GetUnitAbilityLevel takes unit whichUnit, integer abilcode returns integer
 // 降低英雄技能等级 [R]
 native DecUnitAbilityLevel takes unit whichUnit, integer abilcode returns integer
@@ -7586,11 +7594,13 @@ native BlzSetUnitWeaponStringField takes unit whichUnit, unitweaponstringfield w
 native BlzGetUnitSkin takes unit whichUnit returns integer
 // 改变物品皮肤
 native BlzGetItemSkin takes item whichItem returns integer
+// 获取可破坏物皮肤
 // native BlzGetDestructableSkin                         takes destructable whichDestructable returns integer
 // 改变单位皮肤
 native BlzSetUnitSkin takes unit whichUnit, integer skinId returns nothing
 // 改变物品皮肤
 native BlzSetItemSkin takes item whichItem, integer skinId returns nothing
+// 改变可破坏物皮肤
 // native BlzSetDestructableSkin                         takes destructable whichDestructable, integer skinId returns nothing
 // 创建物品皮肤
 native BlzCreateItemWithSkin takes integer itemid, real x, real y, integer skinId returns item
@@ -7600,9 +7610,9 @@ native BlzCreateUnitWithSkin takes player id, integer unitid, real x, real y, re
 native BlzCreateDestructableWithSkin takes integer objectid, real x, real y, real face, real scale, integer variation, integer skinId returns destructable
 // 创建可破坏物皮肤（包含Z轴）
 native BlzCreateDestructableZWithSkin takes integer objectid, real x, real y, real z, real face, real scale, integer variation, integer skinId returns destructable
-// 创建可破坏物（死亡的）皮肤（不包含Z轴）
+// 创建可破坏物（毁坏的）皮肤（不包含Z轴）
 native BlzCreateDeadDestructableWithSkin takes integer objectid, real x, real y, real face, real scale, integer variation, integer skinId returns destructable
-// 创建可破坏物（死亡的）皮肤（包含Z轴）
+// 创建可破坏物（毁坏的）皮肤（包含Z轴）
 native BlzCreateDeadDestructableZWithSkin takes integer objectid, real x, real y, real z, real face, real scale, integer variation, integer skinId returns destructable
 // 获取指定玩家的基地数量（按基地单位的数量统计）
 native BlzGetPlayerTownHallCount takes player whichPlayer returns integer

--- a/static/common.j
+++ b/static/common.j
@@ -1636,383 +1636,571 @@ globals
 	
 	// OS Key constants
 	
-	//键盘 退格键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 退格键
+	// @version 1.33
 	constant oskeytype OSKEY_BACKSPACE = ConvertOsKeyType($08)
-	//键盘 TAB 键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 TAB 键
+	// @version 1.33
 	constant oskeytype OSKEY_TAB = ConvertOsKeyType($09)
-	//键盘 CLEAR 键（Num Lock关闭时的数字键盘5），该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 CLEAR 键（Num Lock关闭时的数字键盘5）
+	// @version 1.33
 	constant oskeytype OSKEY_CLEAR = ConvertOsKeyType($0C)
-	//键盘 回车键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 回车键
+	// @version 1.33
 	constant oskeytype OSKEY_RETURN = ConvertOsKeyType($0D)
-	//键盘 SHIFT 键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 SHIFT 键
+	// @version 1.33
 	constant oskeytype OSKEY_SHIFT = ConvertOsKeyType($10)
-	//键盘 ctrl 键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 ctrl 键
+	// @version 1.33
 	constant oskeytype OSKEY_CONTROL = ConvertOsKeyType($11)
-	//键盘 ALT 键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 ALT 键
+	// @version 1.33
 	constant oskeytype OSKEY_ALT = ConvertOsKeyType($12)
-	//键盘 PAUSE （暂停）键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 PAUSE （暂停）键
+	// @version 1.33
 	constant oskeytype OSKEY_PAUSE = ConvertOsKeyType($13)
-	//键盘 CAPS LOCK 键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 CAPS LOCK 键
+	// @version 1.33
 	constant oskeytype OSKEY_CAPSLOCK = ConvertOsKeyType($14)
-	//键盘 KANA 键，仅用于日语键盘，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 KANA 键，仅用于日语键盘
+	// @version 1.33
 	constant oskeytype OSKEY_KANA = ConvertOsKeyType($15)
-	//键盘 HANGUL 键，仅用于朝鲜/韩语键盘，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 HANGUL 键，仅用于朝鲜/韩语键盘
+	// @version 1.33
 	constant oskeytype OSKEY_HANGUL = ConvertOsKeyType($15)
-	//键盘 JUNJA 键，仅用于特定语言输入法，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 JUNJA 键，仅用于特定语言输入法
+	// @version 1.33
 	constant oskeytype OSKEY_JUNJA = ConvertOsKeyType($17)
-	//键盘 FINAL键，仅用于特定语言输入法，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 FINAL键，仅用于特定语言输入法
+	// @version 1.33
 	constant oskeytype OSKEY_FINAL = ConvertOsKeyType($18)
-	//键盘 HANJA 键，仅用于朝鲜/韩语键盘，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 HANJA 键，仅用于朝鲜/韩语键盘
+	// @version 1.33
 	constant oskeytype OSKEY_HANJA = ConvertOsKeyType($19)
-	//键盘 KANJI 键，仅用于日语键盘，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 KANJI 键，仅用于日语键盘
+	// @version 1.33
 	constant oskeytype OSKEY_KANJI = ConvertOsKeyType($19)
-	//键盘 ESC 键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 ESC 键
+	// @version 1.33
 	constant oskeytype OSKEY_ESCAPE = ConvertOsKeyType($1B)
-	//键盘 Caps lock（开启状态） 键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 Caps lock（开启状态） 键
+	// @version 1.33
 	constant oskeytype OSKEY_CONVERT = ConvertOsKeyType($1C)
-	//键盘 Caps lock（关闭状态） 键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 Caps lock（关闭状态） 键
+	// @version 1.33
 	constant oskeytype OSKEY_NONCONVERT = ConvertOsKeyType($1D)
-	//键盘 ACCEPT 键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 ACCEPT 键
+	// @version 1.33
 	constant oskeytype OSKEY_ACCEPT = ConvertOsKeyType($1E)
-	//键盘  变更模式键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘  变更模式键
+	// @version 1.33
 	constant oskeytype OSKEY_MODECHANGE = ConvertOsKeyType($1F)
-	//键盘 空格键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 空格键
+	// @version 1.33
 	constant oskeytype OSKEY_SPACE = ConvertOsKeyType($20)
-	//键盘 向上翻页键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 向上翻页键
+	// @version 1.33
 	constant oskeytype OSKEY_PAGEUP = ConvertOsKeyType($21)
-	//键盘 向下翻页键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 向下翻页键
+	// @version 1.33
 	constant oskeytype OSKEY_PAGEDOWN = ConvertOsKeyType($22)
-	//键盘 结束键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 结束键
+	// @version 1.33
 	constant oskeytype OSKEY_END = ConvertOsKeyType($23)
-	//键盘 HOME键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 HOME键
+	// @version 1.33
 	constant oskeytype OSKEY_HOME = ConvertOsKeyType($24)
-	//键盘 方向键 左，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 方向键 左
+	// @version 1.33
 	constant oskeytype OSKEY_LEFT = ConvertOsKeyType($25)
-	//键盘 方向键 上，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 方向键 上
+	// @version 1.33
 	constant oskeytype OSKEY_UP = ConvertOsKeyType($26)
-	//键盘 方向键 右，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 方向键 右
+	// @version 1.33
 	constant oskeytype OSKEY_RIGHT = ConvertOsKeyType($27)
-	//键盘 方向键 下，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 方向键 下
+	// @version 1.33
 	constant oskeytype OSKEY_DOWN = ConvertOsKeyType($28)
-	//键盘 选择（右SHIFT）键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 选择（右SHIFT）键
+	// @version 1.33
 	constant oskeytype OSKEY_SELECT = ConvertOsKeyType($29)
-	//键盘 PRINT 键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 PRINT 键
+	// @version 1.33
 	constant oskeytype OSKEY_PRINT = ConvertOsKeyType($2A)
-	//键盘 EXECUTE 键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 EXECUTE 键
+	// @version 1.33
 	constant oskeytype OSKEY_EXECUTE = ConvertOsKeyType($2B)
-	//键盘 截图键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 截图键
+	// @version 1.33
 	constant oskeytype OSKEY_PRINTSCREEN = ConvertOsKeyType($2C)
-	//建盘 INSERT键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//建盘 INSERT键
+	// @version 1.33
 	constant oskeytype OSKEY_INSERT = ConvertOsKeyType($2D)
-	//建盘 DELETE键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//建盘 DELETE键
+	// @version 1.33
 	constant oskeytype OSKEY_DELETE = ConvertOsKeyType($2E)
-	//键盘 帮助（F1）键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 帮助（F1）键
+	// @version 1.33
 	constant oskeytype OSKEY_HELP = ConvertOsKeyType($2F)
-	//键盘 0键（非小/数字键盘），该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 0键（非小/数字键盘）
+	// @version 1.33
 	constant oskeytype OSKEY_0 = ConvertOsKeyType($30)
-	//键盘 1键（非小/数字键盘），该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 1键（非小/数字键盘）
+	// @version 1.33
 	constant oskeytype OSKEY_1 = ConvertOsKeyType($31)
-	//键盘 2键（非小/数字键盘），该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 2键（非小/数字键盘）
+	// @version 1.33
 	constant oskeytype OSKEY_2 = ConvertOsKeyType($32)
-	//键盘 3键（非小/数字键盘），该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 3键（非小/数字键盘）
+	// @version 1.33
 	constant oskeytype OSKEY_3 = ConvertOsKeyType($33)
-	//键盘 4键（非小/数字键盘），该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 4键（非小/数字键盘）
+	// @version 1.33
 	constant oskeytype OSKEY_4 = ConvertOsKeyType($34)
-	//键盘 5键（非小/数字键盘），该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 5键（非小/数字键盘）
+	// @version 1.33
 	constant oskeytype OSKEY_5 = ConvertOsKeyType($35)
-	//键盘 6键（非小/数字键盘），该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 6键（非小/数字键盘）
+	// @version 1.33
 	constant oskeytype OSKEY_6 = ConvertOsKeyType($36)
-	//键盘 7键（非小/数字键盘），该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 7键（非小/数字键盘）
+	// @version 1.33
 	constant oskeytype OSKEY_7 = ConvertOsKeyType($37)
-	//键盘 8键（非小/数字键盘），该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 8键（非小/数字键盘）
+	// @version 1.33
 	constant oskeytype OSKEY_8 = ConvertOsKeyType($38)
-	//键盘 9键（非小/数字键盘），该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 9键（非小/数字键盘）
+	// @version 1.33
 	constant oskeytype OSKEY_9 = ConvertOsKeyType($39)
-	//键盘 A键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 A键
+	// @version 1.33
 	constant oskeytype OSKEY_A = ConvertOsKeyType($41)
-	//键盘 B键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 B键
+	// @version 1.33
 	constant oskeytype OSKEY_B = ConvertOsKeyType($42)
-	//键盘 C键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 C键
+	// @version 1.33
 	constant oskeytype OSKEY_C = ConvertOsKeyType($43)
-	//键盘 D键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 D键
+	// @version 1.33
 	constant oskeytype OSKEY_D = ConvertOsKeyType($44)
-	//键盘 E键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 E键
+	// @version 1.33
 	constant oskeytype OSKEY_E = ConvertOsKeyType($45)
-	//键盘 F键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 F键
+	// @version 1.33
 	constant oskeytype OSKEY_F = ConvertOsKeyType($46)
-	//键盘 G键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 G键
+	// @version 1.33
 	constant oskeytype OSKEY_G = ConvertOsKeyType($47)
-	//键盘 H键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 H键
+	// @version 1.33
 	constant oskeytype OSKEY_H = ConvertOsKeyType($48)
-	//键盘 I键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 I键
+	// @version 1.33
 	constant oskeytype OSKEY_I = ConvertOsKeyType($49)
-	//键盘 J键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 J键
+	// @version 1.33
 	constant oskeytype OSKEY_J = ConvertOsKeyType($4A)
-	//键盘 K键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 K键
+	// @version 1.33
 	constant oskeytype OSKEY_K = ConvertOsKeyType($4B)
-	//键盘 L键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 L键
+	// @version 1.33
 	constant oskeytype OSKEY_L = ConvertOsKeyType($4C)
-	//键盘 M键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 M键
+	// @version 1.33
 	constant oskeytype OSKEY_M = ConvertOsKeyType($4D)
-	//键盘 N键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 N键
+	// @version 1.33
 	constant oskeytype OSKEY_N = ConvertOsKeyType($4E)
-	//键盘 O键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 O键
+	// @version 1.33
 	constant oskeytype OSKEY_O = ConvertOsKeyType($4F)
-	//键盘 P键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 P键
+	// @version 1.33
 	constant oskeytype OSKEY_P = ConvertOsKeyType($50)
-	//键盘 Q键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 Q键
+	// @version 1.33
 	constant oskeytype OSKEY_Q = ConvertOsKeyType($51)
-	//键盘 R键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 R键
+	// @version 1.33
 	constant oskeytype OSKEY_R = ConvertOsKeyType($52)
-	//键盘 S键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 S键
+	// @version 1.33
 	constant oskeytype OSKEY_S = ConvertOsKeyType($53)
-	//键盘 T键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 T键
+	// @version 1.33
 	constant oskeytype OSKEY_T = ConvertOsKeyType($54)
-	//键盘 U键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 U键
+	// @version 1.33
 	constant oskeytype OSKEY_U = ConvertOsKeyType($55)
-	//键盘 V键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 V键
+	// @version 1.33
 	constant oskeytype OSKEY_V = ConvertOsKeyType($56)
-	//键盘 W键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 W键
+	// @version 1.33
 	constant oskeytype OSKEY_W = ConvertOsKeyType($57)
-	//键盘 X键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 X键
+	// @version 1.33
 	constant oskeytype OSKEY_X = ConvertOsKeyType($58)
-	//键盘 Y键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 Y键
+	// @version 1.33
 	constant oskeytype OSKEY_Y = ConvertOsKeyType($59)
-	//键盘 Z键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 Z键
+	// @version 1.33
 	constant oskeytype OSKEY_Z = ConvertOsKeyType($5A)
-	//键盘 LMETA 键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 LMETA 键
+	// @version 1.33
 	constant oskeytype OSKEY_LMETA = ConvertOsKeyType($5B)
-	//键盘 RMETA 键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 RMETA 键
+	// @version 1.33
 	constant oskeytype OSKEY_RMETA = ConvertOsKeyType($5C)
-	//键盘 APPS 键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 APPS 键
+	// @version 1.33
 	constant oskeytype OSKEY_APPS = ConvertOsKeyType($5D)
-	//键盘 休眠键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 休眠键
+	// @version 1.33
 	constant oskeytype OSKEY_SLEEP = ConvertOsKeyType($5F)
-	//小/数字键盘 0键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//小/数字键盘 0键
+	// @version 1.33
 	constant oskeytype OSKEY_NUMPAD0 = ConvertOsKeyType($60)
-	//小/数字键盘 1键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//小/数字键盘 1键
+	// @version 1.33
 	constant oskeytype OSKEY_NUMPAD1 = ConvertOsKeyType($61)
-	//小/数字键盘 2键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//小/数字键盘 2键
+	// @version 1.33
 	constant oskeytype OSKEY_NUMPAD2 = ConvertOsKeyType($62)
-	//小/数字键盘 3键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//小/数字键盘 3键
+	// @version 1.33
 	constant oskeytype OSKEY_NUMPAD3 = ConvertOsKeyType($63)
-	//小/数字键盘 4键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//小/数字键盘 4键
+	// @version 1.33
 	constant oskeytype OSKEY_NUMPAD4 = ConvertOsKeyType($64)
-	//小/数字键盘 5键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//小/数字键盘 5键
+	// @version 1.33
 	constant oskeytype OSKEY_NUMPAD5 = ConvertOsKeyType($65)
-	//小/数字键盘 6键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//小/数字键盘 6键
+	// @version 1.33
 	constant oskeytype OSKEY_NUMPAD6 = ConvertOsKeyType($66)
-	//小/数字键盘 7键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//小/数字键盘 7键
+	// @version 1.33
 	constant oskeytype OSKEY_NUMPAD7 = ConvertOsKeyType($67)
-	//小/数字键盘 8键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//小/数字键盘 8键
+	// @version 1.33
 	constant oskeytype OSKEY_NUMPAD8 = ConvertOsKeyType($68)
-	//小/数字键盘 9键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//小/数字键盘 9键
+	// @version 1.33
 	constant oskeytype OSKEY_NUMPAD9 = ConvertOsKeyType($69)
-	//小/数字键盘 乘号键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//小/数字键盘 乘号键
+	// @version 1.33
 	constant oskeytype OSKEY_MULTIPLY = ConvertOsKeyType($6A)
-	//小/数字键盘 加号键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//小/数字键盘 加号键
+	// @version 1.33
 	constant oskeytype OSKEY_ADD = ConvertOsKeyType($6B)
-	//小/数字键盘 分离键/分隔符键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//小/数字键盘 分离键/分隔符键
+	// @version 1.33
 	constant oskeytype OSKEY_SEPARATOR = ConvertOsKeyType($6C)
-	//小/数字键盘 减号键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//小/数字键盘 减号键
+	// @version 1.33
 	constant oskeytype OSKEY_SUBTRACT = ConvertOsKeyType($6D)
-	//小/数字键盘 小数点键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//小/数字键盘 小数点键
+	// @version 1.33
 	constant oskeytype OSKEY_DECIMAL = ConvertOsKeyType($6E)
-	//小/数字键盘 除号键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//小/数字键盘 除号键
+	// @version 1.33
 	constant oskeytype OSKEY_DIVIDE = ConvertOsKeyType($6F)
-	//键盘 F1键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 F1键
+	// @version 1.33
 	constant oskeytype OSKEY_F1 = ConvertOsKeyType($70)
-	//键盘 F2键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 F2键
+	// @version 1.33
 	constant oskeytype OSKEY_F2 = ConvertOsKeyType($71)
-	//键盘 F3键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 F3键
+	// @version 1.33
 	constant oskeytype OSKEY_F3 = ConvertOsKeyType($72)
-	//键盘 F4键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 F4键
+	// @version 1.33
 	constant oskeytype OSKEY_F4 = ConvertOsKeyType($73)
-	//键盘 F5键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 F5键
+	// @version 1.33
 	constant oskeytype OSKEY_F5 = ConvertOsKeyType($74)
-	//键盘 F6键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 F6键
+	// @version 1.33
 	constant oskeytype OSKEY_F6 = ConvertOsKeyType($75)
-	//键盘 F7键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 F7键
+	// @version 1.33
 	constant oskeytype OSKEY_F7 = ConvertOsKeyType($76)
-	//键盘 F8键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 F8键
+	// @version 1.33
 	constant oskeytype OSKEY_F8 = ConvertOsKeyType($77)
-	//键盘 F9键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 F9键
+	// @version 1.33
 	constant oskeytype OSKEY_F9 = ConvertOsKeyType($78)
-	//键盘 F10键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 F10键
+	// @version 1.33
 	constant oskeytype OSKEY_F10 = ConvertOsKeyType($79)
-	//键盘 F11键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 F11键
+	// @version 1.33
 	constant oskeytype OSKEY_F11 = ConvertOsKeyType($7A)
-	//键盘 F12键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 F12键
+	// @version 1.33
 	constant oskeytype OSKEY_F12 = ConvertOsKeyType($7B)
-	//键盘 F13键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 F13键
+	// @version 1.33
 	constant oskeytype OSKEY_F13 = ConvertOsKeyType($7C)
-	//键盘 F14键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 F14键
+	// @version 1.33
 	constant oskeytype OSKEY_F14 = ConvertOsKeyType($7D)
-	//键盘 F15键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 F15键
+	// @version 1.33
 	constant oskeytype OSKEY_F15 = ConvertOsKeyType($7E)
-	//键盘 F16键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 F16键
+	// @version 1.33
 	constant oskeytype OSKEY_F16 = ConvertOsKeyType($7F)
-	//键盘 F17键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 F17键
+	// @version 1.33
 	constant oskeytype OSKEY_F17 = ConvertOsKeyType($80)
-	//键盘 F18键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 F18键
+	// @version 1.33
 	constant oskeytype OSKEY_F18 = ConvertOsKeyType($81)
-	//键盘 F19键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 F19键
+	// @version 1.33
 	constant oskeytype OSKEY_F19 = ConvertOsKeyType($82)
-	//键盘 F20键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 F20键
+	// @version 1.33
 	constant oskeytype OSKEY_F20 = ConvertOsKeyType($83)
-	//键盘 F21键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 F21键
+	// @version 1.33
 	constant oskeytype OSKEY_F21 = ConvertOsKeyType($84)
-	//键盘 F22键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 F22键
+	// @version 1.33
 	constant oskeytype OSKEY_F22 = ConvertOsKeyType($85)
-	//键盘 F23键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 F23键
+	// @version 1.33
 	constant oskeytype OSKEY_F23 = ConvertOsKeyType($86)
-	//键盘 F24键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 F24键
+	// @version 1.33
 	constant oskeytype OSKEY_F24 = ConvertOsKeyType($87)
-	//小/数字键盘 开关键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//小/数字键盘 开关键
+	// @version 1.33
 	constant oskeytype OSKEY_NUMLOCK = ConvertOsKeyType($90)
-	//键盘 SCROLL LOCK键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 SCROLL LOCK键
+	// @version 1.33
 	constant oskeytype OSKEY_SCROLLLOCK = ConvertOsKeyType($91)
-	//小/数字键盘 等号键（OEM 键），该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//小/数字键盘 等号键（OEM 键）
+	// @version 1.33
 	constant oskeytype OSKEY_OEM_NEC_EQUAL = ConvertOsKeyType($92)
-	//键盘 字典键（OEM 键），该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 字典键（OEM 键）
+	// @version 1.33
 	constant oskeytype OSKEY_OEM_FJ_JISHO = ConvertOsKeyType($92)
-	//键盘 取消注册 Word 键（OEM 键），该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 取消注册 Word 键（OEM 键）
+	// @version 1.33
 	constant oskeytype OSKEY_OEM_FJ_MASSHOU = ConvertOsKeyType($93)
-	//键盘 注册 Word 键（OEM 键），该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 注册 Word 键（OEM 键）
+	// @version 1.33
 	constant oskeytype OSKEY_OEM_FJ_TOUROKU = ConvertOsKeyType($94)
-	//键盘 左 OYAYUBI 键（OEM 键），该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 左 OYAYUBI 键（OEM 键）
+	// @version 1.33
 	constant oskeytype OSKEY_OEM_FJ_LOYA = ConvertOsKeyType($95)
-	//键盘 右 OYAYUBI 键（OEM 键），该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 右 OYAYUBI 键（OEM 键）
+	// @version 1.33
 	constant oskeytype OSKEY_OEM_FJ_ROYA = ConvertOsKeyType($96)
-	//键盘 左 OSHIFT 键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 左 OSHIFT 键
+	// @version 1.33
 	constant oskeytype OSKEY_LSHIFT = ConvertOsKeyType($A0)
-	//键盘 右 OSHIFT 键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 右 OSHIFT 键
+	// @version 1.33
 	constant oskeytype OSKEY_RSHIFT = ConvertOsKeyType($A1)
-	//键盘 左 Ctrl 键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 左 Ctrl 键
+	// @version 1.33
 	constant oskeytype OSKEY_LCONTROL = ConvertOsKeyType($A2)
-	//键盘 右 Ctrl 键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 右 Ctrl 键
+	// @version 1.33
 	constant oskeytype OSKEY_RCONTROL = ConvertOsKeyType($A3)
-	//键盘 左 Alt 键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 左 Alt 键
+	// @version 1.33
 	constant oskeytype OSKEY_LALT = ConvertOsKeyType($A4)
-	//键盘 右 Alt 键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 右 Alt 键
+	// @version 1.33
 	constant oskeytype OSKEY_RALT = ConvertOsKeyType($A5)
-	//键盘 浏览器后退键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 浏览器后退键
+	// @version 1.33
 	constant oskeytype OSKEY_BROWSER_BACK = ConvertOsKeyType($A6)
-	//键盘 浏览器前进键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 浏览器前进键
+	// @version 1.33
 	constant oskeytype OSKEY_BROWSER_FORWARD = ConvertOsKeyType($A7)
-	//键盘 浏览器刷新键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 浏览器刷新键
+	// @version 1.33
 	constant oskeytype OSKEY_BROWSER_REFRESH = ConvertOsKeyType($A8)
-	//键盘 浏览器停止键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 浏览器停止键
+	// @version 1.33
 	constant oskeytype OSKEY_BROWSER_STOP = ConvertOsKeyType($A9)
-	//键盘 浏览器搜索键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 浏览器搜索键
+	// @version 1.33
 	constant oskeytype OSKEY_BROWSER_SEARCH = ConvertOsKeyType($AA)
-	//键盘 浏览器收藏键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 浏览器收藏键，
 	constant oskeytype OSKEY_BROWSER_FAVORITES = ConvertOsKeyType($AB)
-	//键盘 浏览器“开始”和“主页”键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 浏览器“开始”和“主页”键
+	// @version 1.33
 	constant oskeytype OSKEY_BROWSER_HOME = ConvertOsKeyType($AC)
-	//键盘 静音键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 静音键
+	// @version 1.33
 	constant oskeytype OSKEY_VOLUME_MUTE = ConvertOsKeyType($AD)
-	//键盘 减小音量键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 减小音量键
+	// @version 1.33
 	constant oskeytype OSKEY_VOLUME_DOWN = ConvertOsKeyType($AE)
-	//键盘 增大音量键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 增大音量键
+	// @version 1.33
 	constant oskeytype OSKEY_VOLUME_UP = ConvertOsKeyType($AF)
-	//键盘 下一曲键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 下一曲键
+	// @version 1.33
 	constant oskeytype OSKEY_MEDIA_NEXT_TRACK = ConvertOsKeyType($B0)
-	//键盘 上一曲键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 上一曲键
+	// @version 1.33
 	constant oskeytype OSKEY_MEDIA_PREV_TRACK = ConvertOsKeyType($B1)
-	//键盘 停止播放键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 停止播放键
+	// @version 1.33
 	constant oskeytype OSKEY_MEDIA_STOP = ConvertOsKeyType($B2)
-	//键盘 暂停播放键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 暂停播放键
+	// @version 1.33
 	constant oskeytype OSKEY_MEDIA_PLAY_PAUSE = ConvertOsKeyType($B3)
-	//键盘 打开邮箱键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 打开邮箱键
+	// @version 1.33
 	constant oskeytype OSKEY_LAUNCH_MAIL = ConvertOsKeyType($B4)
-	//键盘 选择媒体键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 选择媒体键
+	// @version 1.33
 	constant oskeytype OSKEY_LAUNCH_MEDIA_SELECT = ConvertOsKeyType($B5)
-	//键盘 启动应用程序1键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 启动应用程序1键
+	// @version 1.33
 	constant oskeytype OSKEY_LAUNCH_APP1 = ConvertOsKeyType($B6)
-	//键盘 启动应用程序2键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 启动应用程序2键
+	// @version 1.33
 	constant oskeytype OSKEY_LAUNCH_APP2 = ConvertOsKeyType($B7)
-	//小/数字键盘 1建（OEM 键），该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//小/数字键盘 1建（OEM 键）
+	// @version 1.33
 	constant oskeytype OSKEY_OEM_1 = ConvertOsKeyType($BA)
-	//键盘 加号建（OEM 键），该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 加号建（OEM 键）
+	// @version 1.33
 	constant oskeytype OSKEY_OEM_PLUS = ConvertOsKeyType($BB)
-	//键盘 逗号建（OEM 键），该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 逗号建（OEM 键）
+	// @version 1.33
 	constant oskeytype OSKEY_OEM_COMMA = ConvertOsKeyType($BC)
-	//键盘 减号建（OEM 键），该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 减号建（OEM 键）
+	// @version 1.33
 	constant oskeytype OSKEY_OEM_MINUS = ConvertOsKeyType($BD)
-	//键盘 句号建（OEM 键），该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 句号建（OEM 键）
+	// @version 1.33
 	constant oskeytype OSKEY_OEM_PERIOD = ConvertOsKeyType($BE)
-	//小/数字键盘 2建（OEM 键），该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//小/数字键盘 2建（OEM 键）
+	// @version 1.33
 	constant oskeytype OSKEY_OEM_2 = ConvertOsKeyType($BF)
-	//小/数字键盘 3建（OEM 键），该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//小/数字键盘 3建（OEM 键）
+	// @version 1.33
 	constant oskeytype OSKEY_OEM_3 = ConvertOsKeyType($C0)
-	//小/数字键盘 4建（OEM 键），该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//小/数字键盘 4建（OEM 键）
+	// @version 1.33
 	constant oskeytype OSKEY_OEM_4 = ConvertOsKeyType($DB)
-	//小/数字键盘 5建（OEM 键），该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//小/数字键盘 5建（OEM 键）
+	// @version 1.33
 	constant oskeytype OSKEY_OEM_5 = ConvertOsKeyType($DC)
-	//小/数字键盘 6建（OEM 键），该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//小/数字键盘 6建（OEM 键）
+	// @version 1.33
 	constant oskeytype OSKEY_OEM_6 = ConvertOsKeyType($DD)
-	//小/数字键盘 7建（OEM 键），该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//小/数字键盘 7建（OEM 键）
+	// @version 1.33
 	constant oskeytype OSKEY_OEM_7 = ConvertOsKeyType($DE)
-	//小/数字键盘 8建（OEM 键），该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//小/数字键盘 8建（OEM 键）
+	// @version 1.33
 	constant oskeytype OSKEY_OEM_8 = ConvertOsKeyType($DF)
-	//键盘 AX 建（OEM 键），该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 AX 建（OEM 键）
+	// @version 1.33
 	constant oskeytype OSKEY_OEM_AX = ConvertOsKeyType($E1)
-	//键盘 102 建（OEM 键），该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 102 建（OEM 键）
+	// @version 1.33
 	constant oskeytype OSKEY_OEM_102 = ConvertOsKeyType($E2)
-	//键盘  Ico帮助键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘  Ico帮助键
+	// @version 1.33
 	constant oskeytype OSKEY_ICO_HELP = ConvertOsKeyType($E3)
-	//键盘  Ico00 键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘  Ico00 键
+	// @version 1.33
 	constant oskeytype OSKEY_ICO_00 = ConvertOsKeyType($E4)
-	//键盘 Process 键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 Process 键
+	// @version 1.33
 	constant oskeytype OSKEY_PROCESSKEY = ConvertOsKeyType($E5)
-	//键盘 IcoClr 键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 IcoClr 键
+	// @version 1.33
 	constant oskeytype OSKEY_ICO_CLEAR = ConvertOsKeyType($E6)
-	//键盘 格式化建（OEM 键），该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 格式化建（OEM 键）
+	// @version 1.33
 	constant oskeytype OSKEY_PACKET = ConvertOsKeyType($E7)
-	//键盘 重置建（OEM 键），该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 重置建（OEM 键）
+	// @version 1.33
 	constant oskeytype OSKEY_OEM_RESET = ConvertOsKeyType($E9)
-	//键盘 ATTN 键（OEM 键），该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 ATTN 键（OEM 键）
+	// @version 1.33
 	constant oskeytype OSKEY_OEM_JUMP = ConvertOsKeyType($EA)
-	//键盘 PA1 键（OEM 键），该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 PA1 键（OEM 键）
+	// @version 1.33
 	constant oskeytype OSKEY_OEM_PA1 = ConvertOsKeyType($EB)
-	//键盘 PA2 键（OEM 键），该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 PA2 键（OEM 键）
+	// @version 1.33
 	constant oskeytype OSKEY_OEM_PA2 = ConvertOsKeyType($EC)
-	//键盘 ATTN 键（OEM 键），该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 ATTN 键（OEM 键）
+	// @version 1.33
 	constant oskeytype OSKEY_OEM_PA3 = ConvertOsKeyType($ED)
-	//键盘 WSCTRL 键（OEM 键，似乎是联想杀毒软件定制按键），该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 WSCTRL 键（OEM 键，似乎是联想杀毒软件定制按键）
+	// @version 1.33
 	constant oskeytype OSKEY_OEM_WSCTRL = ConvertOsKeyType($EE)
-	//键盘 ATTN 键（OEM 键），该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 ATTN 键（OEM 键）
+	// @version 1.33
 	constant oskeytype OSKEY_OEM_CUSEL = ConvertOsKeyType($EF)
-	//键盘 ATTN 键（OEM 键），该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 ATTN 键（OEM 键）
+	// @version 1.33
 	constant oskeytype OSKEY_OEM_ATTN = ConvertOsKeyType($F0)
-	//键盘 完成键（OEM 键），该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 完成键（OEM 键）
+	// @version 1.33
 	constant oskeytype OSKEY_OEM_FINISH = ConvertOsKeyType($F1)
-	//键盘 复制键（OEM 键），该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 复制键（OEM 键）
+	// @version 1.33
 	constant oskeytype OSKEY_OEM_COPY = ConvertOsKeyType($F2)
-	//键盘 自动键（OEM 键），该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 自动键（OEM 键）
+	// @version 1.33
 	constant oskeytype OSKEY_OEM_AUTO = ConvertOsKeyType($F3)
-	//键盘 ENLW 键（OEM 键），该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 ENLW 键（OEM 键）
+	// @version 1.33
 	constant oskeytype OSKEY_OEM_ENLW = ConvertOsKeyType($F4)
-	//键盘 BACKTAB 键（OEM 键），该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 BACKTAB 键（OEM 键）
+	// @version 1.33
 	constant oskeytype OSKEY_OEM_BACKTAB = ConvertOsKeyType($F5)
-	//键盘 ATTN 键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 ATTN 键
+	// @version 1.33
 	constant oskeytype OSKEY_ATTN = ConvertOsKeyType($F6)
-	//键盘 CRSEL 键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 CRSEL 键
+	// @version 1.33
 	constant oskeytype OSKEY_CRSEL = ConvertOsKeyType($F7)
-	//键盘 CRSEL 键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 CRSEL 键
+	// @version 1.33
 	constant oskeytype OSKEY_EXSEL = ConvertOsKeyType($F8)
-	//键盘 CRSEL 键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 CRSEL 键
+	// @version 1.33
 	constant oskeytype OSKEY_EREOF = ConvertOsKeyType($F9)
-	//键盘 播放键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 播放键
+	// @version 1.33
 	constant oskeytype OSKEY_PLAY = ConvertOsKeyType($FA)
-	//键盘 缩放键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 缩放键
+	// @version 1.33
 	constant oskeytype OSKEY_ZOOM = ConvertOsKeyType($FB)
-	//键盘 留待将来使用的常数键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 留待将来使用的常数键
+	// @version 1.33
 	constant oskeytype OSKEY_NONAME = ConvertOsKeyType($FC)
-	//键盘 PA1 键，该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 PA1 键
+	// @version 1.33
 	constant oskeytype OSKEY_PA1 = ConvertOsKeyType($FD)
-	//键盘 清理键（OEM 键），该函数在1.31及以上版本可用，1.29及以下版本不可用，1.30及1.30.2未验证
+	//键盘 清理键（OEM 键）
+	// @version 1.33
 	constant oskeytype OSKEY_OEM_CLEAR = ConvertOsKeyType($FE)
 	
 	
@@ -3528,7 +3716,7 @@ native GroupTargetOrderById takes group whichGroup, integer order, widget target
 // and removes them if they leave...
 // 选取指定单位组做多个动作
 native ForGroup takes group whichGroup, code callback returns nothing
-// 单位组中第一个单位
+// 获取单位组中第一个单位
 native FirstOfGroup takes group whichGroup returns unit
 
 
@@ -3548,8 +3736,8 @@ native BlzForceHasPlayer takes force whichForce, player whichPlayer returns bool
 native ForceClear takes force whichForce returns nothing
 // 匹配玩家
 native ForceEnumPlayers takes force whichForce, boolexpr filter returns nothing
-// 匹配玩家
-// @param countLimit 上限
+// 匹配玩家（指定上限）
+// @param countLimit
 native ForceEnumPlayersCounted takes force whichForce, boolexpr filter, integer countLimit returns nothing
 // 匹配联盟
 native ForceEnumAllies takes force whichForce, player whichPlayer, boolexpr filter returns nothing
@@ -3947,19 +4135,24 @@ constant native GetManipulatedItem takes nothing returns item
 // For EVENT_PLAYER_UNIT_PICKUP_ITEM, returns the item absorbing the picked up item in case it is stacking.
 // Returns null if the item was a powerup and not a stacking item.
 
-// 获取吸收被操作物品的物品 @version 1.33
+// 获取吸收被操作物品的物品 
+// @version 1.33
 constant native BlzGetAbsorbingItem takes nothing returns item
-// 获取被操作的物品被吸收 @version 1.33
+// 获取被操作的物品被吸收 
+// @version 1.33
 constant native BlzGetManipulatedItemWasAbsorbed takes nothing returns boolean
 
 // EVENT_PLAYER_UNIT_STACK_ITEM
 // Source is the item that is losing charges, Target is the item getting charges.
 	
-// 获取堆叠源物品 @version 1.33
+// 获取堆叠源物品 
+// @version 1.33
 constant native BlzGetStackingItemSource takes nothing returns item
-// 获取堆叠目标物品 @version 1.33
+// 获取堆叠目标物品 
+// @version 1.33
 constant native BlzGetStackingItemTarget takes nothing returns item
-// 获取堆叠物品的预期售价 @version 1.33
+// 获取堆叠物品的预期售价 
+// @version 1.33
 constant native BlzGetStackingItemTargetPreviousCharges takes nothing returns integer
 //endregion
 
@@ -6465,9 +6658,11 @@ native BlzFrameSetFont takes framehandle frame, string fileName, real height, in
 // 设置frame字体对齐方式
 native BlzFrameSetTextAlignment takes framehandle frame, textaligntype vert, textaligntype horz returns nothing
 
-// 获取Frame子组件数量 (1.32.7)
+// 获取Frame子组件数量
+// @version 1.32.7
 native BlzFrameGetChildrenCount takes framehandle frame returns integer
-// 获取Frame子组件 (1.32.7)
+// 获取Frame子组件 
+// @version 1.32.7
 native BlzFrameGetChild takes framehandle frame, integer index returns framehandle
 
 

--- a/static/common.j
+++ b/static/common.j
@@ -426,7 +426,7 @@ globals
 	constant alliancetype ALLIANCE_PASSIVE = ConvertAllianceType(0)
 	// 联盟类型 帮助请求
 	constant alliancetype ALLIANCE_HELP_REQUEST = ConvertAllianceType(1)
-	// 联盟类型 帮助回答
+	// 联盟类型 帮助请求响应
 	constant alliancetype ALLIANCE_HELP_RESPONSE = ConvertAllianceType(2)
 	// 联盟类型 共享经验值
 	constant alliancetype ALLIANCE_SHARED_XP = ConvertAllianceType(3)
@@ -434,9 +434,9 @@ globals
 	constant alliancetype ALLIANCE_SHARED_SPELLS = ConvertAllianceType(4)
 	// 联盟类型 共享视野
 	constant alliancetype ALLIANCE_SHARED_VISION = ConvertAllianceType(5)
-	// 联盟类型 共享单位
+	// 联盟类型 共享单位控制
 	constant alliancetype ALLIANCE_SHARED_CONTROL = ConvertAllianceType(6)
-	// 联盟类型 完全共享单位
+	// 联盟类型 完全共享单位控制
 	constant alliancetype ALLIANCE_SHARED_ADVANCED_CONTROL = ConvertAllianceType(7)
 	// 联盟类型 可营救
 	constant alliancetype ALLIANCE_RESCUABLE = ConvertAllianceType(8)
@@ -602,7 +602,7 @@ globals
 	constant subanimtype SUBANIM_TYPE_ROOTED = ConvertSubAnimType(11)
 	// 子动画类型 - 生长（古树）
 	constant subanimtype SUBANIM_TYPE_ALTERNATE_EX = ConvertSubAnimType(12)
-	// 子动画类型 - 循环（可能是无操作时的默认动作）
+	// 子动画类型 - 循环（可能是无操作时的默认动画）
 	constant subanimtype SUBANIM_TYPE_LOOPING = ConvertSubAnimType(13)
 	// 子动画类型 - 猛击
 	constant subanimtype SUBANIM_TYPE_SLAM = ConvertSubAnimType(14)
@@ -3366,7 +3366,7 @@ globals
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_DELAY = ConvertAbilityRealLevelField('Nst5')
     // 技能实数等级域 施法持续时间 ('Ncl1')
 	constant abilityreallevelfield ABILITY_RLF_FOLLOW_THROUGH_TIME = ConvertAbilityRealLevelField('Ncl1')
-    // 技能实数等级域 动作持续时间 ('Ncl4')
+    // 技能实数等级域 技能持续时间 ('Ncl4')
 	constant abilityreallevelfield ABILITY_RLF_ART_DURATION = ConvertAbilityRealLevelField('Ncl4')
     // 技能实数等级域 移动速度增加（%） ('Nab1')
 	constant abilityreallevelfield ABILITY_RLF_MOVEMENT_SPEED_REDUCTION_PERCENT_NAB1 = ConvertAbilityRealLevelField('Nab1')
@@ -4362,10 +4362,10 @@ native GroupEnumUnitsOfPlayer takes group whichGroup, player whichPlayer, boolex
 // @param filter过滤，不建议使用在AI脚本中，即filter写成null
 // @param countLimit 数量上限
 native GroupEnumUnitsOfTypeCounted takes group whichGroup, string unitname, boolexpr filter, integer countLimit returns nothing
-// 将指定方形区域的的单位加入单位组
+// 将指定矩形区域的的单位加入单位组
 // @param filter过滤，不建议使用在AI脚本中，即filter写成null
 native GroupEnumUnitsInRect takes group whichGroup, rect r, boolexpr filter returns nothing
-// 将指定方形区域的的单位加入单位组，同时指定添加单位的数量上限
+// 将指定矩形区域的的单位加入单位组，同时指定添加单位的数量上限
 // @param filter过滤，不建议使用在AI脚本中，即filter写成null
 // @param countLimit 数量上限
 native GroupEnumUnitsInRectCounted takes group whichGroup, rect r, boolexpr filter, integer countLimit returns nothing
@@ -4763,7 +4763,7 @@ constant native GetConstructingStructure takes nothing returns unit
 
 // EVENT_PLAYER_UNIT_CONSTRUCT_FINISH
 // EVENT_PLAYER_UNIT_CONSTRUCT_CANCEL
-// 获取取消建造中的建筑
+// 获取取消建造的建筑
 constant native GetCancelledStructure takes nothing returns unit
 // 获取已建造的建筑
 constant native GetConstructedStructure takes nothing returns unit
@@ -5538,7 +5538,7 @@ native UnitSetConstructionProgress takes unit whichUnit, integer constructionPer
 native UnitSetUpgradeProgress takes unit whichUnit, integer upgradePercentage returns nothing
 // 暂停/恢复生命周期 [R]
 native UnitPauseTimedLife takes unit whichUnit, boolean flag returns nothing
-// 设置单位小地图图标
+// 启用/禁用 单位的小地图图标
 native UnitSetUsesAltIcon takes unit whichUnit, boolean flag returns nothing
 
 // 伤害区域 [R]
@@ -5710,7 +5710,7 @@ constant native GetPlayerHandicap takes player whichPlayer returns real
 constant native GetPlayerHandicapXP takes player whichPlayer returns real
 // 玩家障碍恢复时间
 constant native GetPlayerHandicapReviveTime takes player whichPlayer returns real
-// 获取玩家损伤
+// 获取玩家损伤障碍
 constant native GetPlayerHandicapDamage takes player whichPlayer returns real
 // 设置玩家经验上限 [R]
 constant native SetPlayerHandicap takes player whichPlayer, real handicap returns nothing
@@ -5718,7 +5718,7 @@ constant native SetPlayerHandicap takes player whichPlayer, real handicap return
 constant native SetPlayerHandicapXP takes player whichPlayer, real handicap returns nothing
 // 设置玩家障碍恢复时间
 constant native SetPlayerHandicapReviveTime takes player whichPlayer, real handicap returns nothing
-// 设置玩家损伤
+// 设置玩家损伤障碍
 constant native SetPlayerHandicapDamage takes player whichPlayer, real handicap returns nothing
 // 设置玩家的科技上限
 constant native SetPlayerTechMaxAllowed takes player whichPlayer, integer techid, integer maximum returns nothing
@@ -6186,9 +6186,9 @@ native ItemPoolRemoveItemType takes itempool whichItemPool, integer itemId retur
 native PlaceRandomItem takes itempool whichItemPool, real x, real y returns item
 
 // Choose any random unit/item. (NP means Neutral Passive)
-// 随机的中立敌对单位单位类型(有等级)
+// 获取随机中立敌对单位单位类型(指定单位等级)
 native ChooseRandomCreep takes integer level returns integer
-// 随机的中立建筑物类型
+// 获取随机中立建筑物类型
 native ChooseRandomNPBuilding takes nothing returns integer
 // 随机物品-所有等级
 native ChooseRandomItem takes integer level returns integer

--- a/static/common.j
+++ b/static/common.j
@@ -5160,7 +5160,7 @@ native IsItemIdPowerup takes integer itemId returns boolean
 native IsItemIdSellable takes integer itemId returns boolean
 // 物品是否可以抵押
 native IsItemIdPawnable takes integer itemId returns boolean
-// 选取 区域内 所有物品 做动作
+// 选取区域内所有物品做动作
 // @param r区域
 // @param filter过滤
 // @param actionFunc动作
@@ -5169,7 +5169,7 @@ native EnumItemsInRect takes rect r, boolexpr filter, code actionFunc returns no
 native GetItemLevel takes item whichItem returns integer
 // 获取物品类型
 native GetItemType takes item whichItem returns itemtype
-// 设置掉落重生神符的单位类型
+// 设置掉落物品的单位类型
 native SetItemDropID takes item whichItem, integer unitId returns nothing
 // 物品名称
 constant native GetItemName takes item whichItem returns string

--- a/static/common.j
+++ b/static/common.j
@@ -4250,6 +4250,7 @@ constant native GetStartLocationX takes integer whichStartLocation returns real
 constant native GetStartLocationY takes integer whichStartLocation returns real
 // 获取指定开始点的坐标
 // 理论上带入0~11/23的玩家编号即可返回指定玩家的开始点
+// 会生成点，需要排泄
 constant native GetStartLocationLoc takes integer whichStartLocation returns location
 
 
@@ -4493,6 +4494,7 @@ native RegionClearCell takes region whichRegion, real x, real y returns nothing
 native RegionClearCellAtLoc takes region whichRegion, location whichLocation returns nothing
 
 // 将坐标转换成点
+// 会生成点，需要排泄
 native Location takes real x, real y returns location
 // 清除点 [R]
 native RemoveLocation takes location whichLocation returns nothing
@@ -4866,6 +4868,7 @@ constant native GetOrderPointX takes nothing returns real
 // 获取命令目标点 Y 坐标 [R]
 constant native GetOrderPointY takes nothing returns real
 // 获取命令目标点
+// 会生成点，需要排泄
 constant native GetOrderPointLoc takes nothing returns location
 
 // EVENT_PLAYER_UNIT_ISSUED_TARGET_ORDER
@@ -4895,6 +4898,7 @@ constant native GetSpellAbilityId takes nothing returns integer
 // 获取被释放技能
 constant native GetSpellAbility takes nothing returns ability
 // 获取被释放技能目标点
+// 会生成点，需要排泄
 constant native GetSpellTargetLoc takes nothing returns location
 // 获取被释放技能目标点 X 坐标
 constant native GetSpellTargetX takes nothing returns real
@@ -5399,6 +5403,7 @@ constant native GetUnitX takes unit whichUnit returns real
 // 获取指定单位所在 Y 轴坐标 [R]
 constant native GetUnitY takes unit whichUnit returns real
 // 获取指定单位的位置
+// 会生成点，需要排泄
 constant native GetUnitLoc takes unit whichUnit returns location
 // 获取指定单位面向角度
 constant native GetUnitFacing takes unit whichUnit returns real
@@ -5429,6 +5434,7 @@ constant native GetFoodUsed takes integer unitId returns integer
 native SetUnitUseFood takes unit whichUnit, boolean useFood returns nothing
 
 // 获取指定单位的集结点指向的位置（建筑的旗子，集结技能）
+// 会生成点，需要排泄
 constant native GetUnitRallyPoint takes unit whichUnit returns location
 // 获取指定单位集结点指向的单位，仅当集结点指向单位时可正常返回（建筑的旗子，集结技能）
 constant native GetUnitRallyUnit takes unit whichUnit returns unit
@@ -6071,6 +6077,7 @@ native LoadForceHandle takes hashtable table, integer parentKey, integer childKe
 // <1.24> 从哈希表提取单位组 [C]
 native LoadGroupHandle takes hashtable table, integer parentKey, integer childKey returns group
 // <1.24> 从哈希表提取点 [C]
+// 若仍需继续使用该点，请勿排泄
 native LoadLocationHandle takes hashtable table, integer parentKey, integer childKey returns location
 // <1.24> 从哈希表提取区域(矩型) [C]
 native LoadRectHandle takes hashtable table, integer parentKey, integer childKey returns rect
@@ -6581,6 +6588,7 @@ native CameraSetupGetField takes camerasetup whichSetup, camerafield whichField 
 // 设置指定镜头的坐标
 native CameraSetupSetDestPosition takes camerasetup whichSetup, real x, real y, real duration returns nothing
 // 获取指定镜头的目标点
+// 会生成点，需要排泄
 native CameraSetupGetDestPositionLoc takes camerasetup whichSetup returns location
 // 获取指定镜头的 X 坐标
 native CameraSetupGetDestPositionX takes camerasetup whichSetup returns real
@@ -6662,7 +6670,8 @@ constant native GetCameraTargetPositionX takes nothing returns real
 constant native GetCameraTargetPositionY takes nothing returns real
 // 获取当前镜头目标的 Z 坐标
 constant native GetCameraTargetPositionZ takes nothing returns real
-// 获取当前镜头目标点（返回点）
+// 获取当前镜头目标点
+// 会生成点，需要排泄
 constant native GetCameraTargetPositionLoc takes nothing returns location
 // 获取当前镜头观察位置的 X 坐标
 constant native GetCameraEyePositionX takes nothing returns real
@@ -6670,7 +6679,8 @@ constant native GetCameraEyePositionX takes nothing returns real
 constant native GetCameraEyePositionY takes nothing returns real
 // 获取当前镜头观察位置的 Z 坐标
 constant native GetCameraEyePositionZ takes nothing returns real
-// 获取当前照相机的观察位置（返回点）
+// 获取当前照相机的观察位置
+// 会生成点，需要排泄
 constant native GetCameraEyePositionLoc takes nothing returns location
 
 
@@ -7029,11 +7039,12 @@ native AutomationTestEnd takes nothing returns nothing
 native AutomationTestingFinished takes nothing returns nothing
 
 // JAPI Functions
-// 触发鼠标位置 - X
+// 触发鼠标位置 - X 坐标
 native BlzGetTriggerPlayerMouseX takes nothing returns real
-// 触发鼠标位置 - Y
+// 触发鼠标位置 - Y 坐标
 native BlzGetTriggerPlayerMouseY takes nothing returns real
-// 触发鼠标位置
+// 触发鼠标位置 - 点
+// 会生成点，需要排泄
 native BlzGetTriggerPlayerMousePosition takes nothing returns location
 // 触发鼠标按键
 native BlzGetTriggerPlayerMouseButton takes nothing returns mousebuttontype

--- a/static/common.j
+++ b/static/common.j
@@ -892,7 +892,7 @@ globals
 	constant playerstate PLAYER_STATE_RESOURCE_LUMBER = ConvertPlayerState(2)
 	// 玩家英雄数量
 	constant playerstate PLAYER_STATE_RESOURCE_HERO_TOKENS = ConvertPlayerState(3)
-    // 玩家可用人口数（人口建筑提供的数量）
+    // 玩家可用人口数（默认为人口建筑提供的数量）
 	constant playerstate PLAYER_STATE_RESOURCE_FOOD_CAP = ConvertPlayerState(4)
 	// 玩家已用人口数
 	constant playerstate PLAYER_STATE_RESOURCE_FOOD_USED = ConvertPlayerState(5)

--- a/static/common.j
+++ b/static/common.j
@@ -2863,7 +2863,7 @@ globals
 	// Unit
 	// Unit
 
- 	// 单位整数域 战斗 - 护甲类型（普通/小型/中型/大型/城墙/英雄/神圣/无装甲） ('udty')
+ 	// 单位整数域 战斗 - 防御类型（普通/小型/中型/大型/城墙/英雄/神圣/无装甲） ('udty')
 	constant unitintegerfield UNIT_IF_DEFENSE_TYPE = ConvertUnitIntegerField('udty')
 	// 单位整数域 战斗 - 装甲类型（木头/气态/石头/肉体/金属） ('uarm')
 	constant unitintegerfield UNIT_IF_ARMOR_TYPE = ConvertUnitIntegerField('uarm')
@@ -3158,17 +3158,17 @@ globals
 	
 	// Armor Type
 	// Armor Type
-    // 装甲 没有/未知
+    // 装甲类型 没有/未知
  constant armortype ARMOR_TYPE_WHOKNOWS = ConvertArmorType(0)
-    // 装甲 肉体
+    // 装甲类型 肉体
 	constant armortype ARMOR_TYPE_FLESH = ConvertArmorType(1)
-    // 装甲 金属
+    // 装甲类型 金属
 	constant armortype ARMOR_TYPE_METAL = ConvertArmorType(2)
-    // 装甲 木头
+    // 装甲类型 木头
 	constant armortype ARMOR_TYPE_WOOD = ConvertArmorType(3)
-    // 装甲 气态
+    // 装甲类型 气态
 	constant armortype ARMOR_TYPE_ETHREAL = ConvertArmorType(4)
-    // 装甲 石头
+    // 装甲类型 石头
 	constant armortype ARMOR_TYPE_STONE = ConvertArmorType(5)
 	
 	// Regeneration Type
@@ -6276,9 +6276,9 @@ native BlzPlaySpecialEffect takes effect whichEffect, animtype whichAnim returns
 native BlzPlaySpecialEffectWithTimeScale takes effect whichEffect, animtype whichAnim, real timeScale returns nothing
 // 获取动画名
 native BlzGetAnimName takes animtype whichAnim returns string
-// 获取护甲
+// 获取护甲值
 native BlzGetUnitArmor takes unit whichUnit returns real
-// 设置护甲
+// 设置护甲值
 native BlzSetUnitArmor takes unit whichUnit, real armorAmount returns nothing
 // 隐藏技能
 native BlzUnitHideAbility takes unit whichUnit, integer abilId, boolean flag returns nothing

--- a/static/common.j
+++ b/static/common.j
@@ -2926,187 +2926,187 @@ globals
 	constant abilityreallevelfield ABILITY_RLF_INTERVAL_DURATION_EGM2 = ConvertAbilityRealLevelField('Egm2')
     // 技能实数等级域 效果延迟 ('Fla2')
 	constant abilityreallevelfield ABILITY_RLF_EFFECT_DELAY_FLA2 = ConvertAbilityRealLevelField('Fla2')
-    // 技能实数等级域 
+    // 技能实数等级域 采矿持续时间 ('Gld2')
 	constant abilityreallevelfield ABILITY_RLF_MINING_DURATION = ConvertAbilityRealLevelField('Gld2')
-    // 技能实数等级域 
+    // 技能实数等级域 墓碑范围 ('Gyd2')
 	constant abilityreallevelfield ABILITY_RLF_RADIUS_OF_GRAVESTONES = ConvertAbilityRealLevelField('Gyd2')
-    // 技能实数等级域 
+    // 技能实数等级域 尸体范围 ('Gyd3')
 	constant abilityreallevelfield ABILITY_RLF_RADIUS_OF_CORPSES = ConvertAbilityRealLevelField('Gyd3')
-    // 技能实数等级域 
+    // 技能实数等级域 治疗生命值 ('Hea1')
 	constant abilityreallevelfield ABILITY_RLF_HIT_POINTS_GAINED_HEA1 = ConvertAbilityRealLevelField('Hea1')
-    // 技能实数等级域 
+    // 技能实数等级域 攻击增加（%） ('Inf1')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_INCREASE_PERCENT_INF1 = ConvertAbilityRealLevelField('Inf1')
-    // 技能实数等级域 
+    // 技能实数等级域 自动施法范围 ('Inf3')
 	constant abilityreallevelfield ABILITY_RLF_AUTOCAST_RANGE = ConvertAbilityRealLevelField('Inf3')
-    // 技能实数等级域 
+    // 技能实数等级域 生命恢复速度 ('Inf4')
 	constant abilityreallevelfield ABILITY_RLF_LIFE_REGEN_RATE = ConvertAbilityRealLevelField('Inf4')
-    // 技能实数等级域 
+    // 技能实数等级域 效果延迟 ('Lit1')
 	constant abilityreallevelfield ABILITY_RLF_GRAPHIC_DELAY_LIT1 = ConvertAbilityRealLevelField('Lit1')
-    // 技能实数等级域 
+    // 技能实数等级域 效果持续时间 ('Lit2')
 	constant abilityreallevelfield ABILITY_RLF_GRAPHIC_DURATION_LIT2 = ConvertAbilityRealLevelField('Lit2')
-    // 技能实数等级域 
+    // 技能实数等级域 每秒伤害 ('Lsh1')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_PER_SECOND_LSH1 = ConvertAbilityRealLevelField('Lsh1')
-    // 技能实数等级域 
+    // 技能实数等级域 恢复每点魔法所需魔法值 ('Mbt1')
 	constant abilityreallevelfield ABILITY_RLF_MANA_GAINED = ConvertAbilityRealLevelField('Mbt1')
-    // 技能实数等级域 
+    // 技能实数等级域 恢复每点生命所需魔法值 ('Mbt2')
 	constant abilityreallevelfield ABILITY_RLF_HIT_POINTS_GAINED_MBT2 = ConvertAbilityRealLevelField('Mbt2')
-    // 技能实数等级域 
+    // 技能实数等级域 自动施法魔法要求 ('Mbt3')
 	constant abilityreallevelfield ABILITY_RLF_AUTOCAST_REQUIREMENT = ConvertAbilityRealLevelField('Mbt3')
-    // 技能实数等级域 
+    // 技能实数等级域 水面高度 ('Mbt4')
 	constant abilityreallevelfield ABILITY_RLF_WATER_HEIGHT = ConvertAbilityRealLevelField('Mbt4')
-    // 技能实数等级域 
+    // 技能实数等级域 激活延迟 ('Min1')
 	constant abilityreallevelfield ABILITY_RLF_ACTIVATION_DELAY_MIN1 = ConvertAbilityRealLevelField('Min1')
-    // 技能实数等级域 
+    // 技能实数等级域 转换时间 ('Min2')
 	constant abilityreallevelfield ABILITY_RLF_INVISIBILITY_TRANSITION_TIME = ConvertAbilityRealLevelField('Min2')
-    // 技能实数等级域 
+    // 技能实数等级域 激活范围 ('Neu1')
 	constant abilityreallevelfield ABILITY_RLF_ACTIVATION_RADIUS = ConvertAbilityRealLevelField('Neu1')
-    // 技能实数等级域 
+    // 技能实数等级域 每秒恢复值 ('Arm1')
 	constant abilityreallevelfield ABILITY_RLF_AMOUNT_REGENERATED = ConvertAbilityRealLevelField('Arm1')
-    // 技能实数等级域 
+    // 技能实数等级域 每秒伤害 ('Poi1')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_PER_SECOND_POI1 = ConvertAbilityRealLevelField('Poi1')
-    // 技能实数等级域 
+    // 技能实数等级域 攻击速度系数（%） ('Poi2')
 	constant abilityreallevelfield ABILITY_RLF_ATTACK_SPEED_FACTOR_POI2 = ConvertAbilityRealLevelField('Poi2')
-    // 技能实数等级域 
+    // 技能实数等级域 移动速度系数（%） ('Poi3')
 	constant abilityreallevelfield ABILITY_RLF_MOVEMENT_SPEED_FACTOR_POI3 = ConvertAbilityRealLevelField('Poi3')
-    // 技能实数等级域 
+    // 技能实数等级域 额外伤害 ('Poa1')
 	constant abilityreallevelfield ABILITY_RLF_EXTRA_DAMAGE_POA1 = ConvertAbilityRealLevelField('Poa1')
-    // 技能实数等级域 
+    // 技能实数等级域 每秒伤害 ('Poa2')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_PER_SECOND_POA2 = ConvertAbilityRealLevelField('Poa2')
-    // 技能实数等级域 
+    // 技能实数等级域 攻击速度系数 ('Poa3')
 	constant abilityreallevelfield ABILITY_RLF_ATTACK_SPEED_FACTOR_POA3 = ConvertAbilityRealLevelField('Poa3')
-    // 技能实数等级域 
+    // 技能实数等级域 移动速度系数 ('Poa4')
 	constant abilityreallevelfield ABILITY_RLF_MOVEMENT_SPEED_FACTOR_POA4 = ConvertAbilityRealLevelField('Poa4')   
-    // 技能实数等级域 
+    // 技能实数等级域 施法时所受伤害值 ('Pos2')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_AMPLIFICATION = ConvertAbilityRealLevelField('Pos2')
-    // 技能实数等级域 
+    // 技能实数等级域 施放几率 ('War1')
 	constant abilityreallevelfield ABILITY_RLF_CHANCE_TO_STOMP_PERCENT = ConvertAbilityRealLevelField('War1')
-    // 技能实数等级域 
+    // 技能实数等级域 附加伤害 ('War2')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_DEALT_WAR2 = ConvertAbilityRealLevelField('War2')
-    // 技能实数等级域 
+    // 技能实数等级域 全伤害范围 ('War3')
 	constant abilityreallevelfield ABILITY_RLF_FULL_DAMAGE_RADIUS_WAR3 = ConvertAbilityRealLevelField('War3')
-    // 技能实数等级域 
+    // 技能实数等级域 半伤害范围 ('War4')
 	constant abilityreallevelfield ABILITY_RLF_HALF_DAMAGE_RADIUS_WAR4 = ConvertAbilityRealLevelField('War4')
-    // 技能实数等级域 
+    // 技能实数等级域 对召唤单位伤害 ('Prg3')
 	constant abilityreallevelfield ABILITY_RLF_SUMMONED_UNIT_DAMAGE_PRG3 = ConvertAbilityRealLevelField('Prg3')
-    // 技能实数等级域 
+    // 技能实数等级域 单位麻痹时间 ('Prg4')
 	constant abilityreallevelfield ABILITY_RLF_UNIT_PAUSE_DURATION = ConvertAbilityRealLevelField('Prg4')
-    // 技能实数等级域 
+    // 技能实数等级域 英雄麻痹时间 ('Prg5')
 	constant abilityreallevelfield ABILITY_RLF_HERO_PAUSE_DURATION = ConvertAbilityRealLevelField('Prg5')
-    // 技能实数等级域 
+    // 技能实数等级域 生命值恢复 ('Rej1')
 	constant abilityreallevelfield ABILITY_RLF_HIT_POINTS_GAINED_REJ1 = ConvertAbilityRealLevelField('Rej1')
-    // 技能实数等级域 
+    // 技能实数等级域 魔法值恢复 ('Rej2')
 	constant abilityreallevelfield ABILITY_RLF_MANA_POINTS_GAINED_REJ2 = ConvertAbilityRealLevelField('Rej2')
-    // 技能实数等级域 
+    // 技能实数等级域 最小生命需求 ('Rpb3')
 	constant abilityreallevelfield ABILITY_RLF_MINIMUM_LIFE_REQUIRED = ConvertAbilityRealLevelField('Rpb3')
-    // 技能实数等级域 
+    // 技能实数等级域 最小魔法需求 ('Rpb4')
 	constant abilityreallevelfield ABILITY_RLF_MINIMUM_MANA_REQUIRED = ConvertAbilityRealLevelField('Rpb4')
-    // 技能实数等级域 
+    // 技能实数等级域 修理费用比率 ('Rep1')
 	constant abilityreallevelfield ABILITY_RLF_REPAIR_COST_RATIO = ConvertAbilityRealLevelField('Rep1')
-    // 技能实数等级域 
+    // 技能实数等级域 修理时间比率 ('Rep2')
 	constant abilityreallevelfield ABILITY_RLF_REPAIR_TIME_RATIO = ConvertAbilityRealLevelField('Rep2')
-    // 技能实数等级域 
+    // 技能实数等级域 快速建造费用比率 ('Rep3')
 	constant abilityreallevelfield ABILITY_RLF_POWERBUILD_COST = ConvertAbilityRealLevelField('Rep3')
-    // 技能实数等级域 
+    // 技能实数等级域 快速建造时间比率 ('Rep4')
 	constant abilityreallevelfield ABILITY_RLF_POWERBUILD_RATE = ConvertAbilityRealLevelField('Rep4')
-    // 技能实数等级域 
+    // 技能实数等级域 海上修理范围提升 ('Rep5')
 	constant abilityreallevelfield ABILITY_RLF_NAVAL_RANGE_BONUS = ConvertAbilityRealLevelField('Rep5')
-    // 技能实数等级域 
+    // 技能实数等级域 攻击增加（%） ('Roa1')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_INCREASE_PERCENT_ROA1 = ConvertAbilityRealLevelField('Roa1')
-    // 技能实数等级域 
+    // 技能实数等级域 生命恢复速度 ('Roa3')
 	constant abilityreallevelfield ABILITY_RLF_LIFE_REGENERATION_RATE = ConvertAbilityRealLevelField('Roa3')
-    // 技能实数等级域 
+    // 技能实数等级域 魔法再生 ('Roa4')
 	constant abilityreallevelfield ABILITY_RLF_MANA_REGEN = ConvertAbilityRealLevelField('Roa4')
-    // 技能实数等级域 
+    // 技能实数等级域 攻击增加 ('Nbr1')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_INCREASE = ConvertAbilityRealLevelField('Nbr1')
-    // 技能实数等级域 
+    // 技能实数等级域 掠夺比率 ('Sal1')
 	constant abilityreallevelfield ABILITY_RLF_SALVAGE_COST_RATIO = ConvertAbilityRealLevelField('Sal1')
-    // 技能实数等级域 
+    // 技能实数等级域 飞行视野范围 ('Esn1')
 	constant abilityreallevelfield ABILITY_RLF_IN_FLIGHT_SIGHT_RADIUS = ConvertAbilityRealLevelField('Esn1')
-    // 技能实数等级域 
+    // 技能实数等级域 盘踞视野范围 ('Esn2')
 	constant abilityreallevelfield ABILITY_RLF_HOVERING_SIGHT_RADIUS = ConvertAbilityRealLevelField('Esn2')
-    // 技能实数等级域 
+    // 技能实数等级域 盘踞高度 ('Esn3')
 	constant abilityreallevelfield ABILITY_RLF_HOVERING_HEIGHT = ConvertAbilityRealLevelField('Esn3')
-    // 技能实数等级域 
+    // 技能实数等级域 猫头鹰的持续时间 ('Esn5')
 	constant abilityreallevelfield ABILITY_RLF_DURATION_OF_OWLS = ConvertAbilityRealLevelField('Esn5')
-    // 技能实数等级域 
+    // 技能实数等级域 淡化转换时间 ('Shm1')
 	constant abilityreallevelfield ABILITY_RLF_FADE_DURATION = ConvertAbilityRealLevelField('Shm1')
-    // 技能实数等级域 
+    // 技能实数等级域 昼夜交替转换时间 ('Shm2')
 	constant abilityreallevelfield ABILITY_RLF_DAY_NIGHT_DURATION = ConvertAbilityRealLevelField('Shm2')
-    // 技能实数等级域 
+    // 技能实数等级域 行动转换时间 ('Shm3')
 	constant abilityreallevelfield ABILITY_RLF_ACTION_DURATION = ConvertAbilityRealLevelField('Shm3')
-    // 技能实数等级域 
+    // 技能实数等级域 降低移动速度系数（%） ('Slo1')
 	constant abilityreallevelfield ABILITY_RLF_MOVEMENT_SPEED_FACTOR_SLO1 = ConvertAbilityRealLevelField('Slo1')
-    // 技能实数等级域 
+    // 技能实数等级域 降低攻击速度系数（%） ('Slo2')
 	constant abilityreallevelfield ABILITY_RLF_ATTACK_SPEED_FACTOR_SLO2 = ConvertAbilityRealLevelField('Slo2')
-    // 技能实数等级域 
+    // 技能实数等级域 每秒伤害 ('Spo1')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_PER_SECOND_SPO1 = ConvertAbilityRealLevelField('Spo1')
-    // 技能实数等级域 
+    // 技能实数等级域 降低移动速度系数（%） ('Spo2')
 	constant abilityreallevelfield ABILITY_RLF_MOVEMENT_SPEED_FACTOR_SPO2 = ConvertAbilityRealLevelField('Spo2')
-    // 技能实数等级域 
+    // 技能实数等级域 降低攻击速度系数（%） ('Spo3')
 	constant abilityreallevelfield ABILITY_RLF_ATTACK_SPEED_FACTOR_SPO3 = ConvertAbilityRealLevelField('Spo3')
-    // 技能实数等级域 
+    // 技能实数等级域 激活延迟 ('Sta1')
 	constant abilityreallevelfield ABILITY_RLF_ACTIVATION_DELAY_STA1 = ConvertAbilityRealLevelField('Sta1')
-    // 技能实数等级域 
+    // 技能实数等级域 侦察范围 ('Sta2')
 	constant abilityreallevelfield ABILITY_RLF_DETECTION_RADIUS_STA2 = ConvertAbilityRealLevelField('Sta2')
-    // 技能实数等级域 
+    // 技能实数等级域 爆炸范围 ('Sta3')
 	constant abilityreallevelfield ABILITY_RLF_DETONATION_RADIUS = ConvertAbilityRealLevelField('Sta3')
-    // 技能实数等级域 
+    // 技能实数等级域 眩晕持续时间 ('Sta4')
 	constant abilityreallevelfield ABILITY_RLF_STUN_DURATION_STA4 = ConvertAbilityRealLevelField('Sta4')
-    // 技能实数等级域 
+    // 技能实数等级域 攻击速度奖励（%） ('Uhf1')
 	constant abilityreallevelfield ABILITY_RLF_ATTACK_SPEED_BONUS_PERCENT = ConvertAbilityRealLevelField('Uhf1')
-    // 技能实数等级域 
+    // 技能实数等级域 每秒伤害 ('Uhf2')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_PER_SECOND_UHF2 = ConvertAbilityRealLevelField('Uhf2')
-    // 技能实数等级域 
+    // 技能实数等级域 采集木材数/间隔 ('Wha1')
 	constant abilityreallevelfield ABILITY_RLF_LUMBER_PER_INTERVAL = ConvertAbilityRealLevelField('Wha1')
-    // 技能实数等级域 
+    // 技能实数等级域 附着点高度 ('Wha3')
 	constant abilityreallevelfield ABILITY_RLF_ART_ATTACHMENT_HEIGHT = ConvertAbilityRealLevelField('Wha3')
-    // 技能实数等级域 
+    // 技能实数等级域 传送区域宽度 ('Wrp1')
 	constant abilityreallevelfield ABILITY_RLF_TELEPORT_AREA_WIDTH = ConvertAbilityRealLevelField('Wrp1')
-    // 技能实数等级域 
+    // 技能实数等级域 传送区域高度 ('Wrp2')
 	constant abilityreallevelfield ABILITY_RLF_TELEPORT_AREA_HEIGHT = ConvertAbilityRealLevelField('Wrp2')
-    // 技能实数等级域 
+    // 技能实数等级域 攻击偷取生命（%） ('Ivam')
 	constant abilityreallevelfield ABILITY_RLF_LIFE_STOLEN_PER_ATTACK = ConvertAbilityRealLevelField('Ivam')
-    // 技能实数等级域 
+    // 技能实数等级域 附加伤害 ('Idam')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_BONUS_IDAM = ConvertAbilityRealLevelField('Idam')
-    // 技能实数等级域 
+    // 技能实数等级域 击中单位几率 ('Iob2')
 	constant abilityreallevelfield ABILITY_RLF_CHANCE_TO_HIT_UNITS_PERCENT = ConvertAbilityRealLevelField('Iob2')
-    // 技能实数等级域 
+    // 技能实数等级域 击中英雄几率 ('Iob3')
 	constant abilityreallevelfield ABILITY_RLF_CHANCE_TO_HIT_HEROS_PERCENT = ConvertAbilityRealLevelField('Iob3')
-    // 技能实数等级域 
+    // 技能实数等级域 击中召唤物几率 ('Iob4')
 	constant abilityreallevelfield ABILITY_RLF_CHANCE_TO_HIT_SUMMONS_PERCENT = ConvertAbilityRealLevelField('Iob4')
-    // 技能实数等级域 
+    // 技能实数等级域 目标效果延迟 ('Idel')
 	constant abilityreallevelfield ABILITY_RLF_DELAY_FOR_TARGET_EFFECT = ConvertAbilityRealLevelField('Idel')
-    // 技能实数等级域 
+    // 技能实数等级域 施加伤害（%） ('Iild')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_DEALT_PERCENT_OF_NORMAL = ConvertAbilityRealLevelField('Iild')
-    // 技能实数等级域 
+    // 技能实数等级域 受到伤害倍数 ('Iilw')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_RECEIVED_MULTIPLIER = ConvertAbilityRealLevelField('Iilw')
-    // 技能实数等级域 
+    // 技能实数等级域 魔法回复奖励 ('Imrp')
 	constant abilityreallevelfield ABILITY_RLF_MANA_REGENERATION_BONUS_AS_FRACTION_OF_NORMAL = ConvertAbilityRealLevelField('Imrp')
-    // 技能实数等级域 
+    // 技能实数等级域 移动速度增加（%） ('Ispi')
 	constant abilityreallevelfield ABILITY_RLF_MOVEMENT_SPEED_INCREASE_ISPI = ConvertAbilityRealLevelField('Ispi')
-    // 技能实数等级域 
+    // 技能实数等级域 每秒伤害 ('Idps')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_PER_SECOND_IDPS = ConvertAbilityRealLevelField('Idps')
-    // 技能实数等级域 
+    // 技能实数等级域 攻击速度增加（% ） ('Cac1')
 	constant abilityreallevelfield ABILITY_RLF_ATTACK_DAMAGE_INCREASE_CAC1 = ConvertAbilityRealLevelField('Cac1')
-    // 技能实数等级域 
+    // 技能实数等级域 每秒伤害 ('Cor1')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_PER_SECOND_COR1 = ConvertAbilityRealLevelField('Cor1')
-    // 技能实数等级域 
+    // 技能实数等级域 攻击速度增加（%） ('Isx1')
 	constant abilityreallevelfield ABILITY_RLF_ATTACK_SPEED_INCREASE_ISX1 = ConvertAbilityRealLevelField('Isx1')
-    // 技能实数等级域 
+    // 技能实数等级域 伤害 ('Wrs1')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_WRS1 = ConvertAbilityRealLevelField('Wrs1')
-    // 技能实数等级域 
+    // 技能实数等级域 地形变形幅度 ('Wrs2')
 	constant abilityreallevelfield ABILITY_RLF_TERRAIN_DEFORMATION_AMPLITUDE = ConvertAbilityRealLevelField('Wrs2')
-    // 技能实数等级域 
+    // 技能实数等级域 伤害 ('Ctc1')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_CTC1 = ConvertAbilityRealLevelField('Ctc1')
-    // 技能实数等级域 
+    // 技能实数等级域 指定目标伤害 ('Ctc2')
 	constant abilityreallevelfield ABILITY_RLF_EXTRA_DAMAGE_TO_TARGET = ConvertAbilityRealLevelField('Ctc2')
-    // 技能实数等级域 
+    // 技能实数等级域 移动速度减少 ('Ctc3')
 	constant abilityreallevelfield ABILITY_RLF_MOVEMENT_SPEED_REDUCTION_CTC3 = ConvertAbilityRealLevelField('Ctc3')
-    // 技能实数等级域 
+    // 技能实数等级域 攻击速度减少 ('Ctc4')
 	constant abilityreallevelfield ABILITY_RLF_ATTACK_SPEED_REDUCTION_CTC4 = ConvertAbilityRealLevelField('Ctc4')
-    // 技能实数等级域 
+    // 技能实数等级域 伤害 ('Ctb1')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_CTB1 = ConvertAbilityRealLevelField('Ctb1')
-    // 技能实数等级域 
+    // 技能实数等级域 魔法施放延迟 ('Uds2')
 	constant abilityreallevelfield ABILITY_RLF_CASTING_DELAY_SECONDS = ConvertAbilityRealLevelField('Uds2')
     // 技能实数等级域 
 	constant abilityreallevelfield ABILITY_RLF_MANA_LOSS_PER_UNIT_DTN1 = ConvertAbilityRealLevelField('Dtn1')

--- a/static/common.j
+++ b/static/common.j
@@ -1,153 +1,288 @@
 
 // Native types. All native functions take extended handle types when
 // possible to help prevent passing bad values to native functions
-//
+// 代理
 type agent extends handle  // all reference counted objects
+// 事件
 type event extends agent  // a reference to an event registration
+// 玩家
 type player extends agent  // a single player reference
+// 目标
+// 可以是任意有生命的互动游戏对象，如单位、物品、可破坏物
 type widget extends agent  // an interactive game object with life
+// 单位
 type unit extends widget  // a single unit reference
+// 可破坏物
 type destructable extends widget
+// 物品
 type item extends widget
+// 技能
 type ability extends agent
+// 魔法效果
 type buff extends ability
+// 玩家组
 type force extends agent
+// 单位组
 type group extends agent
+// 触发器
 type trigger extends agent
+// 触发器条件
 type triggercondition extends agent
+// 触发器动作
 type triggeraction extends handle
+// 计时器
 type timer extends agent
+// 点
 type location extends agent
+// 区域
 type region extends agent
+// 矩形
 type rect extends agent
+// 条件表达式
 type boolexpr extends agent
+// 声音
 type sound extends agent
+// 条件
 type conditionfunc extends boolexpr
+// 过滤
 type filterfunc extends boolexpr
+// 单位池
 type unitpool extends handle
+// 物品池
 type itempool extends handle
+// 种族
 type race extends handle
+// 联盟类型
 type alliancetype extends handle
+// 种族偏好
 type racepreference extends handle
+// 游戏状态
 type gamestate extends handle
+// 游戏整数状态
 type igamestate extends gamestate
+// 游戏浮动状态
 type fgamestate extends gamestate
+// 玩家状态
 type playerstate extends handle
+// 玩家得分
 type playerscore extends handle
+// 玩家游戏结果
 type playergameresult extends handle
+// 单位状态
 type unitstate extends handle
+// AI难度
 type aidifficulty extends handle
 
+// 事件ID
 type eventid extends handle
+// 游戏事件
 type gameevent extends eventid
+// 玩家事件
 type playerevent extends eventid
+// 玩家单位事件
 type playerunitevent extends eventid
+// 单位事件
 type unitevent extends eventid
+// 比较事件
 type limitop extends eventid
+// 目标事件
 type widgetevent extends eventid
+// 对话框事件
 type dialogevent extends eventid
+// 单位类型
 type unittype extends handle
 
+// 游戏速度
 type gamespeed extends handle
+// 游戏难度
 type gamedifficulty extends handle
+// 游戏类型
 type gametype extends handle
+// 地图参数
 type mapflag extends handle
+// 地图可见性
 type mapvisibility extends handle
+// 地图设置
 type mapsetting extends handle
+// 地图密度
 type mapdensity extends handle
+// 玩家控制者
 type mapcontrol extends handle
+// 小地图标志
 type minimapicon extends handle
+// 玩家槽状态
 type playerslotstate extends handle
+// 音量组
 type volumegroup extends handle
+// 镜头属性
 type camerafield extends handle
+// 镜头
 type camerasetup extends handle
+// 玩家颜色
 type playercolor extends handle
+// 开始点
 type placement extends handle
+// 开始点优先级
 type startlocprio extends handle
+// 罕见动画控制
 type raritycontrol extends handle
+// 混合模式
 type blendmode extends handle
+// 纹理贴图标志
 type texmapflags extends handle
+// 特效
 type effect extends agent
+// 特效类型
 type effecttype extends handle
+// 天气特效
 type weathereffect extends handle
+// 地形变化
 type terraindeformation extends handle
+// 迷雾状态
 type fogstate extends handle
+// 可见度修整器
 type fogmodifier extends agent
+// 对话框
 type dialog extends agent
+// 按钮
 type button extends agent
+// 任务
 type quest extends agent
+// 任务要求
 type questitem extends agent
+// 任务失败条件
 type defeatcondition extends agent
+// 计时器窗口
 type timerdialog extends agent
+// 排行榜
 type leaderboard extends agent
+// 多面板
 type multiboard extends agent
+// 多面板项目
 type multiboarditem extends agent
+// 可追踪物
 type trackable extends agent
+// 游戏缓存
 type gamecache extends agent
+// 版本
+// 混乱之治 或 冰封王座
 type version extends handle
+// 物品类型
 type itemtype extends handle
+// 漂浮文字
 type texttag extends handle
+// 攻击类型
 type attacktype extends handle
+// 伤害类型
 type damagetype extends handle
+// 武器类型
 type weapontype extends handle
+// 声音类型
 type soundtype extends handle
+// 闪电效果
 type lightning extends handle
+// 路径类型
 type pathingtype extends handle
+// 鼠标按键类型
 type mousebuttontype extends handle
+// 动画类型
 type animtype extends handle
+// 子动画类型
 type subanimtype extends handle
+// 图像
 type image extends handle
+// 地表纹理
 type ubersplat extends handle
-type hashtable extends agent
+// 哈希表
+type hashtable extends 
+// 框架/UI
 type framehandle extends handle
+// 原生框架/原生UI类型
 type originframetype extends handle
+// 原生框架/原生UI相对位置
 type framepointtype extends handle
+// 文本对齐方式
 type textaligntype extends handle
+// 框架/UI事件类型
 type frameeventtype extends handle
+// 键盘按键类型
 type oskeytype extends handle
+// 技能整数域
 type abilityintegerfield extends handle
+// 技能实数域
 type abilityrealfield extends handle
+// 技能布尔值域
 type abilitybooleanfield extends handle
+// 技能字串符域
 type abilitystringfield extends handle
+// 技能随等级改变的整数域
 type abilityintegerlevelfield extends handle
+// 技能随等级改变的实数域
 type abilityreallevelfield extends handle
+// 技能随等级改变的布尔值域
 type abilitybooleanlevelfield extends handle
+// 技能随等级改变的字串符域
 type abilitystringlevelfield extends handle
+// 技能随等级改变的整数数组域
 type abilityintegerlevelarrayfield extends handle
+// 技能随等级改变的实数数组域
 type abilityreallevelarrayfield extends handle
+// 技能随等级改变的布尔值数组域
 type abilitybooleanlevelarrayfield extends handle
+// 技能随等级改变的字串符数组域
 type abilitystringlevelarrayfield extends handle
+// 单位整数域
 type unitintegerfield extends handle
+// 单位实数域
 type unitrealfield extends handle
+// 单位布尔值域
 type unitbooleanfield extends handle
+// 单位字串符域
 type unitstringfield extends handle
+// 单位武器整数域
 type unitweaponintegerfield extends handle
+// 单位武器实数域
 type unitweaponrealfield extends handle
+// 单位武器布尔值域
 type unitweaponbooleanfield extends handle
+// 单位武器字串符域
 type unitweaponstringfield extends handle
+// 物品整数域
 type itemintegerfield extends handle
+// 物品实数域
 type itemrealfield extends handle
+// 物品布尔值域
 type itembooleanfield extends handle
+// 物品字串符域
 type itemstringfield extends handle
+// 移动类型
 type movetype extends handle
+// 目标甲类型
 type targetflag extends handle
+// 装甲类型
 type armortype extends handle
+// 英雄属性
 type heroattribute extends handle
+// 防御类型
 type defensetype extends handle
+// 生命恢复类型
 type regentype extends handle
+// 单位类别
 type unitcategory extends handle
+// 放置要求（默认用于建筑物）
 type pathingflag extends handle
+// 特效按钮
 type commandbuttoneffect extends handle
 
 // 转换种族
 constant native ConvertRace takes integer i returns race
 // 转换联盟类型
 constant native ConvertAllianceType takes integer i returns alliancetype
-// 转换种族
+// 转换种族偏好
 constant native ConvertRacePref takes integer i returns racepreference
-// 转换I游戏状态
+// 转换游戏整数状态
 constant native ConvertIGameState takes integer i returns igamestate
-// 转换F游戏状态
+// 转换浮动游戏状态
 constant native ConvertFGameState takes integer i returns fgamestate
 // 玩家状态转换
 constant native ConvertPlayerState takes integer i returns playerstate
@@ -171,21 +306,21 @@ constant native ConvertWidgetEvent takes integer i returns widgetevent
 constant native ConvertDialogEvent takes integer i returns dialogevent
 // 转换单位事件
 constant native ConvertUnitEvent takes integer i returns unitevent
-// 转换限制操作
+// 转换比较
 constant native ConvertLimitOp takes integer i returns limitop
 // 转换单位类型
 constant native ConvertUnitType takes integer i returns unittype
 // 转换游戏速度
 constant native ConvertGameSpeed takes integer i returns gamespeed
-// 转换位置
+// 转换开始点
 constant native ConvertPlacement takes integer i returns placement
-// 转换起始位置优先
+// 转换开始点优先级
 constant native ConvertStartLocPrio takes integer i returns startlocprio
 // 转换游戏难度
 constant native ConvertGameDifficulty takes integer i returns gamedifficulty
 // 转换游戏类型
 constant native ConvertGameType takes integer i returns gametype
-// 转换地图标记
+// 转换地图参数
 constant native ConvertMapFlag takes integer i returns mapflag
 // 转换地图可见性
 constant native ConvertMapVisibility takes integer i returns mapvisibility
@@ -193,11 +328,11 @@ constant native ConvertMapVisibility takes integer i returns mapvisibility
 constant native ConvertMapSetting takes integer i returns mapsetting
 // 转换地图密度
 constant native ConvertMapDensity takes integer i returns mapdensity
-// 转换地图控制器
+// 转换玩家控制者类型
 constant native ConvertMapControl takes integer i returns mapcontrol
 // 转换玩家颜色
 constant native ConvertPlayerColor takes integer i returns playercolor
-// 转换玩家位置状态
+// 转换玩家槽状态
 constant native ConvertPlayerSlotState takes integer i returns playerslotstate
 // 转换音量组
 constant native ConvertVolumeGroup takes integer i returns volumegroup
@@ -205,7 +340,7 @@ constant native ConvertVolumeGroup takes integer i returns volumegroup
 constant native ConvertCameraField takes integer i returns camerafield
 // 转换混合模式
 constant native ConvertBlendMode takes integer i returns blendmode
-// 转换罕见的控制
+// 转换罕见动画控制
 constant native ConvertRarityControl takes integer i returns raritycontrol
 // 转换纹理贴图标志
 constant native ConvertTexMapFlags takes integer i returns texmapflags
@@ -251,21 +386,21 @@ constant native ConvertAbilityRealField takes integer i returns abilityrealfield
 constant native ConvertAbilityBooleanField takes integer i returns abilitybooleanfield
 // 转换技能字符串域
 constant native ConvertAbilityStringField takes integer i returns abilitystringfield
-// 转换技能整数等级域
+// 转换技能随等级改变的整数域
 constant native ConvertAbilityIntegerLevelField takes integer i returns abilityintegerlevelfield
-// 转换技能实数等级域
+// 转换技能随等级改变的实数域
 constant native ConvertAbilityRealLevelField takes integer i returns abilityreallevelfield
-// 转换技能布尔等级域
+// 转换技能随等级改变的布尔值域
 constant native ConvertAbilityBooleanLevelField takes integer i returns abilitybooleanlevelfield
-// 转换技能字符串等级域
+// 转换技能随等级改变的字符串域
 constant native ConvertAbilityStringLevelField takes integer i returns abilitystringlevelfield
-// 转换技能整数等级数组域
+// 转换技能随等级改变的整数数组域
 constant native ConvertAbilityIntegerLevelArrayField takes integer i returns abilityintegerlevelarrayfield
-// 转换技能实数等级数组域
+// 转换技能随等级改变的实数数组域
 constant native ConvertAbilityRealLevelArrayField takes integer i returns abilityreallevelarrayfield
-// 转换技能布尔值等级数组域
+// 转换技能随等级改变的布尔值数组域
 constant native ConvertAbilityBooleanLevelArrayField takes integer i returns abilitybooleanlevelarrayfield
-// 转换技能字符串等级数组域
+// 转换技能随等级改变的字符串数组域
 constant native ConvertAbilityStringLevelArrayField takes integer i returns abilitystringlevelarrayfield
 // 转换单位整数域
 constant native ConvertUnitIntegerField takes integer i returns unitintegerfield
@@ -422,7 +557,7 @@ globals
 	constant playergameresult PLAYER_GAME_RESULT_TIE = ConvertPlayerGameResult(2)
 	// 玩家游戏结果 不确定
 	constant playergameresult PLAYER_GAME_RESULT_NEUTRAL = ConvertPlayerGameResult(3)
-	// 联盟类型 被动联盟（结盟不侵略）
+	// 联盟类型 被动联盟（联盟不侵略）
 	constant alliancetype ALLIANCE_PASSIVE = ConvertAllianceType(0)
 	// 联盟类型 帮助请求
 	constant alliancetype ALLIANCE_HELP_REQUEST = ConvertAllianceType(1)
@@ -766,9 +901,9 @@ globals
 	constant mapflag MAP_LOCK_RESOURCE_TRADING = ConvertMapFlag(256)
 	// 地图 - 容许联盟资源交易
 	constant mapflag MAP_RESOURCE_TRADING_ALLIES_ONLY = ConvertMapFlag(512)
-	// 地图 - 禁止改变联盟类型
+	// 地图 - 禁止变更联盟类型
 	constant mapflag MAP_LOCK_ALLIANCE_CHANGES = ConvertMapFlag(1024)
-	// 地图 - 隐藏联盟类型改变
+	// 地图 - 隐藏联盟类型变更
 	constant mapflag MAP_ALLIANCE_CHANGES_HIDDEN = ConvertMapFlag(2048)
 	// 地图 - 允许作弊码
 	constant mapflag MAP_CHEATS = ConvertMapFlag(4096)
@@ -794,11 +929,11 @@ globals
 	constant placement MAP_PLACEMENT_USE_MAP_SETTINGS = ConvertPlacement(2)   // whatever was specified by the script
 	// 地图 - 联盟玩家开始点放在一起
 	constant placement MAP_PLACEMENT_TEAMS_TOGETHER = ConvertPlacement(3)   // random with allies next to each other
-	// 起始位置分布优先权-低
+	// 开始点分布优先权-低
 	constant startlocprio MAP_LOC_PRIO_LOW = ConvertStartLocPrio(0)
-	// 起始位置分布优先权-高
+	// 开始点分布优先权-高
 	constant startlocprio MAP_LOC_PRIO_HIGH = ConvertStartLocPrio(1)
-	// 起始位置分布优先权-无
+	// 开始点分布优先权-无
 	constant startlocprio MAP_LOC_PRIO_NOT = ConvertStartLocPrio(2)
 	// 地图 - 无密度
 	constant mapdensity MAP_DENSITY_NONE = ConvertMapDensity(0)
@@ -827,11 +962,11 @@ globals
 	constant gamespeed MAP_SPEED_FAST = ConvertGameSpeed(3)
 	// 游戏速度 最快速
 	constant gamespeed MAP_SPEED_FASTEST = ConvertGameSpeed(4)
-	// 玩家游戏状态 没有使用（该位置没有玩家）
+	// 玩家插槽状态 没有使用（该位置没有玩家）
 	constant playerslotstate PLAYER_SLOT_STATE_EMPTY = ConvertPlayerSlotState(0)
-	// 玩家游戏状态 正在游戏
+	// 玩家插槽状态 正在游戏
 	constant playerslotstate PLAYER_SLOT_STATE_PLAYING = ConvertPlayerSlotState(1)
-	// 玩家游戏状态 已离开游戏
+	// 玩家插槽状态 已离开游戏
 	constant playerslotstate PLAYER_SLOT_STATE_LEFT = ConvertPlayerSlotState(2)
 	
 	
@@ -877,27 +1012,27 @@ globals
 	// For use with TriggerRegister<X>StateEvent
 	//
 	
-	// 游戏状态-干涉
+	// 游戏整数状态 - 神圣干涉
 	constant igamestate GAME_STATE_DIVINE_INTERVENTION = ConvertIGameState(0)
-	// 游戏状态-断开连接
+	// 游戏整数状态 - 断开连接
 	constant igamestate GAME_STATE_DISCONNECTED = ConvertIGameState(1)
-	// 游戏状态-当前时间
+	// 游戏浮动状态 - 当前时间
 	constant fgamestate GAME_STATE_TIME_OF_DAY = ConvertFGameState(2)
-	// 玩家状态-游戏结果
+	// 玩家状态 - 游戏结果
 	constant playerstate PLAYER_STATE_GAME_RESULT = ConvertPlayerState(0)
 	
 	// current resource levels
-	// 玩家当前的黄金数量
+	// 玩家状态 - 当前的黄金数量
 	constant playerstate PLAYER_STATE_RESOURCE_GOLD = ConvertPlayerState(1)
-	// 玩家当前的木材数量
+	// 玩家状态 - 当前的木材数量
 	constant playerstate PLAYER_STATE_RESOURCE_LUMBER = ConvertPlayerState(2)
-	// 玩家当前的英雄数量
+	// 玩家状态 - 当前的英雄数量
 	constant playerstate PLAYER_STATE_RESOURCE_HERO_TOKENS = ConvertPlayerState(3)
-    // 玩家可用人口数（默认为人口建筑提供的数量）
+    // 玩家状态 - 可用人口数（默认为人口建筑提供的数量）
 	constant playerstate PLAYER_STATE_RESOURCE_FOOD_CAP = ConvertPlayerState(4)
-	// 玩家已用人口数
+	// 玩家状态 - 已用人口数
 	constant playerstate PLAYER_STATE_RESOURCE_FOOD_USED = ConvertPlayerState(5)
-	// 玩家人口上限数（平衡常数或触发限制的最大数量），默认为100
+	// 玩家状态 - 人口上限数（平衡常数或触发限制的最大数量），默认为100
 	constant playerstate PLAYER_STATE_FOOD_CAP_CEILING = ConvertPlayerState(6)
 	// 玩家状态 - 给予奖励
 	constant playerstate PLAYER_STATE_GIVES_BOUNTY = ConvertPlayerState(7)
@@ -913,9 +1048,9 @@ globals
 	constant playerstate PLAYER_STATE_UNFOLLOWABLE = ConvertPlayerState(12)
 	
 	// taxation rate for each resource
-	// 玩家黄金税率
+	// 玩家状态 - 黄金税率
 	constant playerstate PLAYER_STATE_GOLD_UPKEEP_RATE = ConvertPlayerState(13)
-	// 玩家木材税率
+	// 玩家状态 - 木材税率
 	constant playerstate PLAYER_STATE_LUMBER_UPKEEP_RATE = ConvertPlayerState(14)
 	
 	// cumulative resources collected by the player during the mission
@@ -1308,7 +1443,7 @@ globals
 	
 	// 单位出售
 	constant unitevent EVENT_UNIT_SELL = ConvertUnitEvent(286)
-	// 单位所属改变
+	// 单位所属变更
 	constant unitevent EVENT_UNIT_CHANGE_OWNER = ConvertUnitEvent(287)
 	// 出售物品
 	constant unitevent EVENT_UNIT_SELL_ITEM = ConvertUnitEvent(288)
@@ -1472,19 +1607,19 @@ globals
 	constant raritycontrol RARITY_FREQUENT = ConvertRarityControl(0)
     // 频率控制 罕见频率
 	constant raritycontrol RARITY_RARE = ConvertRarityControl(1)
-	// 地图涂层标志 无
+	// 纹理贴图标志 无
 	constant texmapflags TEXMAP_FLAG_NONE = ConvertTexMapFlags(0)
-	// 地图涂层标志 重叠(U)
+	// 纹理贴图标志 重叠(U)
 	constant texmapflags TEXMAP_FLAG_WRAP_U = ConvertTexMapFlags(1)
-	// 地图涂层标志 重叠(V)
+	// 纹理贴图标志 重叠(V)
 	constant texmapflags TEXMAP_FLAG_WRAP_V = ConvertTexMapFlags(2)
-	// 地图涂层标志 重叠(UV)
+	// 纹理贴图标志 重叠(UV)
 	constant texmapflags TEXMAP_FLAG_WRAP_UV = ConvertTexMapFlags(3)
-	// 可见效果 黑色迷雾
+	// 迷雾状态 黑色迷雾
 	constant fogstate FOG_OF_WAR_MASKED = ConvertFogState(1)
-	// 可见效果 战争迷雾
+	// 迷雾状态 战争迷雾
 	constant fogstate FOG_OF_WAR_FOGGED = ConvertFogState(2)
-	// 可见效果 可见
+	// 迷雾状态 可见
 	constant fogstate FOG_OF_WAR_VISIBLE = ConvertFogState(4)
 	
 	
@@ -2257,1418 +2392,1418 @@ globals
 	// 技能字串符域 音效（循环） ('aefl')
 	constant abilitystringfield ABILITY_SF_EFFECT_SOUND_LOOPING = ConvertAbilityStringField('aefl')
 	
-    // 技能整数等级域 魔法消耗 ('amcs')
+    // 技能随等级改变的整数域 魔法消耗 ('amcs')
 	constant abilityintegerlevelfield ABILITY_ILF_MANA_COST = ConvertAbilityIntegerLevelField('amcs')
-    // 技能整数等级域 波次数量 ('Hbz1')
+    // 技能随等级改变的整数域 波次数量 ('Hbz1')
 	constant abilityintegerlevelfield ABILITY_ILF_NUMBER_OF_WAVES = ConvertAbilityIntegerLevelField('Hbz1')
-    // 技能整数等级域 碎片数量 ('Hbz3')
+    // 技能随等级改变的整数域 碎片数量 ('Hbz3')
 	constant abilityintegerlevelfield ABILITY_ILF_NUMBER_OF_SHARDS = ConvertAbilityIntegerLevelField('Hbz3')
-    // 技能整数等级域 传送单位数量 ('Hmt1')
+    // 技能随等级改变的整数域 传送单位数量 ('Hmt1')
 	constant abilityintegerlevelfield ABILITY_ILF_NUMBER_OF_UNITS_TELEPORTED = ConvertAbilityIntegerLevelField('Hmt1')
-    // 技能整数等级域 召唤单位数量 ('Hwe2')
+    // 技能随等级改变的整数域 召唤单位数量 ('Hwe2')
 	constant abilityintegerlevelfield ABILITY_ILF_SUMMONED_UNIT_COUNT_HWE2 = ConvertAbilityIntegerLevelField('Hwe2')
-    // 技能整数等级域 镜像数量 ('Omi1')
+    // 技能随等级改变的整数域 镜像数量 ('Omi1')
 	constant abilityintegerlevelfield ABILITY_ILF_NUMBER_OF_IMAGES = ConvertAbilityIntegerLevelField('Omi1')
-    // 技能整数等级域 复活死尸数量 ('Uan1')
+    // 技能随等级改变的整数域 复活死尸数量 ('Uan1')
 	constant abilityintegerlevelfield ABILITY_ILF_NUMBER_OF_CORPSES_RAISED_UAN1 = ConvertAbilityIntegerLevelField('Uan1')
-    // 技能整数等级域 变化参数 ('Eme2')
+    // 技能随等级改变的整数域 变化参数 ('Eme2')
 	constant abilityintegerlevelfield ABILITY_ILF_MORPHING_FLAGS = ConvertAbilityIntegerLevelField('Eme2')
-    // 技能整数等级域 力量奖励 ('Nrg5')
+    // 技能随等级改变的整数域 力量奖励 ('Nrg5')
 	constant abilityintegerlevelfield ABILITY_ILF_STRENGTH_BONUS_NRG5 = ConvertAbilityIntegerLevelField('Nrg5')
-    // 技能整数等级域 防御奖励 ('Nrg6')
+    // 技能随等级改变的整数域 防御奖励 ('Nrg6')
 	constant abilityintegerlevelfield ABILITY_ILF_DEFENSE_BONUS_NRG6 = ConvertAbilityIntegerLevelField('Nrg6')
-    // 技能整数等级域 最大目标数量 ('Ocl2')
+    // 技能随等级改变的整数域 最大目标数量 ('Ocl2')
 	constant abilityintegerlevelfield ABILITY_ILF_NUMBER_OF_TARGETS_HIT = ConvertAbilityIntegerLevelField('Ocl2')
-    // 技能整数等级域 侦察类型 ('Ofs1')
+    // 技能随等级改变的整数域 侦察类型 ('Ofs1')
 	constant abilityintegerlevelfield ABILITY_ILF_DETECTION_TYPE_OFS1 = ConvertAbilityIntegerLevelField('Ofs1')
-    // 技能整数等级域 召唤单位数量 ('Osf2')
+    // 技能随等级改变的整数域 召唤单位数量 ('Osf2')
 	constant abilityintegerlevelfield ABILITY_ILF_NUMBER_OF_SUMMONED_UNITS_OSF2 = ConvertAbilityIntegerLevelField('Osf2')
-    // 技能整数等级域 召唤单位数量 ('Efn1')
+    // 技能随等级改变的整数域 召唤单位数量 ('Efn1')
 	constant abilityintegerlevelfield ABILITY_ILF_NUMBER_OF_SUMMONED_UNITS_EFN1 = ConvertAbilityIntegerLevelField('Efn1')
-    // 技能整数等级域 复活单位数量 ('Hre1')
+    // 技能随等级改变的整数域 复活单位数量 ('Hre1')
 	constant abilityintegerlevelfield ABILITY_ILF_NUMBER_OF_CORPSES_RAISED_HRE1 = ConvertAbilityIntegerLevelField('Hre1')
-    // 技能整数等级域 叠加参数 ('Hca4')
+    // 技能随等级改变的整数域 叠加参数 ('Hca4')
 	constant abilityintegerlevelfield ABILITY_ILF_STACK_FLAGS = ConvertAbilityIntegerLevelField('Hca4')
-    // 技能整数等级域 最小单位数 ('Ndp2')
+    // 技能随等级改变的整数域 最小单位数 ('Ndp2')
 	constant abilityintegerlevelfield ABILITY_ILF_MINIMUM_NUMBER_OF_UNITS = ConvertAbilityIntegerLevelField('Ndp2')
-    // 技能整数等级域 最大单位数 ('Ndp3')
+    // 技能随等级改变的整数域 最大单位数 ('Ndp3')
 	constant abilityintegerlevelfield ABILITY_ILF_MAXIMUM_NUMBER_OF_UNITS_NDP3 = ConvertAbilityIntegerLevelField('Ndp3')
-    // 技能整数等级域 创建单位数 ('Nrc2')
+    // 技能随等级改变的整数域 创建单位数 ('Nrc2')
 	constant abilityintegerlevelfield ABILITY_ILF_NUMBER_OF_UNITS_CREATED_NRC2 = ConvertAbilityIntegerLevelField('Nrc2')
-    // 技能整数等级域 护盾生命值 ('Ams3')
+    // 技能随等级改变的整数域 护盾生命值 ('Ams3')
 	constant abilityintegerlevelfield ABILITY_ILF_SHIELD_LIFE = ConvertAbilityIntegerLevelField('Ams3')
-    // 技能整数等级域 魔法损耗 ('Ams4')
+    // 技能随等级改变的整数域 魔法损耗 ('Ams4')
 	constant abilityintegerlevelfield ABILITY_ILF_MANA_LOSS_AMS4 = ConvertAbilityIntegerLevelField('Ams4')
-    // 技能整数等级域 采集黄金数/间隔 ('Bgm1')
+    // 技能随等级改变的整数域 采集黄金数/间隔 ('Bgm1')
 	constant abilityintegerlevelfield ABILITY_ILF_GOLD_PER_INTERVAL_BGM1 = ConvertAbilityIntegerLevelField('Bgm1')
-    // 技能整数等级域 最大矿工数量 ('Bgm3')
+    // 技能随等级改变的整数域 最大矿工数量 ('Bgm3')
 	constant abilityintegerlevelfield ABILITY_ILF_MAX_NUMBER_OF_MINERS = ConvertAbilityIntegerLevelField('Bgm3')
-    // 技能整数等级域 装载容量 ('Car1')
+    // 技能随等级改变的整数域 装载容量 ('Car1')
 	constant abilityintegerlevelfield ABILITY_ILF_CARGO_CAPACITY = ConvertAbilityIntegerLevelField('Car1')
-    // 技能整数等级域 最大目标中立等级 ('Dev3')
+    // 技能随等级改变的整数域 最大目标中立等级 ('Dev3')
 	constant abilityintegerlevelfield ABILITY_ILF_MAXIMUM_CREEP_LEVEL_DEV3 = ConvertAbilityIntegerLevelField('Dev3')
-    // 技能整数等级域 最大目标中立等级 ('Dev1')
+    // 技能随等级改变的整数域 最大目标中立等级 ('Dev1')
 	constant abilityintegerlevelfield ABILITY_ILF_MAX_CREEP_LEVEL_DEV1 = ConvertAbilityIntegerLevelField('Dev1')
-    // 技能整数等级域 采集黄金数/间隔 ('Fae1')
+    // 技能随等级改变的整数域 采集黄金数/间隔 ('Fae1')
 	constant abilityintegerlevelfield ABILITY_ILF_GOLD_PER_INTERVAL_EGM1 = ConvertAbilityIntegerLevelField('Egm1')
-    // 技能整数等级域 防御减少 ('Fae1')
+    // 技能随等级改变的整数域 防御减少 ('Fae1')
 	constant abilityintegerlevelfield ABILITY_ILF_DEFENSE_REDUCTION = ConvertAbilityIntegerLevelField('Fae1')
-    // 技能整数等级域 侦察类型 ('Fla1')
+    // 技能随等级改变的整数域 侦察类型 ('Fla1')
 	constant abilityintegerlevelfield ABILITY_ILF_DETECTION_TYPE_FLA1 = ConvertAbilityIntegerLevelField('Fla1')
-    // 技能整数等级域 闪光弹数量 ('Fla3')
+    // 技能随等级改变的整数域 闪光弹数量 ('Fla3')
 	constant abilityintegerlevelfield ABILITY_ILF_FLARE_COUNT = ConvertAbilityIntegerLevelField('Fla3')
-    // 技能整数等级域 最大黄金数量 ('Gld1')
+    // 技能随等级改变的整数域 最大黄金数量 ('Gld1')
 	constant abilityintegerlevelfield ABILITY_ILF_MAX_GOLD = ConvertAbilityIntegerLevelField('Gld1')
-    // 技能整数等级域 最大矿工容量 ('Gld3')
+    // 技能随等级改变的整数域 最大矿工容量 ('Gld3')
 	constant abilityintegerlevelfield ABILITY_ILF_MINING_CAPACITY = ConvertAbilityIntegerLevelField('Gld3')
-    // 技能整数等级域 最大尸体数量 ('Gyd1')
+    // 技能随等级改变的整数域 最大尸体数量 ('Gyd1')
 	constant abilityintegerlevelfield ABILITY_ILF_MAXIMUM_NUMBER_OF_CORPSES_GYD1 = ConvertAbilityIntegerLevelField('Gyd1')
-    // 技能整数等级域 对树伤害 ('Har1')
+    // 技能随等级改变的整数域 对树伤害 ('Har1')
 	constant abilityintegerlevelfield ABILITY_ILF_DAMAGE_TO_TREE = ConvertAbilityIntegerLevelField('Har1')
-    // 技能整数等级域 （单次采集最大）木材容量 ('Har2')
+    // 技能随等级改变的整数域 （单次采集最大）木材容量 ('Har2')
 	constant abilityintegerlevelfield ABILITY_ILF_LUMBER_CAPACITY = ConvertAbilityIntegerLevelField('Har2')
-    // 技能整数等级域 （单次采集最大）黄金容量 ('Har3')
+    // 技能随等级改变的整数域 （单次采集最大）黄金容量 ('Har3')
 	constant abilityintegerlevelfield ABILITY_ILF_GOLD_CAPACITY = ConvertAbilityIntegerLevelField('Har3')
-    // 技能整数等级域 防御增加 ('Inf2')
+    // 技能随等级改变的整数域 防御增加 ('Inf2')
 	constant abilityintegerlevelfield ABILITY_ILF_DEFENSE_INCREASE_INF2 = ConvertAbilityIntegerLevelField('Inf2')
-    // 技能整数等级域 选择单位类型 ('Neu2')
+    // 技能随等级改变的整数域 选择单位类型 ('Neu2')
 	constant abilityintegerlevelfield ABILITY_ILF_INTERACTION_TYPE = ConvertAbilityIntegerLevelField('Neu2')
-    // 技能整数等级域 黄金消耗 ('Ndt1')
+    // 技能随等级改变的整数域 黄金消耗 ('Ndt1')
 	constant abilityintegerlevelfield ABILITY_ILF_GOLD_COST_NDT1 = ConvertAbilityIntegerLevelField('Ndt1')
-    // 技能整数等级域 木材消耗 ('Ndt2')
+    // 技能随等级改变的整数域 木材消耗 ('Ndt2')
 	constant abilityintegerlevelfield ABILITY_ILF_LUMBER_COST_NDT2 = ConvertAbilityIntegerLevelField('Ndt2')
-    // 技能整数等级域 侦察类型 ('Ndt3')
+    // 技能随等级改变的整数域 侦察类型 ('Ndt3')
 	constant abilityintegerlevelfield ABILITY_ILF_DETECTION_TYPE_NDT3 = ConvertAbilityIntegerLevelField('Ndt3')
-    // 技能整数等级域 叠加类型 ('Poi4')
+    // 技能随等级改变的整数域 叠加类型 ('Poi4')
 	constant abilityintegerlevelfield ABILITY_ILF_STACKING_TYPE_POI4 = ConvertAbilityIntegerLevelField('Poi4')
-    // 技能整数等级域 叠加类型 ('Poa5')
+    // 技能随等级改变的整数域 叠加类型 ('Poa5')
 	constant abilityintegerlevelfield ABILITY_ILF_STACKING_TYPE_POA5 = ConvertAbilityIntegerLevelField('Poa5')
-    // 技能整数等级域 最大目标中立生物等级 ('Ply1')
+    // 技能随等级改变的整数域 最大目标中立生物等级 ('Ply1')
 	constant abilityintegerlevelfield ABILITY_ILF_MAXIMUM_CREEP_LEVEL_PLY1 = ConvertAbilityIntegerLevelField('Ply1')
-    // 技能整数等级域 最大目标中立生物等级 ('Pos1')
+    // 技能随等级改变的整数域 最大目标中立生物等级 ('Pos1')
 	constant abilityintegerlevelfield ABILITY_ILF_MAXIMUM_CREEP_LEVEL_POS1 = ConvertAbilityIntegerLevelField('Pos1')
-    // 技能整数等级域 移动速度更新次数 ('Prg1')
+    // 技能随等级改变的整数域 移动速度更新次数 ('Prg1')
 	constant abilityintegerlevelfield ABILITY_ILF_MOVEMENT_UPDATE_FREQUENCY_PRG1 = ConvertAbilityIntegerLevelField('Prg1')
-    // 技能整数等级域 攻击速度更新次数 ('Prg2')
+    // 技能随等级改变的整数域 攻击速度更新次数 ('Prg2')
 	constant abilityintegerlevelfield ABILITY_ILF_ATTACK_UPDATE_FREQUENCY_PRG2 = ConvertAbilityIntegerLevelField('Prg2')
-    // 技能整数等级域 魔法损耗 ('Prg6')
+    // 技能随等级改变的整数域 魔法损耗 ('Prg6')
 	constant abilityintegerlevelfield ABILITY_ILF_MANA_LOSS_PRG6 = ConvertAbilityIntegerLevelField('Prg6')
-    // 技能整数等级域 单位召唤数量1 ('Rai1')
+    // 技能随等级改变的整数域 单位召唤数量1 ('Rai1')
 	constant abilityintegerlevelfield ABILITY_ILF_UNITS_SUMMONED_TYPE_ONE = ConvertAbilityIntegerLevelField('Rai1')
-    // 技能整数等级域 单位召唤数量1 ('Rai2')
+    // 技能随等级改变的整数域 单位召唤数量1 ('Rai2')
 	constant abilityintegerlevelfield ABILITY_ILF_UNITS_SUMMONED_TYPE_TWO = ConvertAbilityIntegerLevelField('Rai2')
-    // 技能整数等级域 最大召唤数量 ('Ucb5')
+    // 技能随等级改变的整数域 最大召唤数量 ('Ucb5')
 	constant abilityintegerlevelfield ABILITY_ILF_MAX_UNITS_SUMMONED = ConvertAbilityIntegerLevelField('Ucb5')
-    // 技能整数等级域 选项完整时可用 ('Rej3')
+    // 技能随等级改变的整数域 选项完整时可用 ('Rej3')
 	constant abilityintegerlevelfield ABILITY_ILF_ALLOW_WHEN_FULL_REJ3 = ConvertAbilityIntegerLevelField('Rej3')
-    // 技能整数等级域 最多消耗魔法倍数 ('Rpb5')
+    // 技能随等级改变的整数域 最多消耗魔法倍数 ('Rpb5')
 	constant abilityintegerlevelfield ABILITY_ILF_MAXIMUM_UNITS_CHARGED_TO_CASTER = ConvertAbilityIntegerLevelField('Rpb5')
-    // 技能整数等级域 最多可影响到的单位数量('Rpb6')
+    // 技能随等级改变的整数域 最多可影响到的单位数量('Rpb6')
 	constant abilityintegerlevelfield ABILITY_ILF_MAXIMUM_UNITS_AFFECTED = ConvertAbilityIntegerLevelField('Rpb6')
-    // 技能整数等级域 防御增加 ('Roa2')
+    // 技能随等级改变的整数域 防御增加 ('Roa2')
 	constant abilityintegerlevelfield ABILITY_ILF_DEFENSE_INCREASE_ROA2 = ConvertAbilityIntegerLevelField('Roa2')
-    // 技能整数等级域 最大单位数量 ('Roa7')
+    // 技能随等级改变的整数域 最大单位数量 ('Roa7')
 	constant abilityintegerlevelfield ABILITY_ILF_MAX_UNITS_ROA7 = ConvertAbilityIntegerLevelField('Roa7')
-    // 技能整数等级域 扎根攻击模式 ('Roo1')
+    // 技能随等级改变的整数域 扎根攻击模式 ('Roo1')
 	constant abilityintegerlevelfield ABILITY_ILF_ROOTED_WEAPONS = ConvertAbilityIntegerLevelField('Roo1')
-    // 技能整数等级域 拔起攻击模式 ('Roo2')
+    // 技能随等级改变的整数域 拔起攻击模式 ('Roo2')
 	constant abilityintegerlevelfield ABILITY_ILF_UPROOTED_WEAPONS = ConvertAbilityIntegerLevelField('Roo2')
-    // 技能整数等级域 拔起防御模式 ('Roo4')
+    // 技能随等级改变的整数域 拔起防御模式 ('Roo4')
 	constant abilityintegerlevelfield ABILITY_ILF_UPROOTED_DEFENSE_TYPE = ConvertAbilityIntegerLevelField('Roo4')
-    // 技能整数等级域 积聚等级 ('Sal2')
+    // 技能随等级改变的整数域 积聚等级 ('Sal2')
 	constant abilityintegerlevelfield ABILITY_ILF_ACCUMULATION_STEP = ConvertAbilityIntegerLevelField('Sal2')
-    // 技能整数等级域 猫头鹰数量 ('Esn4')
+    // 技能随等级改变的整数域 猫头鹰数量 ('Esn4')
 	constant abilityintegerlevelfield ABILITY_ILF_NUMBER_OF_OWLS = ConvertAbilityIntegerLevelField('Esn4')
-    // 技能整数等级域 叠加类型 ('Spo4')
+    // 技能随等级改变的整数域 叠加类型 ('Spo4')
 	constant abilityintegerlevelfield ABILITY_ILF_STACKING_TYPE_SPO4 = ConvertAbilityIntegerLevelField('Spo4')
-    // 技能整数等级域 单位数量 ('Sod1')
+    // 技能随等级改变的整数域 单位数量 ('Sod1')
 	constant abilityintegerlevelfield ABILITY_ILF_NUMBER_OF_UNITS = ConvertAbilityIntegerLevelField('Sod1')
-    // 技能整数等级域 蜘蛛数量 ('Spa1')
+    // 技能随等级改变的整数域 蜘蛛数量 ('Spa1')
 	constant abilityintegerlevelfield ABILITY_ILF_SPIDER_CAPACITY = ConvertAbilityIntegerLevelField('Spa1')
-    // 技能整数等级域 间隔时间 ('Wha2')
+    // 技能随等级改变的整数域 间隔时间 ('Wha2')
 	constant abilityintegerlevelfield ABILITY_ILF_INTERVALS_BEFORE_CHANGING_TREES = ConvertAbilityIntegerLevelField('Wha2')
-    // 技能整数等级域 敏捷奖励 ('Iagi')
+    // 技能随等级改变的整数域 敏捷奖励 ('Iagi')
 	constant abilityintegerlevelfield ABILITY_ILF_AGILITY_BONUS = ConvertAbilityIntegerLevelField('Iagi')
-    // 技能整数等级域 智力奖励 ('Iint')
+    // 技能随等级改变的整数域 智力奖励 ('Iint')
 	constant abilityintegerlevelfield ABILITY_ILF_INTELLIGENCE_BONUS = ConvertAbilityIntegerLevelField('Iint')
-    // 技能整数等级域 力量奖励 ('Istr')
+    // 技能随等级改变的整数域 力量奖励 ('Istr')
 	constant abilityintegerlevelfield ABILITY_ILF_STRENGTH_BONUS_ISTR = ConvertAbilityIntegerLevelField('Istr')
-    // 技能整数等级域 攻击奖励 ('Iatt')
+    // 技能随等级改变的整数域 攻击奖励 ('Iatt')
 	constant abilityintegerlevelfield ABILITY_ILF_ATTACK_BONUS = ConvertAbilityIntegerLevelField('Iatt')
-    // 技能整数等级域 防御奖励 ('Idef')
+    // 技能随等级改变的整数域 防御奖励 ('Idef')
 	constant abilityintegerlevelfield ABILITY_ILF_DEFENSE_BONUS_IDEF = ConvertAbilityIntegerLevelField('Idef')
-    // 技能整数等级域 召唤单位数量1 ('Isn1')
+    // 技能随等级改变的整数域 召唤单位数量1 ('Isn1')
 	constant abilityintegerlevelfield ABILITY_ILF_SUMMON_1_AMOUNT = ConvertAbilityIntegerLevelField('Isn1')
-    // 技能整数等级域 召唤单位数量2 ('Isn2')
+    // 技能随等级改变的整数域 召唤单位数量2 ('Isn2')
 	constant abilityintegerlevelfield ABILITY_ILF_SUMMON_2_AMOUNT = ConvertAbilityIntegerLevelField('Isn2')
-    // 技能整数等级域 取得经验值 ('Ixpg')
+    // 技能随等级改变的整数域 取得经验值 ('Ixpg')
 	constant abilityintegerlevelfield ABILITY_ILF_EXPERIENCE_GAINED = ConvertAbilityIntegerLevelField('Ixpg')
-    // 技能整数等级域 生命值恢复 ('Ihpg')
+    // 技能随等级改变的整数域 生命值恢复 ('Ihpg')
 	constant abilityintegerlevelfield ABILITY_ILF_HIT_POINTS_GAINED_IHPG = ConvertAbilityIntegerLevelField('Ihpg')
-    // 技能整数等级域 魔法值恢复 ('Impg')
+    // 技能随等级改变的整数域 魔法值恢复 ('Impg')
 	constant abilityintegerlevelfield ABILITY_ILF_MANA_POINTS_GAINED_IMPG = ConvertAbilityIntegerLevelField('Impg')
-    // 技能整数等级域 治疗生命值 ('Ihp2')
+    // 技能随等级改变的整数域 治疗生命值 ('Ihp2')
 	constant abilityintegerlevelfield ABILITY_ILF_HIT_POINTS_GAINED_IHP2 = ConvertAbilityIntegerLevelField('Ihp2')
-    // 技能整数等级域 魔法值获取 ('Imp2')
+    // 技能随等级改变的整数域 魔法值获取 ('Imp2')
 	constant abilityintegerlevelfield ABILITY_ILF_MANA_POINTS_GAINED_IMP2 = ConvertAbilityIntegerLevelField('Imp2')
-    // 技能整数等级域 攻击奖励 ('Idic')
+    // 技能随等级改变的整数域 攻击奖励 ('Idic')
 	constant abilityintegerlevelfield ABILITY_ILF_DAMAGE_BONUS_DICE = ConvertAbilityIntegerLevelField('Idic')
-    // 技能整数等级域 目标防御降低 ('Iarp')
+    // 技能随等级改变的整数域 目标防御降低 ('Iarp')
 	constant abilityintegerlevelfield ABILITY_ILF_ARMOR_PENALTY_IARP = ConvertAbilityIntegerLevelField('Iarp')
-    // 技能整数等级域 允许攻击引索 ('Iob5')
+    // 技能随等级改变的整数域 允许攻击引索 ('Iob5')
 	constant abilityintegerlevelfield ABILITY_ILF_ENABLED_ATTACK_INDEX_IOB5 = ConvertAbilityIntegerLevelField('Iob5')
-    // 技能整数等级域 等级提升 ('Ilev')
+    // 技能随等级改变的整数域 等级提升 ('Ilev')
 	constant abilityintegerlevelfield ABILITY_ILF_LEVELS_GAINED = ConvertAbilityIntegerLevelField('Ilev')
-    // 技能整数等级域 增加最大生命值 ('Ilif')
+    // 技能随等级改变的整数域 增加最大生命值 ('Ilif')
 	constant abilityintegerlevelfield ABILITY_ILF_MAX_LIFE_GAINED = ConvertAbilityIntegerLevelField('Ilif')
-    // 技能整数等级域 增加最大魔法值 ('Iman')
+    // 技能随等级改变的整数域 增加最大魔法值 ('Iman')
 	constant abilityintegerlevelfield ABILITY_ILF_MAX_MANA_GAINED = ConvertAbilityIntegerLevelField('Iman')
-    // 技能整数等级域 获得金钱 ('Igol')
+    // 技能随等级改变的整数域 获得金钱 ('Igol')
 	constant abilityintegerlevelfield ABILITY_ILF_GOLD_GIVEN = ConvertAbilityIntegerLevelField('Igol')
-    // 技能整数等级域 获得木材 ('Ilum')
+    // 技能随等级改变的整数域 获得木材 ('Ilum')
 	constant abilityintegerlevelfield ABILITY_ILF_LUMBER_GIVEN = ConvertAbilityIntegerLevelField('Ilum')
-    // 技能整数等级域 侦察类型 ('Ifa1')
+    // 技能随等级改变的整数域 侦察类型 ('Ifa1')
 	constant abilityintegerlevelfield ABILITY_ILF_DETECTION_TYPE_IFA1 = ConvertAbilityIntegerLevelField('Ifa1')
-    // 技能整数等级域 最大目标中立生物等级 ('Icre')
+    // 技能随等级改变的整数域 最大目标中立生物等级 ('Icre')
 	constant abilityintegerlevelfield ABILITY_ILF_MAXIMUM_CREEP_LEVEL_ICRE = ConvertAbilityIntegerLevelField('Icre')
-    // 技能整数等级域 移动速度奖励 ('Imvb')
+    // 技能随等级改变的整数域 移动速度奖励 ('Imvb')
 	constant abilityintegerlevelfield ABILITY_ILF_MOVEMENT_SPEED_BONUS = ConvertAbilityIntegerLevelField('Imvb')
-    // 技能整数等级域 每秒生命恢复 ('Ihpr')
+    // 技能随等级改变的整数域 每秒生命恢复 ('Ihpr')
 	constant abilityintegerlevelfield ABILITY_ILF_HIT_POINTS_REGENERATED_PER_SECOND = ConvertAbilityIntegerLevelField('Ihpr')
-    // 技能整数等级域 视野范围奖励 ('Isib')
+    // 技能随等级改变的整数域 视野范围奖励 ('Isib')
 	constant abilityintegerlevelfield ABILITY_ILF_SIGHT_RANGE_BONUS = ConvertAbilityIntegerLevelField('Isib')
-    // 技能整数等级域 伤害/间隔 ('Icfd')
+    // 技能随等级改变的整数域 伤害/间隔 ('Icfd')
 	constant abilityintegerlevelfield ABILITY_ILF_DAMAGE_PER_DURATION = ConvertAbilityIntegerLevelField('Icfd')
-    // 技能整数等级域 每秒消耗魔法值 ('Icfm')
+    // 技能随等级改变的整数域 每秒消耗魔法值 ('Icfm')
 	constant abilityintegerlevelfield ABILITY_ILF_MANA_USED_PER_SECOND = ConvertAbilityIntegerLevelField('Icfm')
-    // 技能整数等级域 额外魔法需求 ('Icfx')
+    // 技能随等级改变的整数域 额外魔法需求 ('Icfx')
 	constant abilityintegerlevelfield ABILITY_ILF_EXTRA_MANA_REQUIRED = ConvertAbilityIntegerLevelField('Icfx')
-    // 技能整数等级域 侦察范围 ('Idet')
+    // 技能随等级改变的整数域 侦察范围 ('Idet')
 	constant abilityintegerlevelfield ABILITY_ILF_DETECTION_RADIUS_IDET = ConvertAbilityIntegerLevelField('Idet')
-    // 技能整数等级域 每个单位魔法损耗 ('Idim')
+    // 技能随等级改变的整数域 每个单位魔法损耗 ('Idim')
 	constant abilityintegerlevelfield ABILITY_ILF_MANA_LOSS_PER_UNIT_IDIM = ConvertAbilityIntegerLevelField('Idim')
-    // 技能整数等级域 对召唤单位伤害 ('Idid')
+    // 技能随等级改变的整数域 对召唤单位伤害 ('Idid')
 	constant abilityintegerlevelfield ABILITY_ILF_DAMAGE_TO_SUMMONED_UNITS_IDID = ConvertAbilityIntegerLevelField('Idid')
-    // 技能整数等级域 最大单位数 ('Irec')
+    // 技能随等级改变的整数域 最大单位数 ('Irec')
 	constant abilityintegerlevelfield ABILITY_ILF_MAXIMUM_NUMBER_OF_UNITS_IREC = ConvertAbilityIntegerLevelField('Irec')
-    // 技能整数等级域 重生延迟 ('Ircd')
+    // 技能随等级改变的整数域 重生延迟 ('Ircd')
 	constant abilityintegerlevelfield ABILITY_ILF_DELAY_AFTER_DEATH_SECONDS = ConvertAbilityIntegerLevelField('Ircd')
-    // 技能整数等级域 生命值回复 ('irc2')
+    // 技能随等级改变的整数域 生命值回复 ('irc2')
 	constant abilityintegerlevelfield ABILITY_ILF_RESTORED_LIFE = ConvertAbilityIntegerLevelField('irc2')
-    // 技能整数等级域 魔法值回复 ('irc3')
+    // 技能随等级改变的整数域 魔法值回复 ('irc3')
 	constant abilityintegerlevelfield ABILITY_ILF_RESTORED_MANA__1_FOR_CURRENT = ConvertAbilityIntegerLevelField('irc3')
-    // 技能整数等级域 生命值回复 ('Ihps')
+    // 技能随等级改变的整数域 生命值回复 ('Ihps')
 	constant abilityintegerlevelfield ABILITY_ILF_HIT_POINTS_RESTORED = ConvertAbilityIntegerLevelField('Ihps')
-    // 技能整数等级域 魔法值回复 ('Imps')
+    // 技能随等级改变的整数域 魔法值回复 ('Imps')
 	constant abilityintegerlevelfield ABILITY_ILF_MANA_POINTS_RESTORED = ConvertAbilityIntegerLevelField('Imps')
-    // 技能整数等级域 最大单位数 ('Itpm')
+    // 技能随等级改变的整数域 最大单位数 ('Itpm')
 	constant abilityintegerlevelfield ABILITY_ILF_MAXIMUM_NUMBER_OF_UNITS_ITPM = ConvertAbilityIntegerLevelField('Itpm')
-    // 技能整数等级域 复活死尸数量 ('Cad1')
+    // 技能随等级改变的整数域 复活死尸数量 ('Cad1')
 	constant abilityintegerlevelfield ABILITY_ILF_NUMBER_OF_CORPSES_RAISED_CAD1 = ConvertAbilityIntegerLevelField('Cad1')
-    // 技能整数等级域 地形变形持续时间（毫秒） ('Wrs3')
+    // 技能随等级改变的整数域 地形变形持续时间（毫秒） ('Wrs3')
 	constant abilityintegerlevelfield ABILITY_ILF_TERRAIN_DEFORMATION_DURATION_MS = ConvertAbilityIntegerLevelField('Wrs3')
-    // 技能整数等级域 传送单位数量 ('Uds1')
+    // 技能随等级改变的整数域 传送单位数量 ('Uds1')
 	constant abilityintegerlevelfield ABILITY_ILF_MAXIMUM_UNITS = ConvertAbilityIntegerLevelField('Uds1')
-    // 技能整数等级域 侦察类型 ('Det1')
+    // 技能随等级改变的整数域 侦察类型 ('Det1')
 	constant abilityintegerlevelfield ABILITY_ILF_DETECTION_TYPE_DET1 = ConvertAbilityIntegerLevelField('Det1')
-    // 技能整数等级域 每次建造的金钱消耗 ('Nsp1')
+    // 技能随等级改变的整数域 每次建造的金钱消耗 ('Nsp1')
 	constant abilityintegerlevelfield ABILITY_ILF_GOLD_COST_PER_STRUCTURE = ConvertAbilityIntegerLevelField('Nsp1')
-    // 技能整数等级域 每次使用的木材消耗 ('Nsp2')
+    // 技能随等级改变的整数域 每次使用的木材消耗 ('Nsp2')
 	constant abilityintegerlevelfield ABILITY_ILF_LUMBER_COST_PER_USE = ConvertAbilityIntegerLevelField('Nsp2')
-    // 技能整数等级域 侦察类型 ('Nsp3')
+    // 技能随等级改变的整数域 侦察类型 ('Nsp3')
 	constant abilityintegerlevelfield ABILITY_ILF_DETECTION_TYPE_NSP3 = ConvertAbilityIntegerLevelField('Nsp3')
-    // 技能整数等级域 蝗虫群数量 ('Uls1')
+    // 技能随等级改变的整数域 蝗虫群数量 ('Uls1')
 	constant abilityintegerlevelfield ABILITY_ILF_NUMBER_OF_SWARM_UNITS = ConvertAbilityIntegerLevelField('Uls1')
-    // 技能整数等级域 每个目标最大蝗虫数量 ('Uls3')
+    // 技能随等级改变的整数域 每个目标最大蝗虫数量 ('Uls3')
 	constant abilityintegerlevelfield ABILITY_ILF_MAX_SWARM_UNITS_PER_TARGET = ConvertAbilityIntegerLevelField('Uls3')
-    // 技能整数等级域 召唤单位数量 ('Nba2')
+    // 技能随等级改变的整数域 召唤单位数量 ('Nba2')
 	constant abilityintegerlevelfield ABILITY_ILF_NUMBER_OF_SUMMONED_UNITS_NBA2 = ConvertAbilityIntegerLevelField('Nba2')
-    // 技能整数等级域 最大目标中立生物等级 ('Nch1')
+    // 技能随等级改变的整数域 最大目标中立生物等级 ('Nch1')
 	constant abilityintegerlevelfield ABILITY_ILF_MAXIMUM_CREEP_LEVEL_NCH1 = ConvertAbilityIntegerLevelField('Nch1')
-    // 技能整数等级域 禁止类型 ('Nsi1')
+    // 技能随等级改变的整数域 禁止类型 ('Nsi1')
 	constant abilityintegerlevelfield ABILITY_ILF_ATTACKS_PREVENTED = ConvertAbilityIntegerLevelField('Nsi1')
-    // 技能整数等级域 最大目标数 ('Efk3')
+    // 技能随等级改变的整数域 最大目标数 ('Efk3')
 	constant abilityintegerlevelfield ABILITY_ILF_MAXIMUM_NUMBER_OF_TARGETS_EFK3 = ConvertAbilityIntegerLevelField('Efk3')
-    // 技能整数等级域 召唤单位数量 ('Esv1')
+    // 技能随等级改变的整数域 召唤单位数量 ('Esv1')
 	constant abilityintegerlevelfield ABILITY_ILF_NUMBER_OF_SUMMONED_UNITS_ESV1 = ConvertAbilityIntegerLevelField('Esv1')
-    // 技能整数等级域 最大尸体数量 ('exh1')
+    // 技能随等级改变的整数域 最大尸体数量 ('exh1')
 	constant abilityintegerlevelfield ABILITY_ILF_MAXIMUM_NUMBER_OF_CORPSES_EXH1 = ConvertAbilityIntegerLevelField('exh1')
-    // 技能整数等级域 物品容量 ('inv1')
+    // 技能随等级改变的整数域 物品容量 ('inv1')
 	constant abilityintegerlevelfield ABILITY_ILF_ITEM_CAPACITY = ConvertAbilityIntegerLevelField('inv1')
-    // 技能整数等级域 最大目标数 ('spl2')
+    // 技能随等级改变的整数域 最大目标数 ('spl2')
 	constant abilityintegerlevelfield ABILITY_ILF_MAXIMUM_NUMBER_OF_TARGETS_SPL2 = ConvertAbilityIntegerLevelField('spl2')
-    // 技能整数等级域 选项完整时可用 ('irl3')
+    // 技能随等级改变的整数域 选项完整时可用 ('irl3')
 	constant abilityintegerlevelfield ABILITY_ILF_ALLOW_WHEN_FULL_IRL3 = ConvertAbilityIntegerLevelField('irl3')
-    // 技能整数等级域 最大驱散单位数量 ('idc3')
+    // 技能随等级改变的整数域 最大驱散单位数量 ('idc3')
 	constant abilityintegerlevelfield ABILITY_ILF_MAXIMUM_DISPELLED_UNITS = ConvertAbilityIntegerLevelField('idc3')
-    // 技能整数等级域 陷阱数量 ('imo1')
+    // 技能随等级改变的整数域 陷阱数量 ('imo1')
 	constant abilityintegerlevelfield ABILITY_ILF_NUMBER_OF_LURES = ConvertAbilityIntegerLevelField('imo1')
-    // 技能整数等级域 设置游戏时间 - 时 ('ict1')
+    // 技能随等级改变的整数域 设置游戏时间 - 时 ('ict1')
 	constant abilityintegerlevelfield ABILITY_ILF_NEW_TIME_OF_DAY_HOUR = ConvertAbilityIntegerLevelField('ict1')
-    // 技能整数等级域 设置游戏时间 - 分 ('ict2')
+    // 技能随等级改变的整数域 设置游戏时间 - 分 ('ict2')
 	constant abilityintegerlevelfield ABILITY_ILF_NEW_TIME_OF_DAY_MINUTE = ConvertAbilityIntegerLevelField('ict2')
-    // 技能整数等级域 创建单位数量 ('mec1')
+    // 技能随等级改变的整数域 创建单位数量 ('mec1')
 	constant abilityintegerlevelfield ABILITY_ILF_NUMBER_OF_UNITS_CREATED_MEC1 = ConvertAbilityIntegerLevelField('mec1')
-    // 技能整数等级域 最小法术数量 ('spb3')
+    // 技能随等级改变的整数域 最小法术数量 ('spb3')
 	constant abilityintegerlevelfield ABILITY_ILF_MINIMUM_SPELLS = ConvertAbilityIntegerLevelField('spb3')
-    // 技能整数等级域 最大法术数量 ('spb4')
+    // 技能随等级改变的整数域 最大法术数量 ('spb4')
 	constant abilityintegerlevelfield ABILITY_ILF_MAXIMUM_SPELLS = ConvertAbilityIntegerLevelField('spb4')
-    // 技能整数等级域 禁止攻击引索 ('gra3')
+    // 技能随等级改变的整数域 禁止攻击引索 ('gra3')
 	constant abilityintegerlevelfield ABILITY_ILF_DISABLED_ATTACK_INDEX = ConvertAbilityIntegerLevelField('gra3')
-    // 技能整数等级域 允许攻击引索 ('gra4')
+    // 技能随等级改变的整数域 允许攻击引索 ('gra4')
 	constant abilityintegerlevelfield ABILITY_ILF_ENABLED_ATTACK_INDEX_GRA4 = ConvertAbilityIntegerLevelField('gra4')
-    // 技能整数等级域 最大攻击次数 ('gra5')
+    // 技能随等级改变的整数域 最大攻击次数 ('gra5')
 	constant abilityintegerlevelfield ABILITY_ILF_MAXIMUM_ATTACKS = ConvertAbilityIntegerLevelField('gra5')
-    // 技能整数等级域 建筑类型允许 ('Npr1')
+    // 技能随等级改变的整数域 建筑类型允许 ('Npr1')
 	constant abilityintegerlevelfield ABILITY_ILF_BUILDING_TYPES_ALLOWED_NPR1 = ConvertAbilityIntegerLevelField('Npr1')
-    // 技能整数等级域 建筑类型允许 ('Nsa1')
+    // 技能随等级改变的整数域 建筑类型允许 ('Nsa1')
 	constant abilityintegerlevelfield ABILITY_ILF_BUILDING_TYPES_ALLOWED_NSA1 = ConvertAbilityIntegerLevelField('Nsa1')
-    // 技能整数等级域 攻击增加 ('Iaa1')
+    // 技能随等级改变的整数域 攻击增加 ('Iaa1')
 	constant abilityintegerlevelfield ABILITY_ILF_ATTACK_MODIFICATION = ConvertAbilityIntegerLevelField('Iaa1')
-    // 技能整数等级域 召唤单位数量 ('Npa5')
+    // 技能随等级改变的整数域 召唤单位数量 ('Npa5')
 	constant abilityintegerlevelfield ABILITY_ILF_SUMMONED_UNIT_COUNT_NPA5 = ConvertAbilityIntegerLevelField('Npa5')
-    // 技能整数等级域 科技升级等级 ('Igl1')
+    // 技能随等级改变的整数域 科技升级等级 ('Igl1')
 	constant abilityintegerlevelfield ABILITY_ILF_UPGRADE_LEVELS = ConvertAbilityIntegerLevelField('Igl1')
-    // 技能整数等级域 召唤单位数量 ('Ndo2')
+    // 技能随等级改变的整数域 召唤单位数量 ('Ndo2')
 	constant abilityintegerlevelfield ABILITY_ILF_NUMBER_OF_SUMMONED_UNITS_NDO2 = ConvertAbilityIntegerLevelField('Ndo2')
-    // 技能整数等级域 每秒野怪数量 ('Nst1')
+    // 技能随等级改变的整数域 每秒野怪数量 ('Nst1')
 	constant abilityintegerlevelfield ABILITY_ILF_BEASTS_PER_SECOND = ConvertAbilityIntegerLevelField('Nst1')
-    // 技能整数等级域 目标类型 ('Ncl2')
+    // 技能随等级改变的整数域 目标类型 ('Ncl2')
 	constant abilityintegerlevelfield ABILITY_ILF_TARGET_TYPE = ConvertAbilityIntegerLevelField('Ncl2')
-    // 技能整数等级域 选项 ('Ncl3')
+    // 技能随等级改变的整数域 选项 ('Ncl3')
 	constant abilityintegerlevelfield ABILITY_ILF_OPTIONS = ConvertAbilityIntegerLevelField('Ncl3')
-    // 技能整数等级域 护甲减少 ('Nab3')
+    // 技能随等级改变的整数域 护甲减少 ('Nab3')
 	constant abilityintegerlevelfield ABILITY_ILF_ARMOR_PENALTY_NAB3 = ConvertAbilityIntegerLevelField('Nab3')
-    // 技能整数等级域 医疗波次 ('Nhs6')
+    // 技能随等级改变的整数域 医疗波次 ('Nhs6')
 	constant abilityintegerlevelfield ABILITY_ILF_WAVE_COUNT_NHS6 = ConvertAbilityIntegerLevelField('Nhs6')
-    // 技能整数等级域 最大目标中立生物等级 ('Ntm3')
+    // 技能随等级改变的整数域 最大目标中立生物等级 ('Ntm3')
 	constant abilityintegerlevelfield ABILITY_ILF_MAX_CREEP_LEVEL_NTM3 = ConvertAbilityIntegerLevelField('Ntm3')
-    // 技能整数等级域 导弹数量 ('Ncs3')
+    // 技能随等级改变的整数域 导弹数量 ('Ncs3')
 	constant abilityintegerlevelfield ABILITY_ILF_MISSILE_COUNT = ConvertAbilityIntegerLevelField('Ncs3')
-    // 技能整数等级域 分裂所需攻击次数 ('Nlm3')
+    // 技能随等级改变的整数域 分裂所需攻击次数 ('Nlm3')
 	constant abilityintegerlevelfield ABILITY_ILF_SPLIT_ATTACK_COUNT = ConvertAbilityIntegerLevelField('Nlm3')
-    // 技能整数等级域 分裂代数 ('Nlm6')
+    // 技能随等级改变的整数域 分裂代数 ('Nlm6')
 	constant abilityintegerlevelfield ABILITY_ILF_GENERATION_COUNT = ConvertAbilityIntegerLevelField('Nlm6')
-    // 技能整数等级域 岩石数 ('Nvc1')
+    // 技能随等级改变的整数域 岩石数 ('Nvc1')
 	constant abilityintegerlevelfield ABILITY_ILF_ROCK_RING_COUNT = ConvertAbilityIntegerLevelField('Nvc1')
-    // 技能整数等级域 波数 ('Nvc2')
+    // 技能随等级改变的整数域 波数 ('Nvc2')
 	constant abilityintegerlevelfield ABILITY_ILF_WAVE_COUNT_NVC2 = ConvertAbilityIntegerLevelField('Nvc2')
-    // 技能整数等级域 影响敌方数量 ('Tau1')
+    // 技能随等级改变的整数域 影响敌方数量 ('Tau1')
 	constant abilityintegerlevelfield ABILITY_ILF_PREFER_HOSTILES_TAU1 = ConvertAbilityIntegerLevelField('Tau1')
-    // 技能整数等级域 影响友军数量 ('Tau2')
+    // 技能随等级改变的整数域 影响友军数量 ('Tau2')
 	constant abilityintegerlevelfield ABILITY_ILF_PREFER_FRIENDLIES_TAU2 = ConvertAbilityIntegerLevelField('Tau2')
-    // 技能整数等级域 最大单位数量 ('Tau3')
+    // 技能随等级改变的整数域 最大单位数量 ('Tau3')
 	constant abilityintegerlevelfield ABILITY_ILF_MAX_UNITS_TAU3 = ConvertAbilityIntegerLevelField('Tau3')
-    // 技能整数等级域 增加数量 ('Tau4')
+    // 技能随等级改变的整数域 增加数量 ('Tau4')
 	constant abilityintegerlevelfield ABILITY_ILF_NUMBER_OF_PULSES = ConvertAbilityIntegerLevelField('Tau4')
-    // 技能整数等级域 召唤单位类型 ('Hwe1')
+    // 技能随等级改变的整数域 召唤单位类型 ('Hwe1')
 	constant abilityintegerlevelfield ABILITY_ILF_SUMMONED_UNIT_TYPE_HWE1 = ConvertAbilityIntegerLevelField('Hwe1')
-    // 技能整数等级域 召唤单位类型 ('Uin4')
+    // 技能随等级改变的整数域 召唤单位类型 ('Uin4')
 	constant abilityintegerlevelfield ABILITY_ILF_SUMMONED_UNIT_UIN4 = ConvertAbilityIntegerLevelField('Uin4')
-    // 技能整数等级域 召唤单位类型 ('Osf1')
+    // 技能随等级改变的整数域 召唤单位类型 ('Osf1')
 	constant abilityintegerlevelfield ABILITY_ILF_SUMMONED_UNIT_OSF1 = ConvertAbilityIntegerLevelField('Osf1')
-    // 技能整数等级域 召唤单位类型 ('Efnu')
+    // 技能随等级改变的整数域 召唤单位类型 ('Efnu')
 	constant abilityintegerlevelfield ABILITY_ILF_SUMMONED_UNIT_TYPE_EFNU = ConvertAbilityIntegerLevelField('Efnu')
-    // 技能整数等级域 召唤单位类型 ('Nbau')
+    // 技能随等级改变的整数域 召唤单位类型 ('Nbau')
 	constant abilityintegerlevelfield ABILITY_ILF_SUMMONED_UNIT_TYPE_NBAU = ConvertAbilityIntegerLevelField('Nbau')
-    // 技能整数等级域 召唤单位类型 ('Ntou')
+    // 技能随等级改变的整数域 召唤单位类型 ('Ntou')
 	constant abilityintegerlevelfield ABILITY_ILF_SUMMONED_UNIT_TYPE_NTOU = ConvertAbilityIntegerLevelField('Ntou')
-    // 技能整数等级域 召唤单位类型 ('Esvu')
+    // 技能随等级改变的整数域 召唤单位类型 ('Esvu')
 	constant abilityintegerlevelfield ABILITY_ILF_SUMMONED_UNIT_TYPE_ESVU = ConvertAbilityIntegerLevelField('Esvu')
-    // 技能整数等级域 召唤单位类型 ('Nef1')
+    // 技能随等级改变的整数域 召唤单位类型 ('Nef1')
 	constant abilityintegerlevelfield ABILITY_ILF_SUMMONED_UNIT_TYPES = ConvertAbilityIntegerLevelField('Nef1')
-    // 技能整数等级域 召唤单位类型 ('Ndou')
+    // 技能随等级改变的整数域 召唤单位类型 ('Ndou')
 	constant abilityintegerlevelfield ABILITY_ILF_SUMMONED_UNIT_TYPE_NDOU = ConvertAbilityIntegerLevelField('Ndou')
-    // 技能整数等级域 变化形态单位 ('Emeu')
+    // 技能随等级改变的整数域 变化形态单位 ('Emeu')
 	constant abilityintegerlevelfield ABILITY_ILF_ALTERNATE_FORM_UNIT_EMEU = ConvertAbilityIntegerLevelField('Emeu')
-    // 技能整数等级域 疾病守卫单位类型 ('Aplu')
+    // 技能随等级改变的整数域 疾病守卫单位类型 ('Aplu')
 	constant abilityintegerlevelfield ABILITY_ILF_PLAGUE_WARD_UNIT_TYPE = ConvertAbilityIntegerLevelField('Aplu')
-    // 技能整数等级域 允许单位类型 ('Btl1')
+    // 技能随等级改变的整数域 允许单位类型 ('Btl1')
 	constant abilityintegerlevelfield ABILITY_ILF_ALLOWED_UNIT_TYPE_BTL1 = ConvertAbilityIntegerLevelField('Btl1')
-    // 技能整数等级域 替换单位类型 ('Cha1')
+    // 技能随等级改变的整数域 替换单位类型 ('Cha1')
 	constant abilityintegerlevelfield ABILITY_ILF_NEW_UNIT_TYPE = ConvertAbilityIntegerLevelField('Cha1')
-    // 技能整数等级域 新单位类型 ('ent1')
+    // 技能随等级改变的整数域 新单位类型 ('ent1')
 	constant abilityintegerlevelfield ABILITY_ILF_RESULTING_UNIT_TYPE_ENT1 = ConvertAbilityIntegerLevelField('ent1')
-    // 技能整数等级域 尸体单位类型 ('Gydu')
+    // 技能随等级改变的整数域 尸体单位类型 ('Gydu')
 	constant abilityintegerlevelfield ABILITY_ILF_CORPSE_UNIT_TYPE = ConvertAbilityIntegerLevelField('Gydu')
-    // 技能整数等级域 允许单位类型 ('Loa1')
+    // 技能随等级改变的整数域 允许单位类型 ('Loa1')
 	constant abilityintegerlevelfield ABILITY_ILF_ALLOWED_UNIT_TYPE_LOA1 = ConvertAbilityIntegerLevelField('Loa1')
-    // 技能整数等级域 单位类型限制检查 ('Raiu')
+    // 技能随等级改变的整数域 单位类型限制检查 ('Raiu')
 	constant abilityintegerlevelfield ABILITY_ILF_UNIT_TYPE_FOR_LIMIT_CHECK = ConvertAbilityIntegerLevelField('Raiu')
-    // 技能整数等级域 守卫单位类型 ('Stau')
+    // 技能随等级改变的整数域 守卫单位类型 ('Stau')
 	constant abilityintegerlevelfield ABILITY_ILF_WARD_UNIT_TYPE_STAU = ConvertAbilityIntegerLevelField('Stau')
-    // 技能整数等级域 效果技能 ('Iobu')
+    // 技能随等级改变的整数域 效果技能 ('Iobu')
 	constant abilityintegerlevelfield ABILITY_ILF_EFFECT_ABILITY = ConvertAbilityIntegerLevelField('Iobu')
-    // 技能整数等级域 变化单位类型 ('Ndc2')
+    // 技能随等级改变的整数域 变化单位类型 ('Ndc2')
 	constant abilityintegerlevelfield ABILITY_ILF_CONVERSION_UNIT = ConvertAbilityIntegerLevelField('Ndc2')
-    // 技能整数等级域 可被保存单位 ('Nsl1')
+    // 技能随等级改变的整数域 可被保存单位 ('Nsl1')
 	constant abilityintegerlevelfield ABILITY_ILF_UNIT_TO_PRESERVE = ConvertAbilityIntegerLevelField('Nsl1')
-    // 技能整数等级域 允许单位类型 ('Chl1')
+    // 技能随等级改变的整数域 允许单位类型 ('Chl1')
 	constant abilityintegerlevelfield ABILITY_ILF_UNIT_TYPE_ALLOWED = ConvertAbilityIntegerLevelField('Chl1')
-    // 技能整数等级域 蝗虫单位类型 ('Ulsu')
+    // 技能随等级改变的整数域 蝗虫单位类型 ('Ulsu')
 	constant abilityintegerlevelfield ABILITY_ILF_SWARM_UNIT_TYPE = ConvertAbilityIntegerLevelField('Ulsu')
-    // 技能整数等级域 合成单位类型 ('coau')
+    // 技能随等级改变的整数域 合成单位类型 ('coau')
 	constant abilityintegerlevelfield ABILITY_ILF_RESULTING_UNIT_TYPE_COAU = ConvertAbilityIntegerLevelField('coau')
-    // 技能整数等级域 尸体单位类型 ('exhu')
+    // 技能随等级改变的整数域 尸体单位类型 ('exhu')
 	constant abilityintegerlevelfield ABILITY_ILF_UNIT_TYPE_EXHU = ConvertAbilityIntegerLevelField('exhu')
-    // 技能整数等级域 守卫单位类型 ('hwdu')
+    // 技能随等级改变的整数域 守卫单位类型 ('hwdu')
 	constant abilityintegerlevelfield ABILITY_ILF_WARD_UNIT_TYPE_HWDU = ConvertAbilityIntegerLevelField('hwdu')
-    // 技能整数等级域 陷阱单位类型 ('imou')
+    // 技能随等级改变的整数域 陷阱单位类型 ('imou')
 	constant abilityintegerlevelfield ABILITY_ILF_LURE_UNIT_TYPE = ConvertAbilityIntegerLevelField('imou')
-    // 技能整数等级域 单位类型 ('ipmu')
+    // 技能随等级改变的整数域 单位类型 ('ipmu')
 	constant abilityintegerlevelfield ABILITY_ILF_UNIT_TYPE_IPMU = ConvertAbilityIntegerLevelField('ipmu')
-    // 技能整数等级域 工厂单位ID ('Nsyu')
+    // 技能随等级改变的整数域 工厂单位ID ('Nsyu')
 	constant abilityintegerlevelfield ABILITY_ILF_FACTORY_UNIT_ID = ConvertAbilityIntegerLevelField('Nsyu')
-    // 技能整数等级域 生产单位ID ('Nfyu')
+    // 技能随等级改变的整数域 生产单位ID ('Nfyu')
 	constant abilityintegerlevelfield ABILITY_ILF_SPAWN_UNIT_ID_NFYU = ConvertAbilityIntegerLevelField('Nfyu')
-    // 技能整数等级域 可破坏物ID ('Nvcu')
+    // 技能随等级改变的整数域 可破坏物ID ('Nvcu')
 	constant abilityintegerlevelfield ABILITY_ILF_DESTRUCTIBLE_ID = ConvertAbilityIntegerLevelField('Nvcu')
-    // 技能整数等级域 科技类型 ('Iglu')
+    // 技能随等级改变的整数域 科技类型 ('Iglu')
 	constant abilityintegerlevelfield ABILITY_ILF_UPGRADE_TYPE = ConvertAbilityIntegerLevelField('Iglu')
 	
-    // 技能实数等级域 魔法释放时间 ('acas')
+    // 技能随等级改变的实数域 魔法释放时间 ('acas')
 	constant abilityreallevelfield ABILITY_RLF_CASTING_TIME = ConvertAbilityRealLevelField('acas')
-    // 技能实数等级域 持续时间 - 普通 ('adur')
+    // 技能随等级改变的实数域 持续时间 - 普通 ('adur')
 	constant abilityreallevelfield ABILITY_RLF_DURATION_NORMAL = ConvertAbilityRealLevelField('adur')
-    // 技能实数等级域 持续时间 - 英雄 ('ahdu')
+    // 技能随等级改变的实数域 持续时间 - 英雄 ('ahdu')
 	constant abilityreallevelfield ABILITY_RLF_DURATION_HERO = ConvertAbilityRealLevelField('ahdu')
-    // 技能实数等级域 魔法释放时间间隔 ('acdn')
+    // 技能随等级改变的实数域 魔法释放时间间隔 ('acdn')
 	constant abilityreallevelfield ABILITY_RLF_COOLDOWN = ConvertAbilityRealLevelField('acdn')
-    // 技能实数等级域 影响区域 ('aare')
+    // 技能随等级改变的实数域 影响区域 ('aare')
 	constant abilityreallevelfield ABILITY_RLF_AREA_OF_EFFECT = ConvertAbilityRealLevelField('aare')
-    // 技能实数等级域 施法距离 ('aran')
+    // 技能随等级改变的实数域 施法距离 ('aran')
 	constant abilityreallevelfield ABILITY_RLF_CAST_RANGE = ConvertAbilityRealLevelField('aran')
-    // 技能实数等级域 每波伤害 ('Hbz2')
+    // 技能随等级改变的实数域 每波伤害 ('Hbz2')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_HBZ2 = ConvertAbilityRealLevelField('Hbz2')
-    // 技能实数等级域 建筑伤害参数（%） ('Hbz4')
+    // 技能随等级改变的实数域 建筑伤害参数（%） ('Hbz4')
 	constant abilityreallevelfield ABILITY_RLF_BUILDING_REDUCTION_HBZ4 = ConvertAbilityRealLevelField('Hbz4')
-    // 技能实数等级域 每秒伤害 ('Hbz5')
+    // 技能随等级改变的实数域 每秒伤害 ('Hbz5')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_PER_SECOND_HBZ5 = ConvertAbilityRealLevelField('Hbz5')
-    // 技能实数等级域 每波最大伤害 ('Hbz6')
+    // 技能随等级改变的实数域 每波最大伤害 ('Hbz6')
 	constant abilityreallevelfield ABILITY_RLF_MAXIMUM_DAMAGE_PER_WAVE = ConvertAbilityRealLevelField('Hbz6')
-    // 技能实数等级域 魔法回复加快 ('Hab1')
+    // 技能随等级改变的实数域 魔法回复加快 ('Hab1')
 	constant abilityreallevelfield ABILITY_RLF_MANA_REGENERATION_INCREASE = ConvertAbilityRealLevelField('Hab1')
-    // 技能实数等级域 魔法施放延迟 ('Hmt2')
+    // 技能随等级改变的实数域 魔法施放延迟 ('Hmt2')
 	constant abilityreallevelfield ABILITY_RLF_CASTING_DELAY = ConvertAbilityRealLevelField('Hmt2')
-    // 技能实数等级域 每秒伤害 ('Oww1')
+    // 技能随等级改变的实数域 每秒伤害 ('Oww1')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_PER_SECOND_OWW1 = ConvertAbilityRealLevelField('Oww1')
-    // 技能实数等级域 魔法伤害减少 ('Oww2')
+    // 技能随等级改变的实数域 魔法伤害减少 ('Oww2')
 	constant abilityreallevelfield ABILITY_RLF_MAGIC_DAMAGE_REDUCTION_OWW2 = ConvertAbilityRealLevelField('Oww2')
-    // 技能实数等级域 致命一击几率 ('Ocr1')
+    // 技能随等级改变的实数域 致命一击几率 ('Ocr1')
 	constant abilityreallevelfield ABILITY_RLF_CHANCE_TO_CRITICAL_STRIKE = ConvertAbilityRealLevelField('Ocr1')
-    // 技能实数等级域 伤害倍数 ('Ocr2')
+    // 技能随等级改变的实数域 伤害倍数 ('Ocr2')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_MULTIPLIER_OCR2 = ConvertAbilityRealLevelField('Ocr2')
-    // 技能实数等级域 伤害奖励 ('Ocr3')
+    // 技能随等级改变的实数域 伤害奖励 ('Ocr3')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_BONUS_OCR3 = ConvertAbilityRealLevelField('Ocr3')
-    // 技能实数等级域 闪避几率 ('Ocr4')
+    // 技能随等级改变的实数域 闪避几率 ('Ocr4')
 	constant abilityreallevelfield ABILITY_RLF_CHANCE_TO_EVADE_OCR4 = ConvertAbilityRealLevelField('Ocr4')
-    // 技能实数等级域 施加伤害（%） ('Omi2')
+    // 技能随等级改变的实数域 施加伤害（%） ('Omi2')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_DEALT_PERCENT_OMI2 = ConvertAbilityRealLevelField('Omi2')
-    // 技能实数等级域 所受伤害（%） ('Omi3')
+    // 技能随等级改变的实数域 所受伤害（%） ('Omi3')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_TAKEN_PERCENT_OMI3 = ConvertAbilityRealLevelField('Omi3')
-    // 技能实数等级域 技能延迟 ('Omi4')
+    // 技能随等级改变的实数域 技能延迟 ('Omi4')
 	constant abilityreallevelfield ABILITY_RLF_ANIMATION_DELAY = ConvertAbilityRealLevelField('Omi4')
-    // 技能实数等级域 转变时间 ('Owk1')
+    // 技能随等级改变的实数域 转变时间 ('Owk1')
 	constant abilityreallevelfield ABILITY_RLF_TRANSITION_TIME = ConvertAbilityRealLevelField('Owk1')
-    // 技能实数等级域 移动速度增加（%） ('Owk2')
+    // 技能随等级改变的实数域 移动速度增加（%） ('Owk2')
 	constant abilityreallevelfield ABILITY_RLF_MOVEMENT_SPEED_INCREASE_PERCENT_OWK2 = ConvertAbilityRealLevelField('Owk2')
-    // 技能实数等级域 加成伤害 ('Owk3')
+    // 技能随等级改变的实数域 加成伤害 ('Owk3')
 	constant abilityreallevelfield ABILITY_RLF_BACKSTAB_DAMAGE = ConvertAbilityRealLevelField('Owk3')
-    // 技能实数等级域 治疗数值 ('Udc1')
+    // 技能随等级改变的实数域 治疗数值 ('Udc1')
 	constant abilityreallevelfield ABILITY_RLF_AMOUNT_HEALED_DAMAGED_UDC1 = ConvertAbilityRealLevelField('Udc1')
-    // 技能实数等级域 每点生命转换为魔法 ('Udp1')
+    // 技能随等级改变的实数域 每点生命转换为魔法 ('Udp1')
 	constant abilityreallevelfield ABILITY_RLF_LIFE_CONVERTED_TO_MANA = ConvertAbilityRealLevelField('Udp1')
-    // 技能实数等级域 每点生命转换为生命 ('Udp2')
+    // 技能随等级改变的实数域 每点生命转换为生命 ('Udp2')
 	constant abilityreallevelfield ABILITY_RLF_LIFE_CONVERTED_TO_LIFE = ConvertAbilityRealLevelField('Udp2')
-    // 技能实数等级域 移动速率增加（%） ('Uau1')
+    // 技能随等级改变的实数域 移动速率增加（%） ('Uau1')
 	constant abilityreallevelfield ABILITY_RLF_MOVEMENT_SPEED_INCREASE_PERCENT_UAU1 = ConvertAbilityRealLevelField('Uau1')
-    // 技能实数等级域 生命回复增加 ('Uau2')
+    // 技能随等级改变的实数域 生命回复增加 ('Uau2')
 	constant abilityreallevelfield ABILITY_RLF_LIFE_REGENERATION_INCREASE_PERCENT = ConvertAbilityRealLevelField('Uau2')
-    // 技能实数等级域 闪避几率 ('Eev1')
+    // 技能随等级改变的实数域 闪避几率 ('Eev1')
 	constant abilityreallevelfield ABILITY_RLF_CHANCE_TO_EVADE_EEV1 = ConvertAbilityRealLevelField('Eev1')
-    // 技能实数等级域 伤害/间隔时间 ('Eim1')
+    // 技能随等级改变的实数域 伤害/间隔时间 ('Eim1')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_PER_INTERVAL = ConvertAbilityRealLevelField('Eim1')
-    // 技能实数等级域 每秒魔法消耗 ('Eim2')
+    // 技能随等级改变的实数域 每秒魔法消耗 ('Eim2')
 	constant abilityreallevelfield ABILITY_RLF_MANA_DRAINED_PER_SECOND_EIM2 = ConvertAbilityRealLevelField('Eim2')
-    // 技能实数等级域 启动魔法需求 ('Eim3')
+    // 技能随等级改变的实数域 启动魔法需求 ('Eim3')
 	constant abilityreallevelfield ABILITY_RLF_BUFFER_MANA_REQUIRED = ConvertAbilityRealLevelField('Eim3')
-    // 技能实数等级域 魔法燃烧值 ('Emb1')
+    // 技能随等级改变的实数域 魔法燃烧值 ('Emb1')
 	constant abilityreallevelfield ABILITY_RLF_MAX_MANA_DRAINED = ConvertAbilityRealLevelField('Emb1')
-    // 技能实数等级域 数字显示延迟 ('Emb2')
+    // 技能随等级改变的实数域 数字显示延迟 ('Emb2')
 	constant abilityreallevelfield ABILITY_RLF_BOLT_DELAY = ConvertAbilityRealLevelField('Emb2')
-    // 技能实数等级域 数字显示持续时间 ('Emb3')
+    // 技能随等级改变的实数域 数字显示持续时间 ('Emb3')
 	constant abilityreallevelfield ABILITY_RLF_BOLT_LIFETIME = ConvertAbilityRealLevelField('Emb3')
-    // 技能实数等级域 高度调整时间 ('Eme3')
+    // 技能随等级改变的实数域 高度调整时间 ('Eme3')
 	constant abilityreallevelfield ABILITY_RLF_ALTITUDE_ADJUSTMENT_DURATION = ConvertAbilityRealLevelField('Eme3')
-    // 技能实数等级域 着陆延迟时间 ('Eme4')
+    // 技能随等级改变的实数域 着陆延迟时间 ('Eme4')
 	constant abilityreallevelfield ABILITY_RLF_LANDING_DELAY_TIME = ConvertAbilityRealLevelField('Eme4')
-    // 技能实数等级域 变形生命值奖励 ('Eme5')
+    // 技能随等级改变的实数域 变形生命值奖励 ('Eme5')
 	constant abilityreallevelfield ABILITY_RLF_ALTERNATE_FORM_HIT_POINT_BONUS = ConvertAbilityRealLevelField('Eme5')
-    // 技能实数等级域 移动速度奖励（仅限信息面板） ('Ncr5')
+    // 技能随等级改变的实数域 移动速度奖励（仅限信息面板） ('Ncr5')
 	constant abilityreallevelfield ABILITY_RLF_MOVE_SPEED_BONUS_INFO_PANEL_ONLY = ConvertAbilityRealLevelField('Ncr5')
-    // 技能实数等级域 攻击速度奖励（仅限信息面板） ('Ncr6')
+    // 技能随等级改变的实数域 攻击速度奖励（仅限信息面板） ('Ncr6')
 	constant abilityreallevelfield ABILITY_RLF_ATTACK_SPEED_BONUS_INFO_PANEL_ONLY = ConvertAbilityRealLevelField('Ncr6')
-    // 技能实数等级域 每秒生命回复 ('ave5')
+    // 技能随等级改变的实数域 每秒生命回复 ('ave5')
 	constant abilityreallevelfield ABILITY_RLF_LIFE_REGENERATION_RATE_PER_SECOND = ConvertAbilityRealLevelField('ave5')
-    // 技能实数等级域 无敌时间 ('Usl1')
+    // 技能随等级改变的实数域 无敌时间 ('Usl1')
 	constant abilityreallevelfield ABILITY_RLF_STUN_DURATION_USL1 = ConvertAbilityRealLevelField('Usl1')
-    // 技能实数等级域 近战伤害偷取（%） ('Uav1')
+    // 技能随等级改变的实数域 近战伤害偷取（%） ('Uav1')
 	constant abilityreallevelfield ABILITY_RLF_ATTACK_DAMAGE_STOLEN_PERCENT = ConvertAbilityRealLevelField('Uav1')
-    // 技能实数等级域 伤害 ('Ucs1')
+    // 技能随等级改变的实数域 伤害 ('Ucs1')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_UCS1 = ConvertAbilityRealLevelField('Ucs1')
-    // 技能实数等级域 最大伤害 ('Ucs2')
+    // 技能随等级改变的实数域 最大伤害 ('Ucs2')
 	constant abilityreallevelfield ABILITY_RLF_MAX_DAMAGE_UCS2 = ConvertAbilityRealLevelField('Ucs2')
-    // 技能实数等级域 距离 ('Ucs3')
+    // 技能随等级改变的实数域 距离 ('Ucs3')
 	constant abilityreallevelfield ABILITY_RLF_DISTANCE_UCS3 = ConvertAbilityRealLevelField('Ucs3')
-    // 技能实数等级域 最终区域范围 ('Ucs4')
+    // 技能随等级改变的实数域 最终区域范围 ('Ucs4')
 	constant abilityreallevelfield ABILITY_RLF_FINAL_AREA_UCS4 = ConvertAbilityRealLevelField('Ucs4')
-    // 技能实数等级域 伤害 ('Uin1')
+    // 技能随等级改变的实数域 伤害 ('Uin1')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_UIN1 = ConvertAbilityRealLevelField('Uin1')
-    // 技能实数等级域 单位持续时间 ('Uin2')
+    // 技能随等级改变的实数域 单位持续时间 ('Uin2')
 	constant abilityreallevelfield ABILITY_RLF_DURATION = ConvertAbilityRealLevelField('Uin2')
-    // 技能实数等级域 碰撞延迟 ('Uin3')
+    // 技能随等级改变的实数域 碰撞延迟 ('Uin3')
 	constant abilityreallevelfield ABILITY_RLF_IMPACT_DELAY = ConvertAbilityRealLevelField('Uin3')
-    // 技能实数等级域 伤害 ('Ocl1')
+    // 技能随等级改变的实数域 伤害 ('Ocl1')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_PER_TARGET_OCL1 = ConvertAbilityRealLevelField('Ocl1')
-    // 技能实数等级域 单位持续时间 ('Ocl3')
+    // 技能随等级改变的实数域 单位持续时间 ('Ocl3')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_REDUCTION_PER_TARGET = ConvertAbilityRealLevelField('Ocl3')
-    // 技能实数等级域 效果延迟 ('Oeq1')
+    // 技能随等级改变的实数域 效果延迟 ('Oeq1')
 	constant abilityreallevelfield ABILITY_RLF_EFFECT_DELAY_OEQ1 = ConvertAbilityRealLevelField('Oeq1')
-    // 技能实数等级域 每秒对建筑伤害 ('Oeq2')
+    // 技能随等级改变的实数域 每秒对建筑伤害 ('Oeq2')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_PER_SECOND_TO_BUILDINGS = ConvertAbilityRealLevelField('Oeq2')
-    // 技能实数等级域 单位减速（%） ('Oeq3')
+    // 技能随等级改变的实数域 单位减速（%） ('Oeq3')
 	constant abilityreallevelfield ABILITY_RLF_UNITS_SLOWED_PERCENT = ConvertAbilityRealLevelField('Oeq3')
-    // 技能实数等级域 最终区域范围 ('Oeq4')
+    // 技能随等级改变的实数域 最终区域范围 ('Oeq4')
 	constant abilityreallevelfield ABILITY_RLF_FINAL_AREA_OEQ4 = ConvertAbilityRealLevelField('Oeq4')
-    // 技能实数等级域 每秒伤害 ('Eer1')
+    // 技能随等级改变的实数域 每秒伤害 ('Eer1')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_PER_SECOND_EER1 = ConvertAbilityRealLevelField('Eer1')
-    // 技能实数等级域 近战伤害反弹 ('Eah1')
+    // 技能随等级改变的实数域 近战伤害反弹 ('Eah1')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_DEALT_TO_ATTACKERS = ConvertAbilityRealLevelField('Eah1')
-    // 技能实数等级域 治疗生命值 ('Etq1')
+    // 技能随等级改变的实数域 治疗生命值 ('Etq1')
 	constant abilityreallevelfield ABILITY_RLF_LIFE_HEALED = ConvertAbilityRealLevelField('Etq1')
-    // 技能实数等级域 治疗间隔 ('Etq2')
+    // 技能随等级改变的实数域 治疗间隔 ('Etq2')
 	constant abilityreallevelfield ABILITY_RLF_HEAL_INTERVAL = ConvertAbilityRealLevelField('Etq2')
-    // 技能实数等级域 建筑伤害参数（无效） ('Etq3')
+    // 技能随等级改变的实数域 建筑伤害参数（无效） ('Etq3')
 	constant abilityreallevelfield ABILITY_RLF_BUILDING_REDUCTION_ETQ3 = ConvertAbilityRealLevelField('Etq3')
-    // 技能实数等级域 初始完成CD ('Etq4')
+    // 技能随等级改变的实数域 初始完成CD ('Etq4')
 	constant abilityreallevelfield ABILITY_RLF_INITIAL_IMMUNITY_DURATION = ConvertAbilityRealLevelField('Etq4')
-    // 技能实数等级域 每秒损耗生命百分比 ('Udd1')
+    // 技能随等级改变的实数域 每秒损耗生命百分比 ('Udd1')
 	constant abilityreallevelfield ABILITY_RLF_MAX_LIFE_DRAINED_PER_SECOND_PERCENT = ConvertAbilityRealLevelField('Udd1')
-    // 技能实数等级域 建筑伤害参数（无效） ('Udd2')
+    // 技能随等级改变的实数域 建筑伤害参数（无效） ('Udd2')
 	constant abilityreallevelfield ABILITY_RLF_BUILDING_REDUCTION_UDD2 = ConvertAbilityRealLevelField('Udd2')
-    // 技能实数等级域 护甲持续时间 ('Ufa1')
+    // 技能随等级改变的实数域 护甲持续时间 ('Ufa1')
 	constant abilityreallevelfield ABILITY_RLF_ARMOR_DURATION = ConvertAbilityRealLevelField('Ufa1')
-    // 技能实数等级域 防御奖励 ('Ufa2')
+    // 技能随等级改变的实数域 防御奖励 ('Ufa2')
 	constant abilityreallevelfield ABILITY_RLF_ARMOR_BONUS_UFA2 = ConvertAbilityRealLevelField('Ufa2')
-    // 技能实数等级域 范围目标伤害 ('Ufn1')
+    // 技能随等级改变的实数域 范围目标伤害 ('Ufn1')
 	constant abilityreallevelfield ABILITY_RLF_AREA_OF_EFFECT_DAMAGE = ConvertAbilityRealLevelField('Ufn1')
-    // 技能实数等级域 特定目标伤害 ('Ufn2')
+    // 技能随等级改变的实数域 特定目标伤害 ('Ufn2')
 	constant abilityreallevelfield ABILITY_RLF_SPECIFIC_TARGET_DAMAGE_UFN2 = ConvertAbilityRealLevelField('Ufn2')
-    // 技能实数等级域 伤害奖励 ('Hfa1')
+    // 技能随等级改变的实数域 伤害奖励 ('Hfa1')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_BONUS_HFA1 = ConvertAbilityRealLevelField('Hfa1')
-    // 技能实数等级域 伤害 ('Esf1')
+    // 技能随等级改变的实数域 伤害 ('Esf1')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_DEALT_ESF1 = ConvertAbilityRealLevelField('Esf1')
-    // 技能实数等级域 伤害间隔 ('Esf2')
+    // 技能随等级改变的实数域 伤害间隔 ('Esf2')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_INTERVAL_ESF2 = ConvertAbilityRealLevelField('Esf2')
-    // 技能实数等级域 建筑伤害参数（%） ('Esf3')
+    // 技能随等级改变的实数域 建筑伤害参数（%） ('Esf3')
 	constant abilityreallevelfield ABILITY_RLF_BUILDING_REDUCTION_ESF3 = ConvertAbilityRealLevelField('Esf3')
-    // 技能实数等级域 伤害奖励（%） ('Ear1')
+    // 技能随等级改变的实数域 伤害奖励（%） ('Ear1')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_BONUS_PERCENT = ConvertAbilityRealLevelField('Ear1')
-    // 技能实数等级域 防御奖励 ('Hav1')
+    // 技能随等级改变的实数域 防御奖励 ('Hav1')
 	constant abilityreallevelfield ABILITY_RLF_DEFENSE_BONUS_HAV1 = ConvertAbilityRealLevelField('Hav1')
-    // 技能实数等级域 生命值奖励 ('Hav2')
+    // 技能随等级改变的实数域 生命值奖励 ('Hav2')
 	constant abilityreallevelfield ABILITY_RLF_HIT_POINT_BONUS = ConvertAbilityRealLevelField('Hav2')
-    // 技能实数等级域 伤害奖励 ('Hav3')
+    // 技能随等级改变的实数域 伤害奖励 ('Hav3')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_BONUS_HAV3 = ConvertAbilityRealLevelField('Hav3')
-    // 技能实数等级域 魔法伤害减少（无效） ('Hav4')
+    // 技能随等级改变的实数域 魔法伤害减少（无效） ('Hav4')
 	constant abilityreallevelfield ABILITY_RLF_MAGIC_DAMAGE_REDUCTION_HAV4 = ConvertAbilityRealLevelField('Hav4')
-    // 技能实数等级域 重击几率 ('Hbh1')
+    // 技能随等级改变的实数域 重击几率 ('Hbh1')
 	constant abilityreallevelfield ABILITY_RLF_CHANCE_TO_BASH = ConvertAbilityRealLevelField('Hbh1')
-    // 技能实数等级域 伤害倍数 ('Hbh2')
+    // 技能随等级改变的实数域 伤害倍数 ('Hbh2')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_MULTIPLIER_HBH2 = ConvertAbilityRealLevelField('Hbh2')
-    // 技能实数等级域 伤害奖励 ('Hbh3')
+    // 技能随等级改变的实数域 伤害奖励 ('Hbh3')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_BONUS_HBH3 = ConvertAbilityRealLevelField('Hbh3')
-    // 技能实数等级域 未命中率 ('Hbh4')
+    // 技能随等级改变的实数域 未命中率 ('Hbh4')
 	constant abilityreallevelfield ABILITY_RLF_CHANCE_TO_MISS_HBH4 = ConvertAbilityRealLevelField('Hbh4')
-    // 技能实数等级域 伤害 ('Htb1')
+    // 技能随等级改变的实数域 伤害 ('Htb1')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_HTB1 = ConvertAbilityRealLevelField('Htb1')
-    // 技能实数等级域 范围伤害 ('Htc1')
+    // 技能随等级改变的实数域 范围伤害 ('Htc1')
 	constant abilityreallevelfield ABILITY_RLF_AOE_DAMAGE = ConvertAbilityRealLevelField('Htc1')
-    // 技能实数等级域 指定目标伤害（无效） ('Htc2')
+    // 技能随等级改变的实数域 指定目标伤害（无效） ('Htc2')
 	constant abilityreallevelfield ABILITY_RLF_SPECIFIC_TARGET_DAMAGE_HTC2 = ConvertAbilityRealLevelField('Htc2')
-    // 技能实数等级域 移动速度减少（%） ('Htc3')
+    // 技能随等级改变的实数域 移动速度减少（%） ('Htc3')
 	constant abilityreallevelfield ABILITY_RLF_MOVEMENT_SPEED_REDUCTION_PERCENT_HTC3 = ConvertAbilityRealLevelField('Htc3')
-    // 技能实数等级域 攻击速度减少（%） ('Htc4')
+    // 技能随等级改变的实数域 攻击速度减少（%） ('Htc4')
 	constant abilityreallevelfield ABILITY_RLF_ATTACK_SPEED_REDUCTION_PERCENT_HTC4 = ConvertAbilityRealLevelField('Htc4')
-    // 技能实数等级域 防御奖励 ('Had1')
+    // 技能随等级改变的实数域 防御奖励 ('Had1')
 	constant abilityreallevelfield ABILITY_RLF_ARMOR_BONUS_HAD1 = ConvertAbilityRealLevelField('Had1')
-    // 技能实数等级域 治疗数值 ('Hhb1')
+    // 技能随等级改变的实数域 治疗数值 ('Hhb1')
 	constant abilityreallevelfield ABILITY_RLF_AMOUNT_HEALED_DAMAGED_HHB1 = ConvertAbilityRealLevelField('Hhb1')
-    // 技能实数等级域 附加伤害 ('Hca1')
+    // 技能随等级改变的实数域 附加伤害 ('Hca1')
 	constant abilityreallevelfield ABILITY_RLF_EXTRA_DAMAGE_HCA1 = ConvertAbilityRealLevelField('Hca1')
-    // 技能实数等级域 移动速度减少（%） ('Hca2')
+    // 技能随等级改变的实数域 移动速度减少（%） ('Hca2')
 	constant abilityreallevelfield ABILITY_RLF_MOVEMENT_SPEED_FACTOR_HCA2 = ConvertAbilityRealLevelField('Hca2')
-    // 技能实数等级域 攻击速度减少（%） ('Hca3')
+    // 技能随等级改变的实数域 攻击速度减少（%） ('Hca3')
 	constant abilityreallevelfield ABILITY_RLF_ATTACK_SPEED_FACTOR_HCA3 = ConvertAbilityRealLevelField('Hca3')
-    // 技能实数等级域 移动速度增加（%） ('Oae1')
+    // 技能随等级改变的实数域 移动速度增加（%） ('Oae1')
 	constant abilityreallevelfield ABILITY_RLF_MOVEMENT_SPEED_INCREASE_PERCENT_OAE1 = ConvertAbilityRealLevelField('Oae1')
-    // 技能实数等级域 攻击速度增加（%） ('Oae2')
+    // 技能随等级改变的实数域 攻击速度增加（%） ('Oae2')
 	constant abilityreallevelfield ABILITY_RLF_ATTACK_SPEED_INCREASE_PERCENT_OAE2 = ConvertAbilityRealLevelField('Oae2')
-    // 技能实数等级域 重生延迟 ('Ore1')
+    // 技能随等级改变的实数域 重生延迟 ('Ore1')
 	constant abilityreallevelfield ABILITY_RLF_REINCARNATION_DELAY = ConvertAbilityRealLevelField('Ore1')
-    // 技能实数等级域 伤害 ('Osh1')
+    // 技能随等级改变的实数域 伤害 ('Osh1')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_OSH1 = ConvertAbilityRealLevelField('Osh1')
-    // 技能实数等级域 最大伤害 ('Osh2')
+    // 技能随等级改变的实数域 最大伤害 ('Osh2')
 	constant abilityreallevelfield ABILITY_RLF_MAXIMUM_DAMAGE_OSH2 = ConvertAbilityRealLevelField('Osh2')
-    // 技能实数等级域 距离 ('Osh3')
+    // 技能随等级改变的实数域 距离 ('Osh3')
 	constant abilityreallevelfield ABILITY_RLF_DISTANCE_OSH3 = ConvertAbilityRealLevelField('Osh3')
-    // 技能实数等级域 最终区域范围 ('Osh4')
+    // 技能随等级改变的实数域 最终区域范围 ('Osh4')
 	constant abilityreallevelfield ABILITY_RLF_FINAL_AREA_OSH4 = ConvertAbilityRealLevelField('Osh4')
-    // 技能实数等级域 效果延迟 ('Nfd1')
+    // 技能随等级改变的实数域 效果延迟 ('Nfd1')
 	constant abilityreallevelfield ABILITY_RLF_GRAPHIC_DELAY_NFD1 = ConvertAbilityRealLevelField('Nfd1')
-    // 技能实数等级域 效果持续时间 ('Nfd2')
+    // 技能随等级改变的实数域 效果持续时间 ('Nfd2')
 	constant abilityreallevelfield ABILITY_RLF_GRAPHIC_DURATION_NFD2 = ConvertAbilityRealLevelField('Nfd2')
-    // 技能实数等级域 伤害 ('Nfd3')
+    // 技能随等级改变的实数域 伤害 ('Nfd3')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_NFD3 = ConvertAbilityRealLevelField('Nfd3')
-    // 技能实数等级域 对召唤单位伤害 ('Ams1')
+    // 技能随等级改变的实数域 对召唤单位伤害 ('Ams1')
 	constant abilityreallevelfield ABILITY_RLF_SUMMONED_UNIT_DAMAGE_AMS1 = ConvertAbilityRealLevelField('Ams1')
-    // 技能实数等级域 魔法伤害减少（无效） ('Ams2')
+    // 技能随等级改变的实数域 魔法伤害减少（无效） ('Ams2')
 	constant abilityreallevelfield ABILITY_RLF_MAGIC_DAMAGE_REDUCTION_AMS2 = ConvertAbilityRealLevelField('Ams2')
-    // 技能实数等级域 疾病效果持续时间 ('Apl1')
+    // 技能随等级改变的实数域 疾病效果持续时间 ('Apl1')
 	constant abilityreallevelfield ABILITY_RLF_AURA_DURATION = ConvertAbilityRealLevelField('Apl1')
-    // 技能实数等级域 每秒伤害 ('Apl2')
+    // 技能随等级改变的实数域 每秒伤害 ('Apl2')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_PER_SECOND_APL2 = ConvertAbilityRealLevelField('Apl2')
-    // 技能实数等级域 疾病守卫持续时间 ('Apl3')
+    // 技能随等级改变的实数域 疾病守卫持续时间 ('Apl3')
 	constant abilityreallevelfield ABILITY_RLF_DURATION_OF_PLAGUE_WARD = ConvertAbilityRealLevelField('Apl3')
-    // 技能实数等级域 每秒生命恢复 ('Oar1')
+    // 技能随等级改变的实数域 每秒生命恢复 ('Oar1')
 	constant abilityreallevelfield ABILITY_RLF_AMOUNT_OF_HIT_POINTS_REGENERATED = ConvertAbilityRealLevelField('Oar1')
-    // 技能实数等级域 攻击伤害增加 ('Akb1')
+    // 技能随等级改变的实数域 攻击伤害增加 ('Akb1')
 	constant abilityreallevelfield ABILITY_RLF_ATTACK_DAMAGE_INCREASE_AKB1 = ConvertAbilityRealLevelField('Akb1')
-    // 技能实数等级域 目标魔法损耗 ('Adm1')
+    // 技能随等级改变的实数域 目标魔法损耗 ('Adm1')
 	constant abilityreallevelfield ABILITY_RLF_MANA_LOSS_ADM1 = ConvertAbilityRealLevelField('Adm1')
-    // 技能实数等级域 对召唤单位伤害 ('Adm2')
+    // 技能随等级改变的实数域 对召唤单位伤害 ('Adm2')
 	constant abilityreallevelfield ABILITY_RLF_SUMMONED_UNIT_DAMAGE_ADM2 = ConvertAbilityRealLevelField('Adm2')
-    // 技能实数等级域 扩张范围 ('Bli1')
+    // 技能随等级改变的实数域 扩张范围 ('Bli1')
 	constant abilityreallevelfield ABILITY_RLF_EXPANSION_AMOUNT = ConvertAbilityRealLevelField('Bli1')
-    // 技能实数等级域 采集间隔时间 ('Bgm2')
+    // 技能随等级改变的实数域 采集间隔时间 ('Bgm2')
 	constant abilityreallevelfield ABILITY_RLF_INTERVAL_DURATION_BGM2 = ConvertAbilityRealLevelField('Bgm2')
-    // 技能实数等级域 采集环形半径 ('Bgm4')
+    // 技能随等级改变的实数域 采集环形半径 ('Bgm4')
 	constant abilityreallevelfield ABILITY_RLF_RADIUS_OF_MINING_RING = ConvertAbilityRealLevelField('Bgm4')
-    // 技能实数等级域 攻击速度增加（%） ('Blo1')
+    // 技能随等级改变的实数域 攻击速度增加（%） ('Blo1')
 	constant abilityreallevelfield ABILITY_RLF_ATTACK_SPEED_INCREASE_PERCENT_BLO1 = ConvertAbilityRealLevelField('Blo1')
-    // 技能实数等级域 移动速度增加（%） ('Blo2')
+    // 技能随等级改变的实数域 移动速度增加（%） ('Blo2')
 	constant abilityreallevelfield ABILITY_RLF_MOVEMENT_SPEED_INCREASE_PERCENT_BLO2 = ConvertAbilityRealLevelField('Blo2')
-    // 技能实数等级域 模型放大比例 ('Blo3')
+    // 技能随等级改变的实数域 模型放大比例 ('Blo3')
 	constant abilityreallevelfield ABILITY_RLF_SCALING_FACTOR = ConvertAbilityRealLevelField('Blo3')
-    // 技能实数等级域 每秒恢复生命 ('Can1')
+    // 技能随等级改变的实数域 每秒恢复生命 ('Can1')
 	constant abilityreallevelfield ABILITY_RLF_HIT_POINTS_PER_SECOND_CAN1 = ConvertAbilityRealLevelField('Can1')
-    // 技能实数等级域 最大恢复生命 ('Can2')
+    // 技能随等级改变的实数域 最大恢复生命 ('Can2')
 	constant abilityreallevelfield ABILITY_RLF_MAX_HIT_POINTS = ConvertAbilityRealLevelField('Can2')
-    // 技能实数等级域 每秒伤害 ('Dev2')
+    // 技能随等级改变的实数域 每秒伤害 ('Dev2')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_PER_SECOND_DEV2 = ConvertAbilityRealLevelField('Dev2')
-    // 技能实数等级域 移动速度更新次数 ('Chd1')
+    // 技能随等级改变的实数域 移动速度更新次数 ('Chd1')
 	constant abilityreallevelfield ABILITY_RLF_MOVEMENT_UPDATE_FREQUENCY_CHD1 = ConvertAbilityRealLevelField('Chd1')
-    // 技能实数等级域 攻击速度更新次数 ('Chd2')
+    // 技能随等级改变的实数域 攻击速度更新次数 ('Chd2')
 	constant abilityreallevelfield ABILITY_RLF_ATTACK_UPDATE_FREQUENCY_CHD2 = ConvertAbilityRealLevelField('Chd2')
-    // 技能实数等级域 对召唤单位伤害（无效） ('Chd3')
+    // 技能随等级改变的实数域 对召唤单位伤害（无效） ('Chd3')
 	constant abilityreallevelfield ABILITY_RLF_SUMMONED_UNIT_DAMAGE_CHD3 = ConvertAbilityRealLevelField('Chd3')
-    // 技能实数等级域 移动速度减少（%） ('Cri1')
+    // 技能随等级改变的实数域 移动速度减少（%） ('Cri1')
 	constant abilityreallevelfield ABILITY_RLF_MOVEMENT_SPEED_REDUCTION_PERCENT_CRI1 = ConvertAbilityRealLevelField('Cri1')
-    // 技能实数等级域 攻击速度减少（%） ('Cri2')
+    // 技能随等级改变的实数域 攻击速度减少（%） ('Cri2')
 	constant abilityreallevelfield ABILITY_RLF_ATTACK_SPEED_REDUCTION_PERCENT_CRI2 = ConvertAbilityRealLevelField('Cri2')
-    // 技能实数等级域 伤害减少（%） ('Cri3')
+    // 技能随等级改变的实数域 伤害减少（%） ('Cri3')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_REDUCTION_CRI3 = ConvertAbilityRealLevelField('Cri3')
-    // 技能实数等级域 未命中率 ('Crs1')
+    // 技能随等级改变的实数域 未命中率 ('Crs1')
 	constant abilityreallevelfield ABILITY_RLF_CHANCE_TO_MISS_CRS = ConvertAbilityRealLevelField('Crs1')
-    // 技能实数等级域 全伤害范围 ('Dda1')
+    // 技能随等级改变的实数域 全伤害范围 ('Dda1')
 	constant abilityreallevelfield ABILITY_RLF_FULL_DAMAGE_RADIUS_DDA1 = ConvertAbilityRealLevelField('Dda1')
-    // 技能实数等级域 全伤害数值 ('Dda2')
+    // 技能随等级改变的实数域 全伤害数值 ('Dda2')
 	constant abilityreallevelfield ABILITY_RLF_FULL_DAMAGE_AMOUNT_DDA2 = ConvertAbilityRealLevelField('Dda2')
-    // 技能实数等级域 部分伤害范围 ('Dda3')
+    // 技能随等级改变的实数域 部分伤害范围 ('Dda3')
 	constant abilityreallevelfield ABILITY_RLF_PARTIAL_DAMAGE_RADIUS = ConvertAbilityRealLevelField('Dda3')
-    // 技能实数等级域 部分伤害数值 ('Dda4')
+    // 技能随等级改变的实数域 部分伤害数值 ('Dda4')
 	constant abilityreallevelfield ABILITY_RLF_PARTIAL_DAMAGE_AMOUNT = ConvertAbilityRealLevelField('Dda4')
-    // 技能实数等级域 建筑伤害参数 ('Sds1')
+    // 技能随等级改变的实数域 建筑伤害参数 ('Sds1')
 	constant abilityreallevelfield ABILITY_RLF_BUILDING_DAMAGE_FACTOR_SDS1 = ConvertAbilityRealLevelField('Sds1')
-    // 技能实数等级域 最大攻击伤害 ('Uco5')
+    // 技能随等级改变的实数域 最大攻击伤害 ('Uco5')
 	constant abilityreallevelfield ABILITY_RLF_MAX_DAMAGE_UCO5 = ConvertAbilityRealLevelField('Uco5')
-    // 技能实数等级域 移动速度奖励 ('Uco6')
+    // 技能随等级改变的实数域 移动速度奖励 ('Uco6')
 	constant abilityreallevelfield ABILITY_RLF_MOVE_SPEED_BONUS_UCO6 = ConvertAbilityRealLevelField('Uco6')
-    // 技能实数等级域 所受穿刺伤害（%） ('Def1')
+    // 技能随等级改变的实数域 所受穿刺伤害（%） ('Def1')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_TAKEN_PERCENT_DEF1 = ConvertAbilityRealLevelField('Def1')
-    // 技能实数等级域 伤害倍乘（%） ('Def2')
+    // 技能随等级改变的实数域 伤害倍乘（%） ('Def2')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_DEALT_PERCENT_DEF2 = ConvertAbilityRealLevelField('Def2')
-    // 技能实数等级域 移动速度系数（%） ('Def3')
+    // 技能随等级改变的实数域 移动速度系数（%） ('Def3')
 	constant abilityreallevelfield ABILITY_RLF_MOVEMENT_SPEED_FACTOR_DEF3 = ConvertAbilityRealLevelField('Def3')
-    // 技能实数等级域 攻击速度系数（%） ('Def4')
+    // 技能随等级改变的实数域 攻击速度系数（%） ('Def4')
 	constant abilityreallevelfield ABILITY_RLF_ATTACK_SPEED_FACTOR_DEF4 = ConvertAbilityRealLevelField('Def4')
-    // 技能实数等级域 所受魔法伤害（%） ('Def5')
+    // 技能随等级改变的实数域 所受魔法伤害（%） ('Def5')
 	constant abilityreallevelfield ABILITY_RLF_MAGIC_DAMAGE_REDUCTION_DEF5 = ConvertAbilityRealLevelField('Def5')
-    // 技能实数等级域 反弹几率 ('Def6')
+    // 技能随等级改变的实数域 反弹几率 ('Def6')
 	constant abilityreallevelfield ABILITY_RLF_CHANCE_TO_DEFLECT = ConvertAbilityRealLevelField('Def6')
-    // 技能实数等级域 接受反弹攻击伤害（穿刺） ('Def7')
+    // 技能随等级改变的实数域 接受反弹攻击伤害（穿刺） ('Def7')
 	constant abilityreallevelfield ABILITY_RLF_DEFLECT_DAMAGE_TAKEN_PIERCING = ConvertAbilityRealLevelField('Def7')
-    // 技能实数等级域 接受反弹攻击伤害（魔法） ('Def8')
+    // 技能随等级改变的实数域 接受反弹攻击伤害（魔法） ('Def8')
 	constant abilityreallevelfield ABILITY_RLF_DEFLECT_DAMAGE_TAKEN_SPELLS = ConvertAbilityRealLevelField('Def8')
-    // 技能实数等级域 技能延迟 ('Eat1')
+    // 技能随等级改变的实数域 技能延迟 ('Eat1')
 	constant abilityreallevelfield ABILITY_RLF_RIP_DELAY = ConvertAbilityRealLevelField('Eat1')
-    // 技能实数等级域 吞食延迟 ('Eat2')
+    // 技能随等级改变的实数域 吞食延迟 ('Eat2')
 	constant abilityreallevelfield ABILITY_RLF_EAT_DELAY = ConvertAbilityRealLevelField('Eat2')
-    // 技能实数等级域 总恢复生命值 ('Eat3')
+    // 技能随等级改变的实数域 总恢复生命值 ('Eat3')
 	constant abilityreallevelfield ABILITY_RLF_HIT_POINTS_GAINED_EAT3 = ConvertAbilityRealLevelField('Eat3')
-    // 技能实数等级域 空中单位坠落时间 ('Ens1')
+    // 技能随等级改变的实数域 空中单位坠落时间 ('Ens1')
 	constant abilityreallevelfield ABILITY_RLF_AIR_UNIT_LOWER_DURATION = ConvertAbilityRealLevelField('Ens1')
-    // 技能实数等级域 空中单位高度 ('Ens2')
+    // 技能随等级改变的实数域 空中单位高度 ('Ens2')
 	constant abilityreallevelfield ABILITY_RLF_AIR_UNIT_HEIGHT = ConvertAbilityRealLevelField('Ens2')
-    // 技能实数等级域 近战攻击范围 ('Ens3')
+    // 技能随等级改变的实数域 近战攻击范围 ('Ens3')
 	constant abilityreallevelfield ABILITY_RLF_MELEE_ATTACK_RANGE = ConvertAbilityRealLevelField('Ens3')
-    // 技能实数等级域 间隔时间 ('Egm2')
+    // 技能随等级改变的实数域 间隔时间 ('Egm2')
 	constant abilityreallevelfield ABILITY_RLF_INTERVAL_DURATION_EGM2 = ConvertAbilityRealLevelField('Egm2')
-    // 技能实数等级域 效果延迟 ('Fla2')
+    // 技能随等级改变的实数域 效果延迟 ('Fla2')
 	constant abilityreallevelfield ABILITY_RLF_EFFECT_DELAY_FLA2 = ConvertAbilityRealLevelField('Fla2')
-    // 技能实数等级域 采矿持续时间 ('Gld2')
+    // 技能随等级改变的实数域 采矿持续时间 ('Gld2')
 	constant abilityreallevelfield ABILITY_RLF_MINING_DURATION = ConvertAbilityRealLevelField('Gld2')
-    // 技能实数等级域 墓碑范围 ('Gyd2')
+    // 技能随等级改变的实数域 墓碑范围 ('Gyd2')
 	constant abilityreallevelfield ABILITY_RLF_RADIUS_OF_GRAVESTONES = ConvertAbilityRealLevelField('Gyd2')
-    // 技能实数等级域 尸体范围 ('Gyd3')
+    // 技能随等级改变的实数域 尸体范围 ('Gyd3')
 	constant abilityreallevelfield ABILITY_RLF_RADIUS_OF_CORPSES = ConvertAbilityRealLevelField('Gyd3')
-    // 技能实数等级域 治疗生命值 ('Hea1')
+    // 技能随等级改变的实数域 治疗生命值 ('Hea1')
 	constant abilityreallevelfield ABILITY_RLF_HIT_POINTS_GAINED_HEA1 = ConvertAbilityRealLevelField('Hea1')
-    // 技能实数等级域 攻击增加（%） ('Inf1')
+    // 技能随等级改变的实数域 攻击增加（%） ('Inf1')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_INCREASE_PERCENT_INF1 = ConvertAbilityRealLevelField('Inf1')
-    // 技能实数等级域 自动施法范围 ('Inf3')
+    // 技能随等级改变的实数域 自动施法范围 ('Inf3')
 	constant abilityreallevelfield ABILITY_RLF_AUTOCAST_RANGE = ConvertAbilityRealLevelField('Inf3')
-    // 技能实数等级域 生命恢复速度 ('Inf4')
+    // 技能随等级改变的实数域 生命恢复速度 ('Inf4')
 	constant abilityreallevelfield ABILITY_RLF_LIFE_REGEN_RATE = ConvertAbilityRealLevelField('Inf4')
-    // 技能实数等级域 效果延迟 ('Lit1')
+    // 技能随等级改变的实数域 效果延迟 ('Lit1')
 	constant abilityreallevelfield ABILITY_RLF_GRAPHIC_DELAY_LIT1 = ConvertAbilityRealLevelField('Lit1')
-    // 技能实数等级域 效果持续时间 ('Lit2')
+    // 技能随等级改变的实数域 效果持续时间 ('Lit2')
 	constant abilityreallevelfield ABILITY_RLF_GRAPHIC_DURATION_LIT2 = ConvertAbilityRealLevelField('Lit2')
-    // 技能实数等级域 每秒伤害 ('Lsh1')
+    // 技能随等级改变的实数域 每秒伤害 ('Lsh1')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_PER_SECOND_LSH1 = ConvertAbilityRealLevelField('Lsh1')
-    // 技能实数等级域 恢复每点魔法所需魔法值 ('Mbt1')
+    // 技能随等级改变的实数域 恢复每点魔法所需魔法值 ('Mbt1')
 	constant abilityreallevelfield ABILITY_RLF_MANA_GAINED = ConvertAbilityRealLevelField('Mbt1')
-    // 技能实数等级域 恢复每点生命所需魔法值 ('Mbt2')
+    // 技能随等级改变的实数域 恢复每点生命所需魔法值 ('Mbt2')
 	constant abilityreallevelfield ABILITY_RLF_HIT_POINTS_GAINED_MBT2 = ConvertAbilityRealLevelField('Mbt2')
-    // 技能实数等级域 自动施法魔法要求 ('Mbt3')
+    // 技能随等级改变的实数域 自动施法魔法要求 ('Mbt3')
 	constant abilityreallevelfield ABILITY_RLF_AUTOCAST_REQUIREMENT = ConvertAbilityRealLevelField('Mbt3')
-    // 技能实数等级域 水面高度 ('Mbt4')
+    // 技能随等级改变的实数域 水面高度 ('Mbt4')
 	constant abilityreallevelfield ABILITY_RLF_WATER_HEIGHT = ConvertAbilityRealLevelField('Mbt4')
-    // 技能实数等级域 激活延迟 ('Min1')
+    // 技能随等级改变的实数域 激活延迟 ('Min1')
 	constant abilityreallevelfield ABILITY_RLF_ACTIVATION_DELAY_MIN1 = ConvertAbilityRealLevelField('Min1')
-    // 技能实数等级域 转换时间 ('Min2')
+    // 技能随等级改变的实数域 转换时间 ('Min2')
 	constant abilityreallevelfield ABILITY_RLF_INVISIBILITY_TRANSITION_TIME = ConvertAbilityRealLevelField('Min2')
-    // 技能实数等级域 激活范围 ('Neu1')
+    // 技能随等级改变的实数域 激活范围 ('Neu1')
 	constant abilityreallevelfield ABILITY_RLF_ACTIVATION_RADIUS = ConvertAbilityRealLevelField('Neu1')
-    // 技能实数等级域 每秒恢复值 ('Arm1')
+    // 技能随等级改变的实数域 每秒恢复值 ('Arm1')
 	constant abilityreallevelfield ABILITY_RLF_AMOUNT_REGENERATED = ConvertAbilityRealLevelField('Arm1')
-    // 技能实数等级域 每秒伤害 ('Poi1')
+    // 技能随等级改变的实数域 每秒伤害 ('Poi1')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_PER_SECOND_POI1 = ConvertAbilityRealLevelField('Poi1')
-    // 技能实数等级域 攻击速度系数（%） ('Poi2')
+    // 技能随等级改变的实数域 攻击速度系数（%） ('Poi2')
 	constant abilityreallevelfield ABILITY_RLF_ATTACK_SPEED_FACTOR_POI2 = ConvertAbilityRealLevelField('Poi2')
-    // 技能实数等级域 移动速度系数（%） ('Poi3')
+    // 技能随等级改变的实数域 移动速度系数（%） ('Poi3')
 	constant abilityreallevelfield ABILITY_RLF_MOVEMENT_SPEED_FACTOR_POI3 = ConvertAbilityRealLevelField('Poi3')
-    // 技能实数等级域 额外伤害 ('Poa1')
+    // 技能随等级改变的实数域 额外伤害 ('Poa1')
 	constant abilityreallevelfield ABILITY_RLF_EXTRA_DAMAGE_POA1 = ConvertAbilityRealLevelField('Poa1')
-    // 技能实数等级域 每秒伤害 ('Poa2')
+    // 技能随等级改变的实数域 每秒伤害 ('Poa2')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_PER_SECOND_POA2 = ConvertAbilityRealLevelField('Poa2')
-    // 技能实数等级域 攻击速度系数 ('Poa3')
+    // 技能随等级改变的实数域 攻击速度系数 ('Poa3')
 	constant abilityreallevelfield ABILITY_RLF_ATTACK_SPEED_FACTOR_POA3 = ConvertAbilityRealLevelField('Poa3')
-    // 技能实数等级域 移动速度系数 ('Poa4')
+    // 技能随等级改变的实数域 移动速度系数 ('Poa4')
 	constant abilityreallevelfield ABILITY_RLF_MOVEMENT_SPEED_FACTOR_POA4 = ConvertAbilityRealLevelField('Poa4')   
-    // 技能实数等级域 施法时所受伤害值 ('Pos2')
+    // 技能随等级改变的实数域 施法时所受伤害值 ('Pos2')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_AMPLIFICATION = ConvertAbilityRealLevelField('Pos2')
-    // 技能实数等级域 施放几率 ('War1')
+    // 技能随等级改变的实数域 施放几率 ('War1')
 	constant abilityreallevelfield ABILITY_RLF_CHANCE_TO_STOMP_PERCENT = ConvertAbilityRealLevelField('War1')
-    // 技能实数等级域 附加伤害 ('War2')
+    // 技能随等级改变的实数域 附加伤害 ('War2')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_DEALT_WAR2 = ConvertAbilityRealLevelField('War2')
-    // 技能实数等级域 全伤害范围 ('War3')
+    // 技能随等级改变的实数域 全伤害范围 ('War3')
 	constant abilityreallevelfield ABILITY_RLF_FULL_DAMAGE_RADIUS_WAR3 = ConvertAbilityRealLevelField('War3')
-    // 技能实数等级域 半伤害范围 ('War4')
+    // 技能随等级改变的实数域 半伤害范围 ('War4')
 	constant abilityreallevelfield ABILITY_RLF_HALF_DAMAGE_RADIUS_WAR4 = ConvertAbilityRealLevelField('War4')
-    // 技能实数等级域 对召唤单位伤害 ('Prg3')
+    // 技能随等级改变的实数域 对召唤单位伤害 ('Prg3')
 	constant abilityreallevelfield ABILITY_RLF_SUMMONED_UNIT_DAMAGE_PRG3 = ConvertAbilityRealLevelField('Prg3')
-    // 技能实数等级域 单位麻痹时间 ('Prg4')
+    // 技能随等级改变的实数域 单位麻痹时间 ('Prg4')
 	constant abilityreallevelfield ABILITY_RLF_UNIT_PAUSE_DURATION = ConvertAbilityRealLevelField('Prg4')
-    // 技能实数等级域 英雄麻痹时间 ('Prg5')
+    // 技能随等级改变的实数域 英雄麻痹时间 ('Prg5')
 	constant abilityreallevelfield ABILITY_RLF_HERO_PAUSE_DURATION = ConvertAbilityRealLevelField('Prg5')
-    // 技能实数等级域 生命值恢复 ('Rej1')
+    // 技能随等级改变的实数域 生命值恢复 ('Rej1')
 	constant abilityreallevelfield ABILITY_RLF_HIT_POINTS_GAINED_REJ1 = ConvertAbilityRealLevelField('Rej1')
-    // 技能实数等级域 魔法值恢复 ('Rej2')
+    // 技能随等级改变的实数域 魔法值恢复 ('Rej2')
 	constant abilityreallevelfield ABILITY_RLF_MANA_POINTS_GAINED_REJ2 = ConvertAbilityRealLevelField('Rej2')
-    // 技能实数等级域 最小生命需求 ('Rpb3')
+    // 技能随等级改变的实数域 最小生命需求 ('Rpb3')
 	constant abilityreallevelfield ABILITY_RLF_MINIMUM_LIFE_REQUIRED = ConvertAbilityRealLevelField('Rpb3')
-    // 技能实数等级域 最小魔法需求 ('Rpb4')
+    // 技能随等级改变的实数域 最小魔法需求 ('Rpb4')
 	constant abilityreallevelfield ABILITY_RLF_MINIMUM_MANA_REQUIRED = ConvertAbilityRealLevelField('Rpb4')
-    // 技能实数等级域 修理费用比率 ('Rep1')
+    // 技能随等级改变的实数域 修理费用比率 ('Rep1')
 	constant abilityreallevelfield ABILITY_RLF_REPAIR_COST_RATIO = ConvertAbilityRealLevelField('Rep1')
-    // 技能实数等级域 修理时间比率 ('Rep2')
+    // 技能随等级改变的实数域 修理时间比率 ('Rep2')
 	constant abilityreallevelfield ABILITY_RLF_REPAIR_TIME_RATIO = ConvertAbilityRealLevelField('Rep2')
-    // 技能实数等级域 快速建造费用比率 ('Rep3')
+    // 技能随等级改变的实数域 快速建造费用比率 ('Rep3')
 	constant abilityreallevelfield ABILITY_RLF_POWERBUILD_COST = ConvertAbilityRealLevelField('Rep3')
-    // 技能实数等级域 快速建造时间比率 ('Rep4')
+    // 技能随等级改变的实数域 快速建造时间比率 ('Rep4')
 	constant abilityreallevelfield ABILITY_RLF_POWERBUILD_RATE = ConvertAbilityRealLevelField('Rep4')
-    // 技能实数等级域 海上修理范围提升 ('Rep5')
+    // 技能随等级改变的实数域 海上修理范围提升 ('Rep5')
 	constant abilityreallevelfield ABILITY_RLF_NAVAL_RANGE_BONUS = ConvertAbilityRealLevelField('Rep5')
-    // 技能实数等级域 攻击增加（%） ('Roa1')
+    // 技能随等级改变的实数域 攻击增加（%） ('Roa1')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_INCREASE_PERCENT_ROA1 = ConvertAbilityRealLevelField('Roa1')
-    // 技能实数等级域 生命恢复速度 ('Roa3')
+    // 技能随等级改变的实数域 生命恢复速度 ('Roa3')
 	constant abilityreallevelfield ABILITY_RLF_LIFE_REGENERATION_RATE = ConvertAbilityRealLevelField('Roa3')
-    // 技能实数等级域 魔法再生 ('Roa4')
+    // 技能随等级改变的实数域 魔法再生 ('Roa4')
 	constant abilityreallevelfield ABILITY_RLF_MANA_REGEN = ConvertAbilityRealLevelField('Roa4')
-    // 技能实数等级域 攻击增加 ('Nbr1')
+    // 技能随等级改变的实数域 攻击增加 ('Nbr1')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_INCREASE = ConvertAbilityRealLevelField('Nbr1')
-    // 技能实数等级域 掠夺比率 ('Sal1')
+    // 技能随等级改变的实数域 掠夺比率 ('Sal1')
 	constant abilityreallevelfield ABILITY_RLF_SALVAGE_COST_RATIO = ConvertAbilityRealLevelField('Sal1')
-    // 技能实数等级域 飞行视野范围 ('Esn1')
+    // 技能随等级改变的实数域 飞行视野范围 ('Esn1')
 	constant abilityreallevelfield ABILITY_RLF_IN_FLIGHT_SIGHT_RADIUS = ConvertAbilityRealLevelField('Esn1')
-    // 技能实数等级域 盘踞视野范围 ('Esn2')
+    // 技能随等级改变的实数域 盘踞视野范围 ('Esn2')
 	constant abilityreallevelfield ABILITY_RLF_HOVERING_SIGHT_RADIUS = ConvertAbilityRealLevelField('Esn2')
-    // 技能实数等级域 盘踞高度 ('Esn3')
+    // 技能随等级改变的实数域 盘踞高度 ('Esn3')
 	constant abilityreallevelfield ABILITY_RLF_HOVERING_HEIGHT = ConvertAbilityRealLevelField('Esn3')
-    // 技能实数等级域 猫头鹰的持续时间 ('Esn5')
+    // 技能随等级改变的实数域 猫头鹰的持续时间 ('Esn5')
 	constant abilityreallevelfield ABILITY_RLF_DURATION_OF_OWLS = ConvertAbilityRealLevelField('Esn5')
-    // 技能实数等级域 淡化转换时间 ('Shm1')
+    // 技能随等级改变的实数域 淡化转换时间 ('Shm1')
 	constant abilityreallevelfield ABILITY_RLF_FADE_DURATION = ConvertAbilityRealLevelField('Shm1')
-    // 技能实数等级域 昼夜交替转换时间 ('Shm2')
+    // 技能随等级改变的实数域 昼夜交替转换时间 ('Shm2')
 	constant abilityreallevelfield ABILITY_RLF_DAY_NIGHT_DURATION = ConvertAbilityRealLevelField('Shm2')
-    // 技能实数等级域 行动转换时间 ('Shm3')
+    // 技能随等级改变的实数域 行动转换时间 ('Shm3')
 	constant abilityreallevelfield ABILITY_RLF_ACTION_DURATION = ConvertAbilityRealLevelField('Shm3')
-    // 技能实数等级域 降低移动速度系数（%） ('Slo1')
+    // 技能随等级改变的实数域 降低移动速度系数（%） ('Slo1')
 	constant abilityreallevelfield ABILITY_RLF_MOVEMENT_SPEED_FACTOR_SLO1 = ConvertAbilityRealLevelField('Slo1')
-    // 技能实数等级域 降低攻击速度系数（%） ('Slo2')
+    // 技能随等级改变的实数域 降低攻击速度系数（%） ('Slo2')
 	constant abilityreallevelfield ABILITY_RLF_ATTACK_SPEED_FACTOR_SLO2 = ConvertAbilityRealLevelField('Slo2')
-    // 技能实数等级域 每秒伤害 ('Spo1')
+    // 技能随等级改变的实数域 每秒伤害 ('Spo1')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_PER_SECOND_SPO1 = ConvertAbilityRealLevelField('Spo1')
-    // 技能实数等级域 降低移动速度系数（%） ('Spo2')
+    // 技能随等级改变的实数域 降低移动速度系数（%） ('Spo2')
 	constant abilityreallevelfield ABILITY_RLF_MOVEMENT_SPEED_FACTOR_SPO2 = ConvertAbilityRealLevelField('Spo2')
-    // 技能实数等级域 降低攻击速度系数（%） ('Spo3')
+    // 技能随等级改变的实数域 降低攻击速度系数（%） ('Spo3')
 	constant abilityreallevelfield ABILITY_RLF_ATTACK_SPEED_FACTOR_SPO3 = ConvertAbilityRealLevelField('Spo3')
-    // 技能实数等级域 激活延迟 ('Sta1')
+    // 技能随等级改变的实数域 激活延迟 ('Sta1')
 	constant abilityreallevelfield ABILITY_RLF_ACTIVATION_DELAY_STA1 = ConvertAbilityRealLevelField('Sta1')
-    // 技能实数等级域 侦察范围 ('Sta2')
+    // 技能随等级改变的实数域 侦察范围 ('Sta2')
 	constant abilityreallevelfield ABILITY_RLF_DETECTION_RADIUS_STA2 = ConvertAbilityRealLevelField('Sta2')
-    // 技能实数等级域 爆炸范围 ('Sta3')
+    // 技能随等级改变的实数域 爆炸范围 ('Sta3')
 	constant abilityreallevelfield ABILITY_RLF_DETONATION_RADIUS = ConvertAbilityRealLevelField('Sta3')
-    // 技能实数等级域 眩晕持续时间 ('Sta4')
+    // 技能随等级改变的实数域 眩晕持续时间 ('Sta4')
 	constant abilityreallevelfield ABILITY_RLF_STUN_DURATION_STA4 = ConvertAbilityRealLevelField('Sta4')
-    // 技能实数等级域 攻击速度奖励（%） ('Uhf1')
+    // 技能随等级改变的实数域 攻击速度奖励（%） ('Uhf1')
 	constant abilityreallevelfield ABILITY_RLF_ATTACK_SPEED_BONUS_PERCENT = ConvertAbilityRealLevelField('Uhf1')
-    // 技能实数等级域 每秒伤害 ('Uhf2')
+    // 技能随等级改变的实数域 每秒伤害 ('Uhf2')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_PER_SECOND_UHF2 = ConvertAbilityRealLevelField('Uhf2')
-    // 技能实数等级域 采集木材数/间隔 ('Wha1')
+    // 技能随等级改变的实数域 采集木材数/间隔 ('Wha1')
 	constant abilityreallevelfield ABILITY_RLF_LUMBER_PER_INTERVAL = ConvertAbilityRealLevelField('Wha1')
-    // 技能实数等级域 附着点高度 ('Wha3')
+    // 技能随等级改变的实数域 附着点高度 ('Wha3')
 	constant abilityreallevelfield ABILITY_RLF_ART_ATTACHMENT_HEIGHT = ConvertAbilityRealLevelField('Wha3')
-    // 技能实数等级域 传送区域宽度 ('Wrp1')
+    // 技能随等级改变的实数域 传送区域宽度 ('Wrp1')
 	constant abilityreallevelfield ABILITY_RLF_TELEPORT_AREA_WIDTH = ConvertAbilityRealLevelField('Wrp1')
-    // 技能实数等级域 传送区域高度 ('Wrp2')
+    // 技能随等级改变的实数域 传送区域高度 ('Wrp2')
 	constant abilityreallevelfield ABILITY_RLF_TELEPORT_AREA_HEIGHT = ConvertAbilityRealLevelField('Wrp2')
-    // 技能实数等级域 攻击偷取生命（%） ('Ivam')
+    // 技能随等级改变的实数域 攻击偷取生命（%） ('Ivam')
 	constant abilityreallevelfield ABILITY_RLF_LIFE_STOLEN_PER_ATTACK = ConvertAbilityRealLevelField('Ivam')
-    // 技能实数等级域 附加伤害 ('Idam')
+    // 技能随等级改变的实数域 附加伤害 ('Idam')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_BONUS_IDAM = ConvertAbilityRealLevelField('Idam')
-    // 技能实数等级域 击中单位几率 ('Iob2')
+    // 技能随等级改变的实数域 击中单位几率 ('Iob2')
 	constant abilityreallevelfield ABILITY_RLF_CHANCE_TO_HIT_UNITS_PERCENT = ConvertAbilityRealLevelField('Iob2')
-    // 技能实数等级域 击中英雄几率 ('Iob3')
+    // 技能随等级改变的实数域 击中英雄几率 ('Iob3')
 	constant abilityreallevelfield ABILITY_RLF_CHANCE_TO_HIT_HEROS_PERCENT = ConvertAbilityRealLevelField('Iob3')
-    // 技能实数等级域 击中召唤物几率 ('Iob4')
+    // 技能随等级改变的实数域 击中召唤物几率 ('Iob4')
 	constant abilityreallevelfield ABILITY_RLF_CHANCE_TO_HIT_SUMMONS_PERCENT = ConvertAbilityRealLevelField('Iob4')
-    // 技能实数等级域 目标效果延迟 ('Idel')
+    // 技能随等级改变的实数域 目标效果延迟 ('Idel')
 	constant abilityreallevelfield ABILITY_RLF_DELAY_FOR_TARGET_EFFECT = ConvertAbilityRealLevelField('Idel')
-    // 技能实数等级域 施加伤害（%） ('Iild')
+    // 技能随等级改变的实数域 施加伤害（%） ('Iild')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_DEALT_PERCENT_OF_NORMAL = ConvertAbilityRealLevelField('Iild')
-    // 技能实数等级域 受到伤害倍数 ('Iilw')
+    // 技能随等级改变的实数域 受到伤害倍数 ('Iilw')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_RECEIVED_MULTIPLIER = ConvertAbilityRealLevelField('Iilw')
-    // 技能实数等级域 魔法回复奖励 ('Imrp')
+    // 技能随等级改变的实数域 魔法回复奖励 ('Imrp')
 	constant abilityreallevelfield ABILITY_RLF_MANA_REGENERATION_BONUS_AS_FRACTION_OF_NORMAL = ConvertAbilityRealLevelField('Imrp')
-    // 技能实数等级域 移动速度增加（%） ('Ispi')
+    // 技能随等级改变的实数域 移动速度增加（%） ('Ispi')
 	constant abilityreallevelfield ABILITY_RLF_MOVEMENT_SPEED_INCREASE_ISPI = ConvertAbilityRealLevelField('Ispi')
-    // 技能实数等级域 每秒伤害 ('Idps')
+    // 技能随等级改变的实数域 每秒伤害 ('Idps')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_PER_SECOND_IDPS = ConvertAbilityRealLevelField('Idps')
-    // 技能实数等级域 攻击速度增加（% ） ('Cac1')
+    // 技能随等级改变的实数域 攻击速度增加（% ） ('Cac1')
 	constant abilityreallevelfield ABILITY_RLF_ATTACK_DAMAGE_INCREASE_CAC1 = ConvertAbilityRealLevelField('Cac1')
-    // 技能实数等级域 每秒伤害 ('Cor1')
+    // 技能随等级改变的实数域 每秒伤害 ('Cor1')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_PER_SECOND_COR1 = ConvertAbilityRealLevelField('Cor1')
-    // 技能实数等级域 攻击速度增加（%） ('Isx1')
+    // 技能随等级改变的实数域 攻击速度增加（%） ('Isx1')
 	constant abilityreallevelfield ABILITY_RLF_ATTACK_SPEED_INCREASE_ISX1 = ConvertAbilityRealLevelField('Isx1')
-    // 技能实数等级域 伤害 ('Wrs1')
+    // 技能随等级改变的实数域 伤害 ('Wrs1')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_WRS1 = ConvertAbilityRealLevelField('Wrs1')
-    // 技能实数等级域 地形变形幅度 ('Wrs2')
+    // 技能随等级改变的实数域 地形变形幅度 ('Wrs2')
 	constant abilityreallevelfield ABILITY_RLF_TERRAIN_DEFORMATION_AMPLITUDE = ConvertAbilityRealLevelField('Wrs2')
-    // 技能实数等级域 伤害 ('Ctc1')
+    // 技能随等级改变的实数域 伤害 ('Ctc1')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_CTC1 = ConvertAbilityRealLevelField('Ctc1')
-    // 技能实数等级域 指定目标伤害 ('Ctc2')
+    // 技能随等级改变的实数域 指定目标伤害 ('Ctc2')
 	constant abilityreallevelfield ABILITY_RLF_EXTRA_DAMAGE_TO_TARGET = ConvertAbilityRealLevelField('Ctc2')
-    // 技能实数等级域 移动速度减少 ('Ctc3')
+    // 技能随等级改变的实数域 移动速度减少 ('Ctc3')
 	constant abilityreallevelfield ABILITY_RLF_MOVEMENT_SPEED_REDUCTION_CTC3 = ConvertAbilityRealLevelField('Ctc3')
-    // 技能实数等级域 攻击速度减少 ('Ctc4')
+    // 技能随等级改变的实数域 攻击速度减少 ('Ctc4')
 	constant abilityreallevelfield ABILITY_RLF_ATTACK_SPEED_REDUCTION_CTC4 = ConvertAbilityRealLevelField('Ctc4')
-    // 技能实数等级域 伤害 ('Ctb1')
+    // 技能随等级改变的实数域 伤害 ('Ctb1')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_CTB1 = ConvertAbilityRealLevelField('Ctb1')
-    // 技能实数等级域 魔法施放延迟 ('Uds2')
+    // 技能随等级改变的实数域 魔法施放延迟 ('Uds2')
 	constant abilityreallevelfield ABILITY_RLF_CASTING_DELAY_SECONDS = ConvertAbilityRealLevelField('Uds2')
-    // 技能实数等级域 范围目标魔法损耗 ('Dtn1')
+    // 技能随等级改变的实数域 范围目标魔法损耗 ('Dtn1')
 	constant abilityreallevelfield ABILITY_RLF_MANA_LOSS_PER_UNIT_DTN1 = ConvertAbilityRealLevelField('Dtn1')
-    // 技能实数等级域 对召唤单位伤害 ('Dtn2')
+    // 技能随等级改变的实数域 对召唤单位伤害 ('Dtn2')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_TO_SUMMONED_UNITS_DTN2 = ConvertAbilityRealLevelField('Dtn2')
-    // 技能实数等级域 转变时间 ('Ivs1')
+    // 技能随等级改变的实数域 转变时间 ('Ivs1')
 	constant abilityreallevelfield ABILITY_RLF_TRANSITION_TIME_SECONDS = ConvertAbilityRealLevelField('Ivs1')
-    // 技能实数等级域 每秒魔法消耗 ('Nmr1')
+    // 技能随等级改变的实数域 每秒魔法消耗 ('Nmr1')
 	constant abilityreallevelfield ABILITY_RLF_MANA_DRAINED_PER_SECOND_NMR1 = ConvertAbilityRealLevelField('Nmr1')
-    // 技能实数等级域 减少伤害几率（%） ('Ssk1')
+    // 技能随等级改变的实数域 减少伤害几率（%） ('Ssk1')
 	constant abilityreallevelfield ABILITY_RLF_CHANCE_TO_REDUCE_DAMAGE_PERCENT = ConvertAbilityRealLevelField('Ssk1')
-    // 技能实数等级域 最小伤害 ('Ssk2')
+    // 技能随等级改变的实数域 最小伤害 ('Ssk2')
 	constant abilityreallevelfield ABILITY_RLF_MINIMUM_DAMAGE = ConvertAbilityRealLevelField('Ssk2')
-    // 技能实数等级域 忽略伤害 ('Ssk3')
+    // 技能随等级改变的实数域 忽略伤害 ('Ssk3')
 	constant abilityreallevelfield ABILITY_RLF_IGNORED_DAMAGE = ConvertAbilityRealLevelField('Ssk3')
-    // 技能实数等级域 全伤害数值 ('Hfs1')
+    // 技能随等级改变的实数域 全伤害数值 ('Hfs1')
 	constant abilityreallevelfield ABILITY_RLF_FULL_DAMAGE_DEALT = ConvertAbilityRealLevelField('Hfs1')
-    // 技能实数等级域 全伤害间隔 ('Hfs2')
+    // 技能随等级改变的实数域 全伤害间隔 ('Hfs2')
 	constant abilityreallevelfield ABILITY_RLF_FULL_DAMAGE_INTERVAL = ConvertAbilityRealLevelField('Hfs2')
-    // 技能实数等级域 半伤害数值 ('Hfs3')
+    // 技能随等级改变的实数域 半伤害数值 ('Hfs3')
 	constant abilityreallevelfield ABILITY_RLF_HALF_DAMAGE_DEALT = ConvertAbilityRealLevelField('Hfs3')
-    // 技能实数等级域 半伤害间隔 ('Hfs4')
+    // 技能随等级改变的实数域 半伤害间隔 ('Hfs4')
 	constant abilityreallevelfield ABILITY_RLF_HALF_DAMAGE_INTERVAL = ConvertAbilityRealLevelField('Hfs4')
-    // 技能实数等级域 建筑伤害因素（%） ('Hfs5')
+    // 技能随等级改变的实数域 建筑伤害因素（%） ('Hfs5')
 	constant abilityreallevelfield ABILITY_RLF_BUILDING_REDUCTION_HFS5 = ConvertAbilityRealLevelField('Hfs5')
-    // 技能实数等级域 最大伤害 ('Hfs6')
+    // 技能随等级改变的实数域 最大伤害 ('Hfs6')
 	constant abilityreallevelfield ABILITY_RLF_MAXIMUM_DAMAGE_HFS6 = ConvertAbilityRealLevelField('Hfs6')
-    // 技能实数等级域 每点魔法抵消的伤害值 ('Nms1')
+    // 技能随等级改变的实数域 每点魔法抵消的伤害值 ('Nms1')
 	constant abilityreallevelfield ABILITY_RLF_MANA_PER_HIT_POINT = ConvertAbilityRealLevelField('Nms1')
-    // 技能实数等级域 伤害吸收（%） ('Nms2')
+    // 技能随等级改变的实数域 伤害吸收（%） ('Nms2')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_ABSORBED_PERCENT = ConvertAbilityRealLevelField('Nms2')
-    // 技能实数等级域 波距离 ('Uim1')
+    // 技能随等级改变的实数域 波距离 ('Uim1')
 	constant abilityreallevelfield ABILITY_RLF_WAVE_DISTANCE = ConvertAbilityRealLevelField('Uim1')
-    // 技能实数等级域 波持续时间 ('Uim2')
+    // 技能随等级改变的实数域 波持续时间 ('Uim2')
 	constant abilityreallevelfield ABILITY_RLF_WAVE_TIME_SECONDS = ConvertAbilityRealLevelField('Uim2')
-    // 技能实数等级域 施加伤害 ('Uim3')
+    // 技能随等级改变的实数域 施加伤害 ('Uim3')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_DEALT_UIM3 = ConvertAbilityRealLevelField('Uim3')
-    // 技能实数等级域 空中停留时间 ('Uim4')
+    // 技能随等级改变的实数域 空中停留时间 ('Uim4')
 	constant abilityreallevelfield ABILITY_RLF_AIR_TIME_SECONDS_UIM4 = ConvertAbilityRealLevelField('Uim4')
-    // 技能实数等级域 单位施放间隔 ('Uls2')
+    // 技能随等级改变的实数域 单位施放间隔 ('Uls2')
 	constant abilityreallevelfield ABILITY_RLF_UNIT_RELEASE_INTERVAL_SECONDS = ConvertAbilityRealLevelField('Uls2')
-    // 技能实数等级域 生命偷取参数 ('Uls4')
+    // 技能随等级改变的实数域 生命偷取参数 ('Uls4')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_RETURN_FACTOR = ConvertAbilityRealLevelField('Uls4')
-    // 技能实数等级域 生命偷取极限 ('Uls5')
+    // 技能随等级改变的实数域 生命偷取极限 ('Uls5')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_RETURN_THRESHOLD = ConvertAbilityRealLevelField('Uls5')
-    // 技能实数等级域 近战伤害反弹 ('Uts1')
+    // 技能随等级改变的实数域 近战伤害反弹 ('Uts1')
 	constant abilityreallevelfield ABILITY_RLF_RETURNED_DAMAGE_FACTOR = ConvertAbilityRealLevelField('Uts1')
-    // 技能实数等级域 所受近战伤害（%） ('Uts2')
+    // 技能随等级改变的实数域 所受近战伤害（%） ('Uts2')
 	constant abilityreallevelfield ABILITY_RLF_RECEIVED_DAMAGE_FACTOR = ConvertAbilityRealLevelField('Uts2')
-    // 技能实数等级域 防御奖励 ('Uts3')
+    // 技能随等级改变的实数域 防御奖励 ('Uts3')
 	constant abilityreallevelfield ABILITY_RLF_DEFENSE_BONUS_UTS3 = ConvertAbilityRealLevelField('Uts3')
-    // 技能实数等级域 伤害奖励 ('Nba1')
+    // 技能随等级改变的实数域 伤害奖励 ('Nba1')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_BONUS_NBA1 = ConvertAbilityRealLevelField('Nba1')
-    // 技能实数等级域 召唤单位持续时间 ('Nba3')
+    // 技能随等级改变的实数域 召唤单位持续时间 ('Nba3')
 	constant abilityreallevelfield ABILITY_RLF_SUMMONED_UNIT_DURATION_SECONDS_NBA3 = ConvertAbilityRealLevelField('Nba3')
-    // 技能实数等级域 召唤单位每点生命需要的魔法值 ('Cmg2')
+    // 技能随等级改变的实数域 召唤单位每点生命需要的魔法值 ('Cmg2')
 	constant abilityreallevelfield ABILITY_RLF_MANA_PER_SUMMONED_HITPOINT = ConvertAbilityRealLevelField('Cmg2')
-    // 技能实数等级域 增加当前生命值 ('Cmg3')
+    // 技能随等级改变的实数域 增加当前生命值 ('Cmg3')
 	constant abilityreallevelfield ABILITY_RLF_CHARGE_FOR_CURRENT_LIFE = ConvertAbilityRealLevelField('Cmg3')
-    // 技能实数等级域 生命值汲取 ('Ndr1')
+    // 技能随等级改变的实数域 生命值汲取 ('Ndr1')
 	constant abilityreallevelfield ABILITY_RLF_HIT_POINTS_DRAINED = ConvertAbilityRealLevelField('Ndr1')
-    // 技能实数等级域 魔法值汲取 ('Ndr2')
+    // 技能随等级改变的实数域 魔法值汲取 ('Ndr2')
 	constant abilityreallevelfield ABILITY_RLF_MANA_POINTS_DRAINED = ConvertAbilityRealLevelField('Ndr2')
-    // 技能实数等级域 汲取间隔 ('Ndr3')
+    // 技能随等级改变的实数域 汲取间隔 ('Ndr3')
 	constant abilityreallevelfield ABILITY_RLF_DRAIN_INTERVAL_SECONDS = ConvertAbilityRealLevelField('Ndr3')
-    // 技能实数等级域 每秒传输的生命值 ('Ndr4')
+    // 技能随等级改变的实数域 每秒传输的生命值 ('Ndr4')
 	constant abilityreallevelfield ABILITY_RLF_LIFE_TRANSFERRED_PER_SECOND = ConvertAbilityRealLevelField('Ndr4')
-    // 技能实数等级域 每秒传输的魔法值 ('Ndr5')
+    // 技能随等级改变的实数域 每秒传输的魔法值 ('Ndr5')
 	constant abilityreallevelfield ABILITY_RLF_MANA_TRANSFERRED_PER_SECOND = ConvertAbilityRealLevelField('Ndr5')
-    // 技能实数等级域 生命值奖励参数 ('Ndr6')
+    // 技能随等级改变的实数域 生命值奖励参数 ('Ndr6')
 	constant abilityreallevelfield ABILITY_RLF_BONUS_LIFE_FACTOR = ConvertAbilityRealLevelField('Ndr6')
-    // 技能实数等级域 生命值奖励衰减 ('Ndr7')
+    // 技能随等级改变的实数域 生命值奖励衰减 ('Ndr7')
 	constant abilityreallevelfield ABILITY_RLF_BONUS_LIFE_DECAY = ConvertAbilityRealLevelField('Ndr7')
-    // 技能实数等级域 魔法值奖励参数 ('Ndr8')
+    // 技能随等级改变的实数域 魔法值奖励参数 ('Ndr8')
 	constant abilityreallevelfield ABILITY_RLF_BONUS_MANA_FACTOR = ConvertAbilityRealLevelField('Ndr8')
-    // 技能实数等级域 魔法值奖励衰减 ('Ndr9')
+    // 技能随等级改变的实数域 魔法值奖励衰减 ('Ndr9')
 	constant abilityreallevelfield ABILITY_RLF_BONUS_MANA_DECAY = ConvertAbilityRealLevelField('Ndr9')
-    // 技能实数等级域 未命中率（%） ('Nsi2')
+    // 技能随等级改变的实数域 未命中率（%） ('Nsi2')
 	constant abilityreallevelfield ABILITY_RLF_CHANCE_TO_MISS_PERCENT = ConvertAbilityRealLevelField('Nsi2')
-    // 技能实数等级域 移动速度增加（%） ('Nsi3')
+    // 技能随等级改变的实数域 移动速度增加（%） ('Nsi3')
 	constant abilityreallevelfield ABILITY_RLF_MOVEMENT_SPEED_MODIFIER = ConvertAbilityRealLevelField('Nsi3')
-    // 技能实数等级域 攻击速度增加（%） ('Nsi4')
+    // 技能随等级改变的实数域 攻击速度增加（%） ('Nsi4')
 	constant abilityreallevelfield ABILITY_RLF_ATTACK_SPEED_MODIFIER = ConvertAbilityRealLevelField('Nsi4')
-    // 技能实数等级域 每秒伤害 ('Tdg1')
+    // 技能随等级改变的实数域 每秒伤害 ('Tdg1')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_PER_SECOND_TDG1 = ConvertAbilityRealLevelField('Tdg1')
-    // 技能实数等级域 中范围半径 ('Tdg2')
+    // 技能随等级改变的实数域 中范围半径 ('Tdg2')
 	constant abilityreallevelfield ABILITY_RLF_MEDIUM_DAMAGE_RADIUS_TDG2 = ConvertAbilityRealLevelField('Tdg2')
-    // 技能实数等级域 中范围每秒伤害 ('Tdg3')
+    // 技能随等级改变的实数域 中范围每秒伤害 ('Tdg3')
 	constant abilityreallevelfield ABILITY_RLF_MEDIUM_DAMAGE_PER_SECOND = ConvertAbilityRealLevelField('Tdg3')
-    // 技能实数等级域 小范围半径 ('Tdg4')
+    // 技能随等级改变的实数域 小范围半径 ('Tdg4')
 	constant abilityreallevelfield ABILITY_RLF_SMALL_DAMAGE_RADIUS_TDG4 = ConvertAbilityRealLevelField('Tdg4')
-    // 技能实数等级域 小范围每秒伤害 ('Tdg5')
+    // 技能随等级改变的实数域 小范围每秒伤害 ('Tdg5')
 	constant abilityreallevelfield ABILITY_RLF_SMALL_DAMAGE_PER_SECOND = ConvertAbilityRealLevelField('Tdg5')
-    // 技能实数等级域 空中时间 ('Tsp1')
+    // 技能随等级改变的实数域 空中时间 ('Tsp1')
 	constant abilityreallevelfield ABILITY_RLF_AIR_TIME_SECONDS_TSP1 = ConvertAbilityRealLevelField('Tsp1')
-    // 技能实数等级域 最小间隔 ('Tsp2')
+    // 技能随等级改变的实数域 最小间隔 ('Tsp2')
 	constant abilityreallevelfield ABILITY_RLF_MINIMUM_HIT_INTERVAL_SECONDS = ConvertAbilityRealLevelField('Tsp2')
-    // 技能实数等级域 每秒伤害 ('Nbf5')
+    // 技能随等级改变的实数域 每秒伤害 ('Nbf5')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_PER_SECOND_NBF5 = ConvertAbilityRealLevelField('Nbf5')
-    // 技能实数等级域 最大范围 ('Ebl1')
+    // 技能随等级改变的实数域 最大范围 ('Ebl1')
 	constant abilityreallevelfield ABILITY_RLF_MAXIMUM_RANGE = ConvertAbilityRealLevelField('Ebl1')
-    // 技能实数等级域 最小范围 ('Ebl2')
+    // 技能随等级改变的实数域 最小范围 ('Ebl2')
 	constant abilityreallevelfield ABILITY_RLF_MINIMUM_RANGE = ConvertAbilityRealLevelField('Ebl2')
-    // 技能实数等级域 目标伤害 ('Efk1')
+    // 技能随等级改变的实数域 目标伤害 ('Efk1')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_PER_TARGET_EFK1 = ConvertAbilityRealLevelField('Efk1')
-    // 技能实数等级域 最大输出伤害 ('Efk2')
+    // 技能随等级改变的实数域 最大输出伤害 ('Efk2')
 	constant abilityreallevelfield ABILITY_RLF_MAXIMUM_TOTAL_DAMAGE = ConvertAbilityRealLevelField('Efk2')
-    // 技能实数等级域 最大速度调整 ('Efk4')
+    // 技能随等级改变的实数域 最大速度调整 ('Efk4')
 	constant abilityreallevelfield ABILITY_RLF_MAXIMUM_SPEED_ADJUSTMENT = ConvertAbilityRealLevelField('Efk4')
-    // 技能实数等级域 持续伤害 ('Esh1')
+    // 技能随等级改变的实数域 持续伤害 ('Esh1')
 	constant abilityreallevelfield ABILITY_RLF_DECAYING_DAMAGE = ConvertAbilityRealLevelField('Esh1')
-    // 技能实数等级域 移动速度系数（%） ('Esh2')
+    // 技能随等级改变的实数域 移动速度系数（%） ('Esh2')
 	constant abilityreallevelfield ABILITY_RLF_MOVEMENT_SPEED_FACTOR_ESH2 = ConvertAbilityRealLevelField('Esh2')
-    // 技能实数等级域 攻击速度减少 ('Esh3')
+    // 技能随等级改变的实数域 攻击速度减少 ('Esh3')
 	constant abilityreallevelfield ABILITY_RLF_ATTACK_SPEED_FACTOR_ESH3 = ConvertAbilityRealLevelField('Esh3')
-    // 技能实数等级域 速度衰减幅度 ('Esh4')
+    // 技能随等级改变的实数域 速度衰减幅度 ('Esh4')
 	constant abilityreallevelfield ABILITY_RLF_DECAY_POWER = ConvertAbilityRealLevelField('Esh4')
-    // 技能实数等级域 初始伤害 ('Esh5')
+    // 技能随等级改变的实数域 初始伤害 ('Esh5')
 	constant abilityreallevelfield ABILITY_RLF_INITIAL_DAMAGE_ESH5 = ConvertAbilityRealLevelField('Esh5')
-    // 技能实数等级域 最大生命吸收 ('abs1')
+    // 技能随等级改变的实数域 最大生命吸收 ('abs1')
 	constant abilityreallevelfield ABILITY_RLF_MAXIMUM_LIFE_ABSORBED = ConvertAbilityRealLevelField('abs1')
-    // 技能实数等级域 最大魔法吸收 ('abs2')
+    // 技能随等级改变的实数域 最大魔法吸收 ('abs2')
 	constant abilityreallevelfield ABILITY_RLF_MAXIMUM_MANA_ABSORBED = ConvertAbilityRealLevelField('abs2')
-    // 技能实数等级域 移动速度增加（%） ('bsk1')
+    // 技能随等级改变的实数域 移动速度增加（%） ('bsk1')
 	constant abilityreallevelfield ABILITY_RLF_MOVEMENT_SPEED_INCREASE_BSK1 = ConvertAbilityRealLevelField('bsk1')
-    // 技能实数等级域 攻击速度增加（%） ('bsk2')
+    // 技能随等级改变的实数域 攻击速度增加（%） ('bsk2')
 	constant abilityreallevelfield ABILITY_RLF_ATTACK_SPEED_INCREASE_BSK2 = ConvertAbilityRealLevelField('bsk2')
-    // 技能实数等级域 所受伤害增加（%） ('bsk3')
+    // 技能随等级改变的实数域 所受伤害增加（%） ('bsk3')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_TAKEN_INCREASE = ConvertAbilityRealLevelField('bsk3')
-    // 技能实数等级域 每个单位给予生命值 ('dvm1')
+    // 技能随等级改变的实数域 每个单位给予生命值 ('dvm1')
 	constant abilityreallevelfield ABILITY_RLF_LIFE_PER_UNIT = ConvertAbilityRealLevelField('dvm1')
-    // 技能实数等级域 每个单位给予魔法值 ('dvm2')
+    // 技能随等级改变的实数域 每个单位给予魔法值 ('dvm2')
 	constant abilityreallevelfield ABILITY_RLF_MANA_PER_UNIT = ConvertAbilityRealLevelField('dvm2')
-    // 技能实数等级域 每个Buff给予生命值 ('dvm3')
+    // 技能随等级改变的实数域 每个Buff给予生命值 ('dvm3')
 	constant abilityreallevelfield ABILITY_RLF_LIFE_PER_BUFF = ConvertAbilityRealLevelField('dvm3')
-    // 技能实数等级域 每个Buff给予魔法值 ('dvm4')
+    // 技能随等级改变的实数域 每个Buff给予魔法值 ('dvm4')
 	constant abilityreallevelfield ABILITY_RLF_MANA_PER_BUFF = ConvertAbilityRealLevelField('dvm4')
-    // 技能实数等级域 对召唤单位伤害 ('dvm5')
+    // 技能随等级改变的实数域 对召唤单位伤害 ('dvm5')
 	constant abilityreallevelfield ABILITY_RLF_SUMMONED_UNIT_DAMAGE_DVM5 = ConvertAbilityRealLevelField('dvm5')
-    // 技能实数等级域 伤害奖励 ('fak1')
+    // 技能随等级改变的实数域 伤害奖励 ('fak1')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_BONUS_FAK1 = ConvertAbilityRealLevelField('fak1')
-    // 技能实数等级域 中伤害参数 ('fak2')
+    // 技能随等级改变的实数域 中伤害参数 ('fak2')
 	constant abilityreallevelfield ABILITY_RLF_MEDIUM_DAMAGE_FACTOR_FAK2 = ConvertAbilityRealLevelField('fak2')
-    // 技能实数等级域 小伤害参数 ('fak3')
+    // 技能随等级改变的实数域 小伤害参数 ('fak3')
 	constant abilityreallevelfield ABILITY_RLF_SMALL_DAMAGE_FACTOR_FAK3 = ConvertAbilityRealLevelField('fak3')
-    // 技能实数等级域 全伤害范围 ('fak4')
+    // 技能随等级改变的实数域 全伤害范围 ('fak4')
 	constant abilityreallevelfield ABILITY_RLF_FULL_DAMAGE_RADIUS_FAK4 = ConvertAbilityRealLevelField('fak4')
-    // 技能实数等级域 中伤害范围 ('fak5')
+    // 技能随等级改变的实数域 中伤害范围 ('fak5')
 	constant abilityreallevelfield ABILITY_RLF_HALF_DAMAGE_RADIUS_FAK5 = ConvertAbilityRealLevelField('fak5')
-    // 技能实数等级域 额外每秒伤害 ('liq1')
+    // 技能随等级改变的实数域 额外每秒伤害 ('liq1')
 	constant abilityreallevelfield ABILITY_RLF_EXTRA_DAMAGE_PER_SECOND = ConvertAbilityRealLevelField('liq1')
-    // 技能实数等级域 移动速度减少 ('liq2')
+    // 技能随等级改变的实数域 移动速度减少 ('liq2')
 	constant abilityreallevelfield ABILITY_RLF_MOVEMENT_SPEED_REDUCTION_LIQ2 = ConvertAbilityRealLevelField('liq2')
-    // 技能实数等级域 攻击速度减少 ('liq3')
+    // 技能随等级改变的实数域 攻击速度减少 ('liq3')
 	constant abilityreallevelfield ABILITY_RLF_ATTACK_SPEED_REDUCTION_LIQ3 = ConvertAbilityRealLevelField('liq3')
-    // 技能实数等级域 魔法伤害参数 ('mim1')
+    // 技能随等级改变的实数域 魔法伤害参数 ('mim1')
 	constant abilityreallevelfield ABILITY_RLF_MAGIC_DAMAGE_FACTOR = ConvertAbilityRealLevelField('mim1')
-    // 技能实数等级域 单位 - 每点魔法造成的伤害 ('mfl1')
+    // 技能随等级改变的实数域 单位 - 每点魔法造成的伤害 ('mfl1')
 	constant abilityreallevelfield ABILITY_RLF_UNIT_DAMAGE_PER_MANA_POINT = ConvertAbilityRealLevelField('mfl1')
-    // 技能实数等级域 英雄 - 每点魔法造成的伤害 ('mfl2')
+    // 技能随等级改变的实数域 英雄 - 每点魔法造成的伤害 ('mfl2')
 	constant abilityreallevelfield ABILITY_RLF_HERO_DAMAGE_PER_MANA_POINT = ConvertAbilityRealLevelField('mfl2')
-    // 技能实数等级域 单位 - 最大伤害 ('mfl3')
+    // 技能随等级改变的实数域 单位 - 最大伤害 ('mfl3')
 	constant abilityreallevelfield ABILITY_RLF_UNIT_MAXIMUM_DAMAGE = ConvertAbilityRealLevelField('mfl3')
-    // 技能实数等级域 英雄 - 最大伤害 ('mfl3')
+    // 技能随等级改变的实数域 英雄 - 最大伤害 ('mfl3')
 	constant abilityreallevelfield ABILITY_RLF_HERO_MAXIMUM_DAMAGE = ConvertAbilityRealLevelField('mfl4')
-    // 技能实数等级域 护甲增加 ('mfl5')
+    // 技能随等级改变的实数域 护甲增加 ('mfl5')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_COOLDOWN = ConvertAbilityRealLevelField('mfl5')
-    // 技能实数等级域 分布伤害参数 ('spl1')
+    // 技能随等级改变的实数域 分布伤害参数 ('spl1')
 	constant abilityreallevelfield ABILITY_RLF_DISTRIBUTED_DAMAGE_FACTOR_SPL1 = ConvertAbilityRealLevelField('spl1')
-    // 技能实数等级域 生命回复 ('irl1')
+    // 技能随等级改变的实数域 生命回复 ('irl1')
 	constant abilityreallevelfield ABILITY_RLF_LIFE_REGENERATED = ConvertAbilityRealLevelField('irl1')
-    // 技能实数等级域 魔法回复 ('irl2')
+    // 技能随等级改变的实数域 魔法回复 ('irl2')
 	constant abilityreallevelfield ABILITY_RLF_MANA_REGENERATED = ConvertAbilityRealLevelField('irl2')
-    // 技能实数等级域 每个单位魔法损耗 ('idc1')
+    // 技能随等级改变的实数域 每个单位魔法损耗 ('idc1')
 	constant abilityreallevelfield ABILITY_RLF_MANA_LOSS_PER_UNIT_IDC1 = ConvertAbilityRealLevelField('idc1')
-    // 技能实数等级域 对召唤单位伤害 ('idc2')
+    // 技能随等级改变的实数域 对召唤单位伤害 ('idc2')
 	constant abilityreallevelfield ABILITY_RLF_SUMMONED_UNIT_DAMAGE_IDC2 = ConvertAbilityRealLevelField('idc2')
-    // 技能实数等级域 激活延迟 ('imo2')
+    // 技能随等级改变的实数域 激活延迟 ('imo2')
 	constant abilityreallevelfield ABILITY_RLF_ACTIVATION_DELAY_IMO2 = ConvertAbilityRealLevelField('imo2')
-    // 技能实数等级域 引诱间隔 ('imo3')
+    // 技能随等级改变的实数域 引诱间隔 ('imo3')
 	constant abilityreallevelfield ABILITY_RLF_LURE_INTERVAL_SECONDS = ConvertAbilityRealLevelField('imo3')
-    // 技能实数等级域 伤害奖励 ('isr1')
+    // 技能随等级改变的实数域 伤害奖励 ('isr1')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_BONUS_ISR1 = ConvertAbilityRealLevelField('isr1')
-    // 技能实数等级域 魔法伤害减少 ('isr2')
+    // 技能随等级改变的实数域 魔法伤害减少 ('isr2')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_REDUCTION_ISR2 = ConvertAbilityRealLevelField('isr2')
-    // 技能实数等级域 伤害奖励 ('ipv1')
+    // 技能随等级改变的实数域 伤害奖励 ('ipv1')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_BONUS_IPV1 = ConvertAbilityRealLevelField('ipv1')
-    // 技能实数等级域 生命偷取值 ('ipv2')
+    // 技能随等级改变的实数域 生命偷取值 ('ipv2')
 	constant abilityreallevelfield ABILITY_RLF_LIFE_STEAL_AMOUNT = ConvertAbilityRealLevelField('ipv2')
-    // 技能实数等级域 生命回复参数 ('ast1')
+    // 技能随等级改变的实数域 生命回复参数 ('ast1')
 	constant abilityreallevelfield ABILITY_RLF_LIFE_RESTORED_FACTOR = ConvertAbilityRealLevelField('ast1')
-    // 技能实数等级域 魔法回复参数 ('ast2')
+    // 技能随等级改变的实数域 魔法回复参数 ('ast2')
 	constant abilityreallevelfield ABILITY_RLF_MANA_RESTORED_FACTOR = ConvertAbilityRealLevelField('ast2')
-    // 技能实数等级域 附加延迟 ('gra1')
+    // 技能随等级改变的实数域 附加延迟 ('gra1')
 	constant abilityreallevelfield ABILITY_RLF_ATTACH_DELAY = ConvertAbilityRealLevelField('gra1')
-    // 技能实数等级域 移除延迟 ('gra2')
+    // 技能随等级改变的实数域 移除延迟 ('gra2')
 	constant abilityreallevelfield ABILITY_RLF_REMOVE_DELAY = ConvertAbilityRealLevelField('gra2')
-    // 技能实数等级域 英雄回复延迟 ('Nsa2')
+    // 技能随等级改变的实数域 英雄回复延迟 ('Nsa2')
 	constant abilityreallevelfield ABILITY_RLF_HERO_REGENERATION_DELAY = ConvertAbilityRealLevelField('Nsa2')
-    // 技能实数等级域 单位回复延迟 ('Nsa3')
+    // 技能随等级改变的实数域 单位回复延迟 ('Nsa3')
 	constant abilityreallevelfield ABILITY_RLF_UNIT_REGENERATION_DELAY = ConvertAbilityRealLevelField('Nsa3')
-    // 技能实数等级域 魔法伤害参数 ('Nsa4')
+    // 技能随等级改变的实数域 魔法伤害参数 ('Nsa4')
 	constant abilityreallevelfield ABILITY_RLF_MAGIC_DAMAGE_REDUCTION_NSA4 = ConvertAbilityRealLevelField('Nsa4')
-    // 技能实数等级域 每秒生命恢复 ('Nsa5')
+    // 技能随等级改变的实数域 每秒生命恢复 ('Nsa5')
 	constant abilityreallevelfield ABILITY_RLF_HIT_POINTS_PER_SECOND_NSA5 = ConvertAbilityRealLevelField('Nsa5')
-    // 技能实数等级域 对召唤单位伤害 ('Ixs1')
+    // 技能随等级改变的实数域 对召唤单位伤害 ('Ixs1')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_TO_SUMMONED_UNITS_IXS1 = ConvertAbilityRealLevelField('Ixs1')
-    // 技能实数等级域 魔法伤害减少 ('Ixs2')
+    // 技能随等级改变的实数域 魔法伤害减少 ('Ixs2')
 	constant abilityreallevelfield ABILITY_RLF_MAGIC_DAMAGE_REDUCTION_IXS2 = ConvertAbilityRealLevelField('Ixs2')
-    // 技能实数等级域 召唤单位持续时间 ('Npa6')
+    // 技能随等级改变的实数域 召唤单位持续时间 ('Npa6')
 	constant abilityreallevelfield ABILITY_RLF_SUMMONED_UNIT_DURATION = ConvertAbilityRealLevelField('Npa6')
-    // 技能实数等级域 护盾CD间隔 ('Nse1')
+    // 技能随等级改变的实数域 护盾CD间隔 ('Nse1')
 	constant abilityreallevelfield ABILITY_RLF_SHIELD_COOLDOWN_TIME = ConvertAbilityRealLevelField('Nse1')
-    // 技能实数等级域 每秒伤害 ('Ndo1')
+    // 技能随等级改变的实数域 每秒伤害 ('Ndo1')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_PER_SECOND_NDO1 = ConvertAbilityRealLevelField('Ndo1')
-    // 技能实数等级域 召唤单位持续时间 ('Ndo3')
+    // 技能随等级改变的实数域 召唤单位持续时间 ('Ndo3')
 	constant abilityreallevelfield ABILITY_RLF_SUMMONED_UNIT_DURATION_SECONDS_NDO3 = ConvertAbilityRealLevelField('Ndo3')
-    // 技能实数等级域 小伤害范围 ('flk1')
+    // 技能随等级改变的实数域 小伤害范围 ('flk1')
 	constant abilityreallevelfield ABILITY_RLF_MEDIUM_DAMAGE_RADIUS_FLK1 = ConvertAbilityRealLevelField('flk1')
-    // 技能实数等级域 中伤害范围 ('flk2')
+    // 技能随等级改变的实数域 中伤害范围 ('flk2')
 	constant abilityreallevelfield ABILITY_RLF_SMALL_DAMAGE_RADIUS_FLK2 = ConvertAbilityRealLevelField('flk2')
-    // 技能实数等级域 全伤害数值 ('flk3')
+    // 技能随等级改变的实数域 全伤害数值 ('flk3')
 	constant abilityreallevelfield ABILITY_RLF_FULL_DAMAGE_AMOUNT_FLK3 = ConvertAbilityRealLevelField('flk3')
-    // 技能实数等级域 中伤害数值 ('flk4')
+    // 技能随等级改变的实数域 中伤害数值 ('flk4')
 	constant abilityreallevelfield ABILITY_RLF_MEDIUM_DAMAGE_AMOUNT = ConvertAbilityRealLevelField('flk4')
-    // 技能实数等级域 小伤害数值 ('flk5')
+    // 技能随等级改变的实数域 小伤害数值 ('flk5')
 	constant abilityreallevelfield ABILITY_RLF_SMALL_DAMAGE_AMOUNT = ConvertAbilityRealLevelField('flk5')
-    // 技能实数等级域 移动速度减少（%） ('Hbn1')
+    // 技能随等级改变的实数域 移动速度减少（%） ('Hbn1')
 	constant abilityreallevelfield ABILITY_RLF_MOVEMENT_SPEED_REDUCTION_PERCENT_HBN1 = ConvertAbilityRealLevelField('Hbn1')
-    // 技能实数等级域 攻击速度减少（%） ('Hbn2')
+    // 技能随等级改变的实数域 攻击速度减少（%） ('Hbn2')
 	constant abilityreallevelfield ABILITY_RLF_ATTACK_SPEED_REDUCTION_PERCENT_HBN2 = ConvertAbilityRealLevelField('Hbn2')
-    // 技能实数等级域 最大损耗魔法 - 单位 ('fbk1')
+    // 技能随等级改变的实数域 最大损耗魔法 - 单位 ('fbk1')
 	constant abilityreallevelfield ABILITY_RLF_MAX_MANA_DRAINED_UNITS = ConvertAbilityRealLevelField('fbk1')
-    // 技能实数等级域 伤害比率 - 单位('fbk2')
+    // 技能随等级改变的实数域 伤害比率 - 单位('fbk2')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_RATIO_UNITS_PERCENT = ConvertAbilityRealLevelField('fbk2')
-    // 技能实数等级域 最大损耗魔法 - 英雄 ('fbk3')
+    // 技能随等级改变的实数域 最大损耗魔法 - 英雄 ('fbk3')
 	constant abilityreallevelfield ABILITY_RLF_MAX_MANA_DRAINED_HEROS = ConvertAbilityRealLevelField('fbk3')
-    // 技能实数等级域 伤害比率 - 英雄 ('fbk4')
+    // 技能随等级改变的实数域 伤害比率 - 英雄 ('fbk4')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_RATIO_HEROS_PERCENT = ConvertAbilityRealLevelField('fbk4')
-    // 技能实数等级域 对召唤单位伤害 ('fbk5')
+    // 技能随等级改变的实数域 对召唤单位伤害 ('fbk5')
 	constant abilityreallevelfield ABILITY_RLF_SUMMONED_DAMAGE = ConvertAbilityRealLevelField('fbk5')
-    // 技能实数等级域 分裂伤害参数 ('nca1')
+    // 技能随等级改变的实数域 分裂伤害参数 ('nca1')
 	constant abilityreallevelfield ABILITY_RLF_DISTRIBUTED_DAMAGE_FACTOR_NCA1 = ConvertAbilityRealLevelField('nca1')
-    // 技能实数等级域 初始伤害 ('pxf1')
+    // 技能随等级改变的实数域 初始伤害 ('pxf1')
 	constant abilityreallevelfield ABILITY_RLF_INITIAL_DAMAGE_PXF1 = ConvertAbilityRealLevelField('pxf1')
-    // 技能实数等级域 每秒伤害 ('pxf2')
+    // 技能随等级改变的实数域 每秒伤害 ('pxf2')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_PER_SECOND_PXF2 = ConvertAbilityRealLevelField('pxf2')
-    // 技能实数等级域 每秒伤害 ('mls1')
+    // 技能随等级改变的实数域 每秒伤害 ('mls1')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_PER_SECOND_MLS1 = ConvertAbilityRealLevelField('mls1')
-    // 技能实数等级域 野兽碰撞范围 ('Nst2')
+    // 技能随等级改变的实数域 野兽碰撞范围 ('Nst2')
 	constant abilityreallevelfield ABILITY_RLF_BEAST_COLLISION_RADIUS = ConvertAbilityRealLevelField('Nst2')
-    // 技能实数等级域 伤害数值 ('Nst3')
+    // 技能随等级改变的实数域 伤害数值 ('Nst3')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_AMOUNT_NST3 = ConvertAbilityRealLevelField('Nst3')
-    // 技能实数等级域 伤害范围 ('Nst4')
+    // 技能随等级改变的实数域 伤害范围 ('Nst4')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_RADIUS = ConvertAbilityRealLevelField('Nst4')
-    // 技能实数等级域 伤害延迟 ('Nst5')
+    // 技能随等级改变的实数域 伤害延迟 ('Nst5')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_DELAY = ConvertAbilityRealLevelField('Nst5')
-    // 技能实数等级域 施法持续时间 ('Ncl1')
+    // 技能随等级改变的实数域 施法持续时间 ('Ncl1')
 	constant abilityreallevelfield ABILITY_RLF_FOLLOW_THROUGH_TIME = ConvertAbilityRealLevelField('Ncl1')
-    // 技能实数等级域 技能持续时间 ('Ncl4')
+    // 技能随等级改变的实数域 技能持续时间 ('Ncl4')
 	constant abilityreallevelfield ABILITY_RLF_ART_DURATION = ConvertAbilityRealLevelField('Ncl4')
-    // 技能实数等级域 移动速度增加（%） ('Nab1')
+    // 技能随等级改变的实数域 移动速度增加（%） ('Nab1')
 	constant abilityreallevelfield ABILITY_RLF_MOVEMENT_SPEED_REDUCTION_PERCENT_NAB1 = ConvertAbilityRealLevelField('Nab1')
-    // 技能实数等级域 攻击速度增加（%） ('Nab2')
+    // 技能随等级改变的实数域 攻击速度增加（%） ('Nab2')
 	constant abilityreallevelfield ABILITY_RLF_ATTACK_SPEED_REDUCTION_PERCENT_NAB2 = ConvertAbilityRealLevelField('Nab2')
-    // 技能实数等级域 目标持续伤害数值 ('Nab4')
+    // 技能随等级改变的实数域 目标持续伤害数值 ('Nab4')
 	constant abilityreallevelfield ABILITY_RLF_PRIMARY_DAMAGE = ConvertAbilityRealLevelField('Nab4')
-    // 技能实数等级域 范围持续伤害数值 ('Nab5')
+    // 技能随等级改变的实数域 范围持续伤害数值 ('Nab5')
 	constant abilityreallevelfield ABILITY_RLF_SECONDARY_DAMAGE = ConvertAbilityRealLevelField('Nab5')
-    // 技能实数等级域 伤害间隔 ('Nab6')
+    // 技能随等级改变的实数域 伤害间隔 ('Nab6')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_INTERVAL_NAB6 = ConvertAbilityRealLevelField('Nab6')
-    // 技能实数等级域 黄金奖励参数 ('Ntm1')
+    // 技能随等级改变的实数域 黄金奖励参数 ('Ntm1')
 	constant abilityreallevelfield ABILITY_RLF_GOLD_COST_FACTOR = ConvertAbilityRealLevelField('Ntm1')
-    // 技能实数等级域 木材奖励参数 ('Ntm2')
+    // 技能随等级改变的实数域 木材奖励参数 ('Ntm2')
 	constant abilityreallevelfield ABILITY_RLF_LUMBER_COST_FACTOR = ConvertAbilityRealLevelField('Ntm2')
-    // 技能实数等级域 移动速度奖励 ('Neg1')
+    // 技能随等级改变的实数域 移动速度奖励 ('Neg1')
 	constant abilityreallevelfield ABILITY_RLF_MOVE_SPEED_BONUS_NEG1 = ConvertAbilityRealLevelField('Neg1')
-    // 技能实数等级域 攻击奖励 ('Neg2')
+    // 技能随等级改变的实数域 攻击奖励 ('Neg2')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_BONUS_NEG2 = ConvertAbilityRealLevelField('Neg2')
-    // 技能实数等级域 伤害数值 ('Ncs1')
+    // 技能随等级改变的实数域 伤害数值 ('Ncs1')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_AMOUNT_NCS1 = ConvertAbilityRealLevelField('Ncs1')
-    // 技能实数等级域 伤害间隔 ('Ncs2')
+    // 技能随等级改变的实数域 伤害间隔 ('Ncs2')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_INTERVAL_NCS2 = ConvertAbilityRealLevelField('Ncs2')
-    // 技能实数等级域 最高输出伤害 ('Ncs4')
+    // 技能随等级改变的实数域 最高输出伤害 ('Ncs4')
 	constant abilityreallevelfield ABILITY_RLF_MAX_DAMAGE_NCS4 = ConvertAbilityRealLevelField('Ncs4')
-    // 技能实数等级域 建筑物伤害参数 ('Ncs5')
+    // 技能随等级改变的实数域 建筑物伤害参数 ('Ncs5')
 	constant abilityreallevelfield ABILITY_RLF_BUILDING_DAMAGE_FACTOR_NCS5 = ConvertAbilityRealLevelField('Ncs5')
-    // 技能实数等级域 技能持续时间 ('Ncs6')
+    // 技能随等级改变的实数域 技能持续时间 ('Ncs6')
 	constant abilityreallevelfield ABILITY_RLF_EFFECT_DURATION = ConvertAbilityRealLevelField('Ncs6')
-    // 技能实数等级域 生产单位间隔 ('Nsy1')
+    // 技能随等级改变的实数域 生产单位间隔 ('Nsy1')
 	constant abilityreallevelfield ABILITY_RLF_SPAWN_INTERVAL_NSY1 = ConvertAbilityRealLevelField('Nsy1')
-    // 技能实数等级域 生产单位持续时间 ('Nsy3')
+    // 技能随等级改变的实数域 生产单位持续时间 ('Nsy3')
 	constant abilityreallevelfield ABILITY_RLF_SPAWN_UNIT_DURATION = ConvertAbilityRealLevelField('Nsy3')
-    // 技能实数等级域 产生单位位移 ('Nsy4')
+    // 技能随等级改变的实数域 产生单位位移 ('Nsy4')
 	constant abilityreallevelfield ABILITY_RLF_SPAWN_UNIT_OFFSET = ConvertAbilityRealLevelField('Nsy4')
-    // 技能实数等级域 约束范围 ('Nsy5')
+    // 技能随等级改变的实数域 约束范围 ('Nsy5')
 	constant abilityreallevelfield ABILITY_RLF_LEASH_RANGE_NSY5 = ConvertAbilityRealLevelField('Nsy5')
-    // 技能实数等级域 生产单位间隔 ('Nfy1')
+    // 技能随等级改变的实数域 生产单位间隔 ('Nfy1')
 	constant abilityreallevelfield ABILITY_RLF_SPAWN_INTERVAL_NFY1 = ConvertAbilityRealLevelField('Nfy1')
-    // 技能实数等级域 约束范围 ('Nfy2')
+    // 技能随等级改变的实数域 约束范围 ('Nfy2')
 	constant abilityreallevelfield ABILITY_RLF_LEASH_RANGE_NFY2 = ConvertAbilityRealLevelField('Nfy2')
-    // 技能实数等级域 粉碎几率 ('Nde1')
+    // 技能随等级改变的实数域 粉碎几率 ('Nde1')
 	constant abilityreallevelfield ABILITY_RLF_CHANCE_TO_DEMOLISH = ConvertAbilityRealLevelField('Nde1')
-    // 技能实数等级域 伤害倍乘（建筑物） ('Nde2')
+    // 技能随等级改变的实数域 伤害倍乘（建筑物） ('Nde2')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_MULTIPLIER_BUILDINGS = ConvertAbilityRealLevelField('Nde2')
-    // 技能实数等级域 伤害倍乘（单位） ('Nde3')
+    // 技能随等级改变的实数域 伤害倍乘（单位） ('Nde3')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_MULTIPLIER_UNITS = ConvertAbilityRealLevelField('Nde3')
-    // 技能实数等级域 伤害倍乘（英雄） ('Nde4')
+    // 技能随等级改变的实数域 伤害倍乘（英雄） ('Nde4')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_MULTIPLIER_HEROES = ConvertAbilityRealLevelField('Nde4')
-    // 技能实数等级域 燃灰伤害值奖励 ('Nic1')
+    // 技能随等级改变的实数域 燃灰伤害值奖励 ('Nic1')
 	constant abilityreallevelfield ABILITY_RLF_BONUS_DAMAGE_MULTIPLIER = ConvertAbilityRealLevelField('Nic1')
-    // 技能实数等级域 死亡伤害 - 全伤害 ('Nic2')
+    // 技能随等级改变的实数域 死亡伤害 - 全伤害 ('Nic2')
 	constant abilityreallevelfield ABILITY_RLF_DEATH_DAMAGE_FULL_AMOUNT = ConvertAbilityRealLevelField('Nic2')
-    // 技能实数等级域 死亡伤害 - 全伤害范围 ('Nic3')
+    // 技能随等级改变的实数域 死亡伤害 - 全伤害范围 ('Nic3')
 	constant abilityreallevelfield ABILITY_RLF_DEATH_DAMAGE_FULL_AREA = ConvertAbilityRealLevelField('Nic3')
-    // 技能实数等级域 死亡伤害 - 半伤害 ('Nic4')
+    // 技能随等级改变的实数域 死亡伤害 - 半伤害 ('Nic4')
 	constant abilityreallevelfield ABILITY_RLF_DEATH_DAMAGE_HALF_AMOUNT = ConvertAbilityRealLevelField('Nic4')
-    // 技能实数等级域 死亡伤害 - 半伤害范围 ('Nic5')
+    // 技能随等级改变的实数域 死亡伤害 - 半伤害范围 ('Nic5')
 	constant abilityreallevelfield ABILITY_RLF_DEATH_DAMAGE_HALF_AREA = ConvertAbilityRealLevelField('Nic5')
-    // 技能实数等级域 死亡伤害 - 延迟 ('Nic6')
+    // 技能随等级改变的实数域 死亡伤害 - 延迟 ('Nic6')
 	constant abilityreallevelfield ABILITY_RLF_DEATH_DAMAGE_DELAY = ConvertAbilityRealLevelField('Nic6')
-    // 技能实数等级域 伤害值 ('Nso1')
+    // 技能随等级改变的实数域 伤害值 ('Nso1')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_AMOUNT_NSO1 = ConvertAbilityRealLevelField('Nso1')
-    // 技能实数等级域 伤害周期 ('Nso2')
+    // 技能随等级改变的实数域 伤害周期 ('Nso2')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_PERIOD = ConvertAbilityRealLevelField('Nso2')
-    // 技能实数等级域 攻击减少 ('Nso3')
+    // 技能随等级改变的实数域 攻击减少 ('Nso3')
 	constant abilityreallevelfield ABILITY_RLF_DAMAGE_PENALTY = ConvertAbilityRealLevelField('Nso3')
-    // 技能实数等级域 移动速度减少（%） ('Nso4')
+    // 技能随等级改变的实数域 移动速度减少（%） ('Nso4')
 	constant abilityreallevelfield ABILITY_RLF_MOVEMENT_SPEED_REDUCTION_PERCENT_NSO4 = ConvertAbilityRealLevelField('Nso4')
-    // 技能实数等级域 攻击速度减少（%） ('Nso5')
+    // 技能随等级改变的实数域 攻击速度减少（%） ('Nso5')
 	constant abilityreallevelfield ABILITY_RLF_ATTACK_SPEED_REDUCTION_PERCENT_NSO5 = ConvertAbilityRealLevelField('Nso5')
-    // 技能实数等级域 分裂延迟 ('Nlm2')
+    // 技能随等级改变的实数域 分裂延迟 ('Nlm2')
 	constant abilityreallevelfield ABILITY_RLF_SPLIT_DELAY = ConvertAbilityRealLevelField('Nlm2')
-    // 技能实数等级域 最大生命值参数 ('Nlm4')
+    // 技能随等级改变的实数域 最大生命值参数 ('Nlm4')
 	constant abilityreallevelfield ABILITY_RLF_MAX_HITPOINT_FACTOR = ConvertAbilityRealLevelField('Nlm4')
-    // 技能实数等级域 分裂生命周期奖励 ('Nlm5')
+    // 技能随等级改变的实数域 分裂生命周期奖励 ('Nlm5')
 	constant abilityreallevelfield ABILITY_RLF_LIFE_DURATION_SPLIT_BONUS = ConvertAbilityRealLevelField('Nlm5')
-    // 技能实数等级域 波间隔时间 ('Nvc3')
+    // 技能随等级改变的实数域 波间隔时间 ('Nvc3')
 	constant abilityreallevelfield ABILITY_RLF_WAVE_INTERVAL = ConvertAbilityRealLevelField('Nvc3')
-    // 技能实数等级域 建筑伤害参数（%） ('Nvc4')
+    // 技能随等级改变的实数域 建筑伤害参数（%） ('Nvc4')
 	constant abilityreallevelfield ABILITY_RLF_BUILDING_DAMAGE_FACTOR_NVC4 = ConvertAbilityRealLevelField('Nvc4')
-    // 技能实数等级域 全伤害数值 ('Nvc5')
+    // 技能随等级改变的实数域 全伤害数值 ('Nvc5')
 	constant abilityreallevelfield ABILITY_RLF_FULL_DAMAGE_AMOUNT_NVC5 = ConvertAbilityRealLevelField('Nvc5')
-    // 技能实数等级域 半伤害参数 ('Nvc6')
+    // 技能随等级改变的实数域 半伤害参数 ('Nvc6')
 	constant abilityreallevelfield ABILITY_RLF_HALF_DAMAGE_FACTOR = ConvertAbilityRealLevelField('Nvc6')
-    // 技能实数等级域 增量间隔 ('Tau5')
+    // 技能随等级改变的实数域 增量间隔 ('Tau5')
 	constant abilityreallevelfield ABILITY_RLF_INTERVAL_BETWEEN_PULSES = ConvertAbilityRealLevelField('Tau5')
 	
-    // 技能布尔值等级域 百分比奖励 ('Hab2')
+    // 技能随等级改变的布尔值域 百分比奖励 ('Hab2')
 	constant abilitybooleanlevelfield ABILITY_BLF_PERCENT_BONUS_HAB2 = ConvertAbilityBooleanLevelField('Hab2')
-    // 技能布尔值等级域 传送单位聚集 ('Hmt3')
+    // 技能随等级改变的布尔值域 传送单位聚集 ('Hmt3')
 	constant abilitybooleanlevelfield ABILITY_BLF_USE_TELEPORT_CLUSTERING_HMT3 = ConvertAbilityBooleanLevelField('Hmt3')
-    // 技能布尔值等级域 不会丢失 ('Ocr5')
+    // 技能随等级改变的布尔值域 不会丢失 ('Ocr5')
 	constant abilitybooleanlevelfield ABILITY_BLF_NEVER_MISS_OCR5 = ConvertAbilityBooleanLevelField('Ocr5')
-    // 技能布尔值等级域 排除物品伤害 ('Ocr6')
+    // 技能随等级改变的布尔值域 排除物品伤害 ('Ocr6')
 	constant abilitybooleanlevelfield ABILITY_BLF_EXCLUDE_ITEM_DAMAGE = ConvertAbilityBooleanLevelField('Ocr6')
-    // 技能布尔值等级域 加成伤害 ('Owk4')
+    // 技能随等级改变的布尔值域 加成伤害 ('Owk4')
 	constant abilitybooleanlevelfield ABILITY_BLF_BACKSTAB_DAMAGE = ConvertAbilityBooleanLevelField('Owk4')
-    // 技能布尔值等级域 继承升级 ('Uan3')
+    // 技能随等级改变的布尔值域 继承升级 ('Uan3')
 	constant abilitybooleanlevelfield ABILITY_BLF_INHERIT_UPGRADES_UAN3 = ConvertAbilityBooleanLevelField('Uan3')
-    // 技能布尔值等级域 魔法数值转换 ('Udp3')
+    // 技能随等级改变的布尔值域 魔法数值转换 ('Udp3')
 	constant abilitybooleanlevelfield ABILITY_BLF_MANA_CONVERSION_AS_PERCENT = ConvertAbilityBooleanLevelField('Udp3')
-    // 技能布尔值等级域 生命数值转换 ('Udp4')
+    // 技能随等级改变的布尔值域 生命数值转换 ('Udp4')
 	constant abilitybooleanlevelfield ABILITY_BLF_LIFE_CONVERSION_AS_PERCENT = ConvertAbilityBooleanLevelField('Udp4')
-    // 技能布尔值等级域 目标存活 ('Udp5')
+    // 技能随等级改变的布尔值域 目标存活 ('Udp5')
 	constant abilitybooleanlevelfield ABILITY_BLF_LEAVE_TARGET_ALIVE = ConvertAbilityBooleanLevelField('Udp5')
-    // 技能布尔值等级域 百分比奖励 ('Uau3')
+    // 技能随等级改变的布尔值域 百分比奖励 ('Uau3')
 	constant abilitybooleanlevelfield ABILITY_BLF_PERCENT_BONUS_UAU3 = ConvertAbilityBooleanLevelField('Uau3')
-    // 技能布尔值等级域 按百分比反弹 ('Eah2')
+    // 技能随等级改变的布尔值域 按百分比反弹 ('Eah2')
 	constant abilitybooleanlevelfield ABILITY_BLF_DAMAGE_IS_PERCENT_RECEIVED = ConvertAbilityBooleanLevelField('Eah2')
-    // 技能布尔值等级域 近战奖励 ('Ear2')
+    // 技能随等级改变的布尔值域 近战奖励 ('Ear2')
 	constant abilitybooleanlevelfield ABILITY_BLF_MELEE_BONUS = ConvertAbilityBooleanLevelField('Ear2')
-    // 技能布尔值等级域 远程奖励 ('Ear3')
+    // 技能随等级改变的布尔值域 远程奖励 ('Ear3')
 	constant abilitybooleanlevelfield ABILITY_BLF_RANGED_BONUS = ConvertAbilityBooleanLevelField('Ear3')
-    // 技能布尔值等级域 使用指定数值奖励 ('Ear4')
+    // 技能随等级改变的布尔值域 使用指定数值奖励 ('Ear4')
 	constant abilitybooleanlevelfield ABILITY_BLF_FLAT_BONUS = ConvertAbilityBooleanLevelField('Ear4')
-    // 技能布尔值等级域 不会丢失 ('Hbh5')
+    // 技能随等级改变的布尔值域 不会丢失 ('Hbh5')
 	constant abilitybooleanlevelfield ABILITY_BLF_NEVER_MISS_HBH5 = ConvertAbilityBooleanLevelField('Hbh5')
-    // 技能布尔值等级域 百分比奖励 ('Had2')
+    // 技能随等级改变的布尔值域 百分比奖励 ('Had2')
 	constant abilitybooleanlevelfield ABILITY_BLF_PERCENT_BONUS_HAD2 = ConvertAbilityBooleanLevelField('Had2')
-    // 技能布尔值等级域 可以取消 ('Hds1')
+    // 技能随等级改变的布尔值域 可以取消 ('Hds1')
 	constant abilitybooleanlevelfield ABILITY_BLF_CAN_DEACTIVATE = ConvertAbilityBooleanLevelField('Hds1')
-    // 技能布尔值等级域 复活单位是无敌的 ('Hre2')
+    // 技能随等级改变的布尔值域 复活单位是无敌的 ('Hre2')
 	constant abilitybooleanlevelfield ABILITY_BLF_RAISED_UNITS_ARE_INVULNERABLE = ConvertAbilityBooleanLevelField('Hre2')
-    // 技能布尔值等级域 按百分比回复 ('Oar2')
+    // 技能随等级改变的布尔值域 按百分比回复 ('Oar2')
 	constant abilitybooleanlevelfield ABILITY_BLF_PERCENTAGE_OAR2 = ConvertAbilityBooleanLevelField('Oar2')
-    // 技能布尔值等级域 召唤非空闲单位 ('Btl2')
+    // 技能随等级改变的布尔值域 召唤非空闲单位 ('Btl2')
 	constant abilitybooleanlevelfield ABILITY_BLF_SUMMON_BUSY_UNITS = ConvertAbilityBooleanLevelField('Btl2')
-    // 技能布尔值等级域 创建荒芜地表 ('Bli2')
+    // 技能随等级改变的布尔值域 创建荒芜地表 ('Bli2')
 	constant abilitybooleanlevelfield ABILITY_BLF_CREATES_BLIGHT = ConvertAbilityBooleanLevelField('Bli2')
-    // 技能布尔值等级域 尸体爆炸 ('Sds6')
+    // 技能随等级改变的布尔值域 尸体爆炸 ('Sds6')
 	constant abilitybooleanlevelfield ABILITY_BLF_EXPLODES_ON_DEATH = ConvertAbilityBooleanLevelField('Sds6')
-    // 技能布尔值等级域 总是自动施放 ('Fae2')
+    // 技能随等级改变的布尔值域 总是自动施放 ('Fae2')
 	constant abilitybooleanlevelfield ABILITY_BLF_ALWAYS_AUTOCAST_FAE2 = ConvertAbilityBooleanLevelField('Fae2')
-    // 技能布尔值等级域 只能在夜间回复 ('Mbt5')
+    // 技能随等级改变的布尔值域 只能在夜间回复 ('Mbt5')
 	constant abilitybooleanlevelfield ABILITY_BLF_REGENERATE_ONLY_AT_NIGHT = ConvertAbilityBooleanLevelField('Mbt5')
-    // 技能布尔值等级域 显示选择单位按钮 ('Neu3')
+    // 技能随等级改变的布尔值域 显示选择单位按钮 ('Neu3')
 	constant abilitybooleanlevelfield ABILITY_BLF_SHOW_SELECT_UNIT_BUTTON = ConvertAbilityBooleanLevelField('Neu3')
-    // 技能布尔值等级域 显示单位指示器 ('Neu4')
+    // 技能随等级改变的布尔值域 显示单位指示器 ('Neu4')
 	constant abilitybooleanlevelfield ABILITY_BLF_SHOW_UNIT_INDICATOR = ConvertAbilityBooleanLevelField('Neu4')
-    // 技能布尔值等级域 向技能拥有者收费 ('Ans6')
+    // 技能随等级改变的布尔值域 向技能拥有者收费 ('Ans6')
 	constant abilitybooleanlevelfield ABILITY_BLF_CHARGE_OWNING_PLAYER = ConvertAbilityBooleanLevelField('Ans6')
-    // 技能布尔值等级域 按百分比回复 ('Arm2')
+    // 技能随等级改变的布尔值域 按百分比回复 ('Arm2')
 	constant abilitybooleanlevelfield ABILITY_BLF_PERCENTAGE_ARM2 = ConvertAbilityBooleanLevelField('Arm2')
-    // 技能布尔值等级域 目标无敌 ('Pos3')
+    // 技能随等级改变的布尔值域 目标无敌 ('Pos3')
 	constant abilitybooleanlevelfield ABILITY_BLF_TARGET_IS_INVULNERABLE = ConvertAbilityBooleanLevelField('Pos3')
-    // 技能布尔值等级域 目标魔法免疫 ('Pos4')
+    // 技能随等级改变的布尔值域 目标魔法免疫 ('Pos4')
 	constant abilitybooleanlevelfield ABILITY_BLF_TARGET_IS_MAGIC_IMMUNE = ConvertAbilityBooleanLevelField('Pos4')
-    // 技能布尔值等级域 施法者死亡时杀死召唤单位 ('Ucb6')
+    // 技能随等级改变的布尔值域 施法者死亡时杀死召唤单位 ('Ucb6')
 	constant abilitybooleanlevelfield ABILITY_BLF_KILL_ON_CASTER_DEATH = ConvertAbilityBooleanLevelField('Ucb6')
-    // 技能布尔值等级域 只能对自己施放 ('Rej4')
+    // 技能随等级改变的布尔值域 只能对自己施放 ('Rej4')
 	constant abilitybooleanlevelfield ABILITY_BLF_NO_TARGET_REQUIRED_REJ4 = ConvertAbilityBooleanLevelField('Rej4')
-    // 技能布尔值等级域 接受黄金 ('Rtn1')
+    // 技能随等级改变的布尔值域 接受黄金 ('Rtn1')
 	constant abilitybooleanlevelfield ABILITY_BLF_ACCEPTS_GOLD = ConvertAbilityBooleanLevelField('Rtn1')
-    // 技能布尔值等级域 接受木材 ('Rtn2')
+    // 技能随等级改变的布尔值域 接受木材 ('Rtn2')
 	constant abilitybooleanlevelfield ABILITY_BLF_ACCEPTS_LUMBER = ConvertAbilityBooleanLevelField('Rtn2')
-    // 技能布尔值等级域 影响敌方数量 ('Roa5')
+    // 技能随等级改变的布尔值域 影响敌方数量 ('Roa5')
 	constant abilitybooleanlevelfield ABILITY_BLF_PREFER_HOSTILES_ROA5 = ConvertAbilityBooleanLevelField('Roa5')
-    // 技能布尔值等级域 影响友方数量 ('Roa6')
+    // 技能随等级改变的布尔值域 影响友方数量 ('Roa6')
 	constant abilitybooleanlevelfield ABILITY_BLF_PREFER_FRIENDLIES_ROA6 = ConvertAbilityBooleanLevelField('Roa6')
-    // 技能布尔值等级域 扎根可转向 ('Roo3')
+    // 技能随等级改变的布尔值域 扎根可转向 ('Roo3')
 	constant abilitybooleanlevelfield ABILITY_BLF_ROOTED_TURNING = ConvertAbilityBooleanLevelField('Roo3')
-    // 技能布尔值等级域 总是自动施放 ('Slo3')
+    // 技能随等级改变的布尔值域 总是自动施放 ('Slo3')
 	constant abilitybooleanlevelfield ABILITY_BLF_ALWAYS_AUTOCAST_SLO3 = ConvertAbilityBooleanLevelField('Slo3')
-    // 技能布尔值等级域 隐藏按钮 ('Ihid')
+    // 技能随等级改变的布尔值域 隐藏按钮 ('Ihid')
 	constant abilitybooleanlevelfield ABILITY_BLF_HIDE_BUTTON = ConvertAbilityBooleanLevelField('Ihid')
-    // 技能布尔值等级域 传送单位聚集 ('Itp2')
+    // 技能随等级改变的布尔值域 传送单位聚集 ('Itp2')
 	constant abilitybooleanlevelfield ABILITY_BLF_USE_TELEPORT_CLUSTERING_ITP2 = ConvertAbilityBooleanLevelField('Itp2')
-    // 技能布尔值等级域 对变形效果免疫 ('Eth1')
+    // 技能随等级改变的布尔值域 对变形效果免疫 ('Eth1')
 	constant abilitybooleanlevelfield ABILITY_BLF_IMMUNE_TO_MORPH_EFFECTS = ConvertAbilityBooleanLevelField('Eth1')
-    // 技能布尔值等级域 不妨碍建造 ('Eth2')
+    // 技能随等级改变的布尔值域 不妨碍建造 ('Eth2')
 	constant abilitybooleanlevelfield ABILITY_BLF_DOES_NOT_BLOCK_BUILDINGS = ConvertAbilityBooleanLevelField('Eth2')
-    // 技能布尔值等级域 自动获取攻击目标 ('Gho1')
+    // 技能随等级改变的布尔值域 自动获取攻击目标 ('Gho1')
 	constant abilitybooleanlevelfield ABILITY_BLF_AUTO_ACQUIRE_ATTACK_TARGETS = ConvertAbilityBooleanLevelField('Gho1')
-    // 技能布尔值等级域 对变形效果免疫 ('Gho2')
+    // 技能随等级改变的布尔值域 对变形效果免疫 ('Gho2')
 	constant abilitybooleanlevelfield ABILITY_BLF_IMMUNE_TO_MORPH_EFFECTS_GHO2 = ConvertAbilityBooleanLevelField('Gho2')
-    // 技能布尔值等级域 不妨碍建造 ('Gho3')
+    // 技能随等级改变的布尔值域 不妨碍建造 ('Gho3')
 	constant abilitybooleanlevelfield ABILITY_BLF_DO_NOT_BLOCK_BUILDINGS = ConvertAbilityBooleanLevelField('Gho3')
-    // 技能布尔值等级域 远程伤害加成 ('Ssk4')
+    // 技能随等级改变的布尔值域 远程伤害加成 ('Ssk4')
 	constant abilitybooleanlevelfield ABILITY_BLF_INCLUDE_RANGED_DAMAGE = ConvertAbilityBooleanLevelField('Ssk4')
-    // 技能布尔值等级域 近战伤害加成 ('Ssk5')
+    // 技能随等级改变的布尔值域 近战伤害加成 ('Ssk5')
 	constant abilitybooleanlevelfield ABILITY_BLF_INCLUDE_MELEE_DAMAGE = ConvertAbilityBooleanLevelField('Ssk5')
-    // 技能布尔值等级域 向目标靠拢 ('coa2')
+    // 技能随等级改变的布尔值域 向目标靠拢 ('coa2')
 	constant abilitybooleanlevelfield ABILITY_BLF_MOVE_TO_PARTNER = ConvertAbilityBooleanLevelField('coa2')
-    // 技能布尔值等级域 可以被驱散 ('cyc1')
+    // 技能随等级改变的布尔值域 可以被驱散 ('cyc1')
 	constant abilitybooleanlevelfield ABILITY_BLF_CAN_BE_DISPELLED = ConvertAbilityBooleanLevelField('cyc1')
-    // 技能布尔值等级域 忽略友军的增益魔法效果 ('dvm6')
+    // 技能随等级改变的布尔值域 忽略友军的增益魔法效果 ('dvm6')
 	constant abilitybooleanlevelfield ABILITY_BLF_IGNORE_FRIENDLY_BUFFS = ConvertAbilityBooleanLevelField('dvm6')
-    // 技能布尔值等级域 死亡掉落物品 ('inv2')
+    // 技能随等级改变的布尔值域 死亡掉落物品 ('inv2')
 	constant abilitybooleanlevelfield ABILITY_BLF_DROP_ITEMS_ON_DEATH = ConvertAbilityBooleanLevelField('inv2')
-    // 技能布尔值等级域 可以使用物品 ('inv3')
+    // 技能随等级改变的布尔值域 可以使用物品 ('inv3')
 	constant abilitybooleanlevelfield ABILITY_BLF_CAN_USE_ITEMS = ConvertAbilityBooleanLevelField('inv3')
-    // 技能布尔值等级域 可以取得物品 ('inv4')
+    // 技能随等级改变的布尔值域 可以取得物品 ('inv4')
 	constant abilitybooleanlevelfield ABILITY_BLF_CAN_GET_ITEMS = ConvertAbilityBooleanLevelField('inv4')
-    // 技能布尔值等级域 可以丢弃物品 ('inv5')
+    // 技能随等级改变的布尔值域 可以丢弃物品 ('inv5')
 	constant abilitybooleanlevelfield ABILITY_BLF_CAN_DROP_ITEMS = ConvertAbilityBooleanLevelField('inv5')
-    // 技能布尔值等级域 修理允许 ('liq4')
+    // 技能随等级改变的布尔值域 修理允许 ('liq4')
 	constant abilitybooleanlevelfield ABILITY_BLF_REPAIRS_ALLOWED = ConvertAbilityBooleanLevelField('liq4')
-    // 技能布尔值等级域 仅溅射伤害有魔法单位 ('mfl6')
+    // 技能随等级改变的布尔值域 仅溅射伤害有魔法单位 ('mfl6')
 	constant abilitybooleanlevelfield ABILITY_BLF_CASTER_ONLY_SPLASH = ConvertAbilityBooleanLevelField('mfl6')
-    // 技能布尔值等级域 只对自己施放 ('irl4')
+    // 技能随等级改变的布尔值域 只对自己施放 ('irl4')
 	constant abilitybooleanlevelfield ABILITY_BLF_NO_TARGET_REQUIRED_IRL4 = ConvertAbilityBooleanLevelField('irl4')
-    // 技能布尔值等级域 被攻击时驱散效果 ('irl5')
+    // 技能随等级改变的布尔值域 被攻击时驱散效果 ('irl5')
 	constant abilitybooleanlevelfield ABILITY_BLF_DISPEL_ON_ATTACK = ConvertAbilityBooleanLevelField('irl5')
-    // 技能布尔值等级域 使用原始值 ('ipv3')
+    // 技能随等级改变的布尔值域 使用原始值 ('ipv3')
 	constant abilitybooleanlevelfield ABILITY_BLF_AMOUNT_IS_RAW_VALUE = ConvertAbilityBooleanLevelField('ipv3')
-    // 技能布尔值等级域 共享法术CD间隔 ('spb2')
+    // 技能随等级改变的布尔值域 共享法术CD间隔 ('spb2')
 	constant abilitybooleanlevelfield ABILITY_BLF_SHARED_SPELL_COOLDOWN = ConvertAbilityBooleanLevelField('spb2')
-    // 技能布尔值等级域 睡眠一次 ('sla1')
+    // 技能随等级改变的布尔值域 睡眠一次 ('sla1')
 	constant abilitybooleanlevelfield ABILITY_BLF_SLEEP_ONCE = ConvertAbilityBooleanLevelField('sla1')
-    // 技能布尔值等级域 允许任意玩家 ('sla2')
+    // 技能随等级改变的布尔值域 允许任意玩家 ('sla2')
 	constant abilitybooleanlevelfield ABILITY_BLF_ALLOW_ON_ANY_PLAYER_SLOT = ConvertAbilityBooleanLevelField('sla2')
-    // 技能布尔值等级域 使其他技能无效 ('Ncl5')
+    // 技能随等级改变的布尔值域 使其他技能无效 ('Ncl5')
 	constant abilitybooleanlevelfield ABILITY_BLF_DISABLE_OTHER_ABILITIES = ConvertAbilityBooleanLevelField('Ncl5')
-    // 技能布尔值等级域 附加杀敌奖励 ('Ntm4')
+    // 技能随等级改变的布尔值域 附加杀敌奖励 ('Ntm4')
 	constant abilitybooleanlevelfield ABILITY_BLF_ALLOW_BOUNTY = ConvertAbilityBooleanLevelField('Ntm4')
 	
-	// 技能字符串等级域 图标 - 普通 ('aart')
+	// 技能随等级改变的字串符域 图标 - 普通 ('aart')
 	constant abilitystringlevelfield ABILITY_SLF_ICON_NORMAL = ConvertAbilityStringLevelField('aart')
-	// 技能字符串等级域 效果 - 施法者 ('acat')
+	// 技能随等级改变的字串符域 效果 - 施法者 ('acat')
 	constant abilitystringlevelfield ABILITY_SLF_CASTER = ConvertAbilityStringLevelField('acat')
-	// 技能字符串等级域 效果 - 目标 ('atat')
+	// 技能随等级改变的字串符域 效果 - 目标 ('atat')
 	constant abilitystringlevelfield ABILITY_SLF_TARGET = ConvertAbilityStringLevelField('atat')
-	// 技能字符串等级域 效果 - 特殊 ('asat')
+	// 技能随等级改变的字串符域 效果 - 特殊 ('asat')
 	constant abilitystringlevelfield ABILITY_SLF_SPECIAL = ConvertAbilityStringLevelField('asat')
-	// 技能字符串等级域 效果 - 目标点 ('aeat')
+	// 技能随等级改变的字串符域 效果 - 目标点 ('aeat')
 	constant abilitystringlevelfield ABILITY_SLF_EFFECT = ConvertAbilityStringLevelField('aeat')
-	// 技能字符串等级域 效果 - 区域 ('aaea')
+	// 技能随等级改变的字串符域 效果 - 区域 ('aaea')
 	constant abilitystringlevelfield ABILITY_SLF_AREA_EFFECT = ConvertAbilityStringLevelField('aaea')
-	// 技能字符串等级域 效果 - 闪电效果 ('alig')
+	// 技能随等级改变的字串符域 效果 - 闪电效果 ('alig')
 	constant abilitystringlevelfield ABILITY_SLF_LIGHTNING_EFFECTS = ConvertAbilityStringLevelField('alig')
-	// 技能字符串等级域 效果 - 投射物图像 ('amat')
+	// 技能随等级改变的字串符域 效果 - 投射物图像 ('amat')
 	constant abilitystringlevelfield ABILITY_SLF_MISSILE_ART = ConvertAbilityStringLevelField('amat')
-	// 技能字符串等级域 提示工具 - 学习 ('aret')
+	// 技能随等级改变的字串符域 提示工具 - 学习 ('aret')
 	constant abilitystringlevelfield ABILITY_SLF_TOOLTIP_LEARN = ConvertAbilityStringLevelField('aret')
-	// 技能字符串等级域 提示工具 - 学习 - 扩展 ('arut')
+	// 技能随等级改变的字串符域 提示工具 - 学习 - 扩展 ('arut')
 	constant abilitystringlevelfield ABILITY_SLF_TOOLTIP_LEARN_EXTENDED = ConvertAbilityStringLevelField('arut')
-	// 技能字符串等级域 提示工具 - 普通 ('atp1')
+	// 技能随等级改变的字串符域 提示工具 - 普通 ('atp1')
 	constant abilitystringlevelfield ABILITY_SLF_TOOLTIP_NORMAL = ConvertAbilityStringLevelField('atp1')
-	// 技能字符串等级域 提示工具 - 关闭 ('aut1')
+	// 技能随等级改变的字串符域 提示工具 - 关闭 ('aut1')
 	constant abilitystringlevelfield ABILITY_SLF_TOOLTIP_TURN_OFF = ConvertAbilityStringLevelField('aut1')
-	// 技能字符串等级域 提示工具 - 普通 - 扩展 ('aub1')
+	// 技能随等级改变的字串符域 提示工具 - 普通 - 扩展 ('aub1')
 	constant abilitystringlevelfield ABILITY_SLF_TOOLTIP_NORMAL_EXTENDED = ConvertAbilityStringLevelField('aub1')
-	// 技能字符串等级域 提示工具 - 关闭 - 扩展 ('auu1')
+	// 技能随等级改变的字串符域 提示工具 - 关闭 - 扩展 ('auu1')
 	constant abilitystringlevelfield ABILITY_SLF_TOOLTIP_TURN_OFF_EXTENDED = ConvertAbilityStringLevelField('auu1')
-	// 技能字符串等级域 普通形态单位 ('Eme1')
+	// 技能随等级改变的字串符域 普通形态单位 ('Eme1')
 	constant abilitystringlevelfield ABILITY_SLF_NORMAL_FORM_UNIT_EME1 = ConvertAbilityStringLevelField('Eme1')
-	// 技能字符串等级域 召唤单位类型 ('Ndp1')
+	// 技能随等级改变的字串符域 召唤单位类型 ('Ndp1')
 	constant abilitystringlevelfield ABILITY_SLF_SPAWNED_UNITS = ConvertAbilityStringLevelField('Ndp1')
-	// 技能字符串等级域 关联技能 ('Nrc1')
+	// 技能随等级改变的字串符域 关联技能 ('Nrc1')
 	constant abilitystringlevelfield ABILITY_SLF_ABILITY_FOR_UNIT_CREATION = ConvertAbilityStringLevelField('Nrc1')
-	// 技能字符串等级域 普通形态单位 ('Mil1')
+	// 技能随等级改变的字串符域 普通形态单位 ('Mil1')
 	constant abilitystringlevelfield ABILITY_SLF_NORMAL_FORM_UNIT_MIL1 = ConvertAbilityStringLevelField('Mil1')
-	// 技能字符串等级域 变化形态单位 ('Mil2')
+	// 技能随等级改变的字串符域 变化形态单位 ('Mil2')
 	constant abilitystringlevelfield ABILITY_SLF_ALTERNATE_FORM_UNIT_MIL2 = ConvertAbilityStringLevelField('Mil2')
-	// 技能字符串等级域 基础命令ID ('Ans5')
+	// 技能随等级改变的字串符域 基础命令ID ('Ans5')
 	constant abilitystringlevelfield ABILITY_SLF_BASE_ORDER_ID_ANS5 = ConvertAbilityStringLevelField('Ans5')
-	// 技能字符串等级域 变形单位 - 地面 ('Ply2')
+	// 技能随等级改变的字串符域 变形单位 - 地面 ('Ply2')
 	constant abilitystringlevelfield ABILITY_SLF_MORPH_UNITS_GROUND = ConvertAbilityStringLevelField('Ply2')
-	// 技能字符串等级域 变形单位 - 空中 ('Ply3')
+	// 技能随等级改变的字串符域 变形单位 - 空中 ('Ply3')
 	constant abilitystringlevelfield ABILITY_SLF_MORPH_UNITS_AIR = ConvertAbilityStringLevelField('Ply3')
-	// 技能字符串等级域 变形单位 - 两栖 ('Ply4')
+	// 技能随等级改变的字串符域 变形单位 - 两栖 ('Ply4')
 	constant abilitystringlevelfield ABILITY_SLF_MORPH_UNITS_AMPHIBIOUS = ConvertAbilityStringLevelField('Ply4')
-	// 技能字符串等级域 变形单位 - 水中 ('Ply5')
+	// 技能随等级改变的字串符域 变形单位 - 水中 ('Ply5')
 	constant abilitystringlevelfield ABILITY_SLF_MORPH_UNITS_WATER = ConvertAbilityStringLevelField('Ply5')
-	// 技能字符串等级域 单位召唤类型1 ('Rai3')
+	// 技能随等级改变的字串符域 单位召唤类型1 ('Rai3')
 	constant abilitystringlevelfield ABILITY_SLF_UNIT_TYPE_ONE = ConvertAbilityStringLevelField('Rai3')
-	// 技能字符串等级域 单位召唤类型2 ('Rai4')
+	// 技能随等级改变的字串符域 单位召唤类型2 ('Rai4')
 	constant abilitystringlevelfield ABILITY_SLF_UNIT_TYPE_TWO = ConvertAbilityStringLevelField('Rai4')
-	// 技能字符串等级域 单位类型 ('Sod2')
+	// 技能随等级改变的字串符域 单位类型 ('Sod2')
 	constant abilitystringlevelfield ABILITY_SLF_UNIT_TYPE_SOD2 = ConvertAbilityStringLevelField('Sod2')
-	// 技能字符串等级域 召唤单位类型1 ('Ist1')
+	// 技能随等级改变的字串符域 召唤单位类型1 ('Ist1')
 	constant abilitystringlevelfield ABILITY_SLF_SUMMON_1_UNIT_TYPE = ConvertAbilityStringLevelField('Ist1')
-	// 技能字符串等级域 召唤单位类型2 ('Ist2')
+	// 技能随等级改变的字串符域 召唤单位类型2 ('Ist2')
 	constant abilitystringlevelfield ABILITY_SLF_SUMMON_2_UNIT_TYPE = ConvertAbilityStringLevelField('Ist2')
-	// 技能字符串等级域 允许转换种族 ('Ndc1')
+	// 技能随等级改变的字串符域 允许转换种族 ('Ndc1')
 	constant abilitystringlevelfield ABILITY_SLF_RACE_TO_CONVERT = ConvertAbilityStringLevelField('Ndc1')
-	// 技能字符串等级域 辅助单位类型 ('coa1')
+	// 技能随等级改变的字串符域 辅助单位类型 ('coa1')
 	constant abilitystringlevelfield ABILITY_SLF_PARTNER_UNIT_TYPE = ConvertAbilityStringLevelField('coa1')
-	// 技能字符串等级域 辅助单位类型1 ('dcp1')
+	// 技能随等级改变的字串符域 辅助单位类型1 ('dcp1')
 	constant abilitystringlevelfield ABILITY_SLF_PARTNER_UNIT_TYPE_ONE = ConvertAbilityStringLevelField('dcp1')
-	// 技能字符串等级域 辅助单位类型2 ('dcp2')
+	// 技能随等级改变的字串符域 辅助单位类型2 ('dcp2')
 	constant abilitystringlevelfield ABILITY_SLF_PARTNER_UNIT_TYPE_TWO = ConvertAbilityStringLevelField('dcp2')
-	// 技能字符串等级域 要求单位类型 ('tpi1')
+	// 技能随等级改变的字串符域 要求单位类型 ('tpi1')
 	constant abilitystringlevelfield ABILITY_SLF_REQUIRED_UNIT_TYPE = ConvertAbilityStringLevelField('tpi1')
-	// 技能字符串等级域 转换单位类型 ('tpi2')
+	// 技能随等级改变的字串符域 转换单位类型 ('tpi2')
 	constant abilitystringlevelfield ABILITY_SLF_CONVERTED_UNIT_TYPE = ConvertAbilityStringLevelField('tpi2')
-	// 技能字符串等级域 法术列表 ('spb1')
+	// 技能随等级改变的字串符域 法术列表 ('spb1')
 	constant abilitystringlevelfield ABILITY_SLF_SPELL_LIST = ConvertAbilityStringLevelField('spb1')
-	// 技能字符串等级域 基础命令ID ('spb5')
+	// 技能随等级改变的字串符域 基础命令ID ('spb5')
 	constant abilitystringlevelfield ABILITY_SLF_BASE_ORDER_ID_SPB5 = ConvertAbilityStringLevelField('spb5')
-	// 技能字符串等级域 基础命令ID ('spb6')
+	// 技能随等级改变的字串符域 基础命令ID ('spb6')
 	constant abilitystringlevelfield ABILITY_SLF_BASE_ORDER_ID_NCL6 = ConvertAbilityStringLevelField('Ncl6')
-	// 技能字符串等级域 技能升级1 ('Neg3')
+	// 技能随等级改变的字串符域 技能升级1 ('Neg3')
 	constant abilitystringlevelfield ABILITY_SLF_ABILITY_UPGRADE_1 = ConvertAbilityStringLevelField('Neg3')
-	// 技能字符串等级域 技能升级2 ('Neg4')
+	// 技能随等级改变的字串符域 技能升级2 ('Neg4')
 	constant abilitystringlevelfield ABILITY_SLF_ABILITY_UPGRADE_2 = ConvertAbilityStringLevelField('Neg4')
-	// 技能字符串等级域 技能升级3 ('Neg5')
+	// 技能随等级改变的字串符域 技能升级3 ('Neg5')
 	constant abilitystringlevelfield ABILITY_SLF_ABILITY_UPGRADE_3 = ConvertAbilityStringLevelField('Neg5')
-	// 技能字符串等级域 技能升级4 ('Neg6')
+	// 技能随等级改变的字串符域 技能升级4 ('Neg6')
 	constant abilitystringlevelfield ABILITY_SLF_ABILITY_UPGRADE_4 = ConvertAbilityStringLevelField('Neg6')
-	// 技能字符串等级域 生产单位ID ('Nsy2')
+	// 技能随等级改变的字串符域 生产单位ID ('Nsy2')
 	constant abilitystringlevelfield ABILITY_SLF_SPAWN_UNIT_ID_NSY2 = ConvertAbilityStringLevelField('Nsy2')
 	
 	// Item
@@ -4230,7 +4365,7 @@ native GetPlayers takes nothing returns integer
 native IsGameTypeSupported takes gametype whichGameType returns boolean
 // 游戏选择类型
 native GetGameTypeSelected takes nothing returns gametype
-// 地图参数
+// 查询地图参数状态（指定参数）
 native IsMapFlagSet takes mapflag whichMapFlag returns boolean
 // 获取障碍设置，怀疑是最大生命值百分比限制
 constant native GetGamePlacement takes nothing returns placement
@@ -4265,7 +4400,7 @@ native SetPlayerStartLocation takes player whichPlayer, integer startLocIndex re
 // use random placement for any unplaced players etc )
 // 势力玩家开始点
 native ForcePlayerStartLocation takes player whichPlayer, integer startLocIndex returns nothing
-// 改变玩家颜色 [R]
+// 设置玩家颜色 [R]
 native SetPlayerColor takes player whichPlayer, playercolor color returns nothing
 // 设置联盟类型(指定项目) [R]
 native SetPlayerAlliance takes player sourcePlayer, player otherPlayer, alliancetype whichAllianceSetting, boolean value returns nothing
@@ -4283,23 +4418,23 @@ native SetPlayerName takes player whichPlayer, string name returns nothing
 // 显示/隐藏计分屏显示 [R]
 native SetPlayerOnScoreScreen takes player whichPlayer, boolean flag returns nothing
 
-// 玩家在的队伍
+// 获取玩家队伍编号
 native GetPlayerTeam takes player whichPlayer returns integer
-// 玩家开始点
+// 获取玩家开始点
 native GetPlayerStartLocation takes player whichPlayer returns integer
-// 玩家的颜色
+// 获取玩家颜色
 native GetPlayerColor takes player whichPlayer returns playercolor
-// 玩家是否可选
+// 获取玩家是否可选
 native GetPlayerSelectable takes player whichPlayer returns boolean
-// 玩家控制者
+// 获取玩家控制者
 native GetPlayerController takes player whichPlayer returns mapcontrol
-// 玩家游戏属性
+// 获取玩家槽状态
 native GetPlayerSlotState takes player whichPlayer returns playerslotstate
-// 玩家税率 [R]
+// 获取玩家税率 [R]
 native GetPlayerTaxRate takes player sourcePlayer, player otherPlayer, playerstate whichResource returns integer
-// 玩家的种族选择
+// 判断玩家的种族
 native IsPlayerRacePrefSet takes player whichPlayer, racepreference pref returns boolean
-// 玩家名字
+// 获取玩家名字
 native GetPlayerName takes player whichPlayer returns string
 
 
@@ -4548,9 +4683,9 @@ constant native GetFilterUnit takes nothing returns unit
 // 获取选取的单位
 constant native GetEnumUnit takes nothing returns unit
 
-// 获取匹配的可毁坏物
+// 获取匹配的可破坏物
 constant native GetFilterDestructable takes nothing returns destructable
-// 获取选取的可毁坏物
+// 获取选取的可破坏物
 constant native GetEnumDestructable takes nothing returns destructable
 
 // 获取匹配的物品
@@ -4818,7 +4953,7 @@ constant native GetBuyingUnit takes nothing returns unit
 constant native GetSoldItem takes nothing returns item
 
 // EVENT_PLAYER_UNIT_CHANGE_OWNER
-// 获取改变了所有者的单位
+// 获取变更了所有者的单位
 constant native GetChangingUnit takes nothing returns unit
 // 获取前一个所有者
 constant native GetChangingUnitPrevOwner takes nothing returns player
@@ -4874,7 +5009,7 @@ constant native GetOrderPointLoc takes nothing returns location
 // EVENT_PLAYER_UNIT_ISSUED_TARGET_ORDER
 // 获取接受命令的单位
 constant native GetOrderTarget takes nothing returns widget
-// 获取命令目标可毁坏物
+// 获取命令目标可破坏物
 constant native GetOrderTargetDestructable takes nothing returns destructable
 // 获取命令目标物品
 constant native GetOrderTargetItem takes nothing returns item
@@ -4904,21 +5039,21 @@ constant native GetSpellTargetLoc takes nothing returns location
 constant native GetSpellTargetX takes nothing returns real
 // 获取被释放技能目标点 Y 坐标
 constant native GetSpellTargetY takes nothing returns real
-// 获取被释放技能目标可毁坏物
+// 获取被释放技能目标可破坏物
 constant native GetSpellTargetDestructable takes nothing returns destructable
 // 获取被释放技能目标物品
 constant native GetSpellTargetItem takes nothing returns item
 // 获取被释放技能目标单位
 constant native GetSpellTargetUnit takes nothing returns unit
 
-// 注册玩家联盟类型改变事件(特殊)
+// 注册玩家联盟类型变更事件(特殊)
 native TriggerRegisterPlayerAllianceChange takes trigger whichTrigger, player whichPlayer, alliancetype whichAlliance returns event
-// 注册玩家属性事件
+// 注册玩家状态事件
 native TriggerRegisterPlayerStateEvent takes trigger whichTrigger, player whichPlayer, playerstate whichState, limitop opcode, real limitval returns event
 
 // EVENT_PLAYER_STATE_LIMIT
 // EVENT_PLAYER_STATE_LIMIT
-// 获取玩家属性
+// 获取玩家状态
 constant native GetEventPlayerState takes nothing returns playerstate
 
 // 玩家输入聊天信息
@@ -5101,9 +5236,9 @@ native DestructableRestoreLife takes destructable d, real life, boolean birth re
 native QueueDestructableAnimation takes destructable d, string whichAnimation returns nothing
 // 设置可破坏物的动画
 native SetDestructableAnimation takes destructable d, string whichAnimation returns nothing
-// 改变可破坏物动画播放速度 [R]
+// 设置可破坏物动画播放速度 [R]
 native SetDestructableAnimationSpeed takes destructable d, real speedFactor returns nothing
-// 显示/隐藏可破坏物的[R]
+// 显示/隐藏 可破坏物[R]
 native ShowDestructable takes destructable d, boolean flag returns nothing
 // 获取可破坏物的闭塞高度
 native GetDestructableOccluderHeight takes destructable d returns real
@@ -5226,7 +5361,7 @@ native SetUnitFlyHeight takes unit whichUnit, real newHeight, real rate returns 
 native SetUnitTurnSpeed takes unit whichUnit, real newTurnSpeed returns nothing
 // 设置单位转向角度(弧度制) [R]
 native SetUnitPropWindow takes unit whichUnit, real newPropWindowAngle returns nothing
-// 设置感知敌人距离
+// 设置主动攻击范围
 native SetUnitAcquireRange takes unit whichUnit, real newAcquireRange returns nothing
 // 锁定指定单位的警戒点 [R]
 native SetUnitCreepGuard takes unit whichUnit, boolean creepGuard returns nothing
@@ -5249,18 +5384,18 @@ native GetUnitDefaultPropWindow takes unit whichUnit returns real
 // 飞行高度 (默认)
 native GetUnitDefaultFlyHeight takes unit whichUnit returns real
 
-// 改变单位所有者
+// 设置单位所有者
 native SetUnitOwner takes unit whichUnit, player whichPlayer, boolean changeColor returns nothing
-// 改变单位颜色
+// 设置单位颜色
 native SetUnitColor takes unit whichUnit, playercolor whichColor returns nothing
 
-// 改变单位尺寸(按倍数) [R]
+// 设置单位尺寸(按倍数) [R]
 native SetUnitScale takes unit whichUnit, real scaleX, real scaleY, real scaleZ returns nothing
-// 改变单位动画播放速度(按倍数) [R]
+// 设置单位动画播放速度(按倍数) [R]
 native SetUnitTimeScale takes unit whichUnit, real timeScale returns nothing
-// 改变单位混合时间
+// 设置单位混合时间
 native SetUnitBlendTime takes unit whichUnit, real blendTime returns nothing
-// 改变单位的颜色(RGB:0-255) [R]
+// 设置单位的颜色(RGB:0-255) [R]
 native SetUnitVertexColor takes unit whichUnit, integer red, integer green, integer blue, integer alpha returns nothing
 // 将单位动画加入队列
 native QueueUnitAnimation takes unit whichUnit, string whichAnimation returns nothing
@@ -5696,7 +5831,7 @@ constant native GetPlayerTypedUnitCount takes player whichPlayer, string unitNam
 // 获得玩家的建筑的数量
 // @param includeIncomplete是否仅包含已完成建造的建筑
 constant native GetPlayerStructureCount takes player whichPlayer, boolean includeIncomplete returns integer
-// 获取玩家属性
+// 获取玩家状态
 constant native GetPlayerState takes player whichPlayer, playerstate whichPlayerState returns integer
 // 获取玩家得分
 constant native GetPlayerScore takes player whichPlayer, playerscore whichPlayerScore returns integer
@@ -5735,13 +5870,14 @@ constant native GetPlayerTechCount takes player whichPlayer, integer techid, boo
 
 // 设置单位所属玩家
 native SetPlayerUnitsOwner takes player whichPlayer, integer newOwner returns nothing
-// 削弱玩家
+// 暴露玩家位置（出生点）
+// 默认用于对战模式胜负判定规则
 native CripplePlayer takes player whichPlayer, force toWhichPlayers, boolean flag returns nothing
 
 // 允许/禁用 技能 [R]
 native SetPlayerAbilityAvailable takes player whichPlayer, integer abilid, boolean avail returns nothing
 
-// 设置玩家属性
+// 设置玩家状态
 native SetPlayerState takes player whichPlayer, playerstate whichPlayerState, integer value returns nothing
 // 踢除玩家
 native RemovePlayer takes player whichPlayer, playergameresult gameResult returns nothing
@@ -5753,11 +5889,11 @@ native CachePlayerHeroData takes player whichPlayer returns nothing
 
 
 // Fog of War API
-// 设置地图迷雾(矩形区域) [R]
+// 设置迷雾状态(矩形区域) [R]
 native SetFogStateRect takes player forWhichPlayer, fogstate whichState, rect where, boolean useSharedVision returns nothing
-// 设置地图迷雾(圆范围) （指定坐标）[R]
+// 设置迷雾状态(圆形区域) （指定坐标）[R]
 native SetFogStateRadius takes player forWhichPlayer, fogstate whichState, real centerx, real centerY, real radius, boolean useSharedVision returns nothing
-// 设置地图迷雾(圆范围)（指定点） [R]
+// 设置迷雾状态(圆形区域)（指定点） [R]
 native SetFogStateRadiusLoc takes player forWhichPlayer, fogstate whichState, location center, real radius, boolean useSharedVision returns nothing
 // 启用/禁用黑色阴影 [R]
 native FogMaskEnable takes boolean enable returns nothing
@@ -5770,9 +5906,9 @@ native IsFogEnabled takes nothing returns boolean
 
 // 新建可见度修正器(矩形区域) [R]
 native CreateFogModifierRect takes player forWhichPlayer, fogstate whichState, rect where, boolean useSharedVision, boolean afterUnits returns fogmodifier
-// 新建可见度修正器(圆范围) [R]
+// 新建可见度修正器(圆形区域) [R]
 native CreateFogModifierRadius takes player forWhichPlayer, fogstate whichState, real centerx, real centerY, real radius, boolean useSharedVision, boolean afterUnits returns fogmodifier
-// 新建可见度修正器(圆范围) [R]
+// 新建可见度修正器(圆形区域) [R]
 native CreateFogModifierRadiusLoc takes player forWhichPlayer, fogstate whichState, location center, real radius, boolean useSharedVision, boolean afterUnits returns fogmodifier
 // 删除可见度修正器
 native DestroyFogModifier takes fogmodifier whichFogModifier returns nothing
@@ -5829,13 +5965,13 @@ native SetMaxCheckpointSaves takes integer maxCheckpointSaves returns nothing
 native SaveGameCheckpoint takes string saveFileName, boolean showWindow returns nothing
 // 同步选择
 native SyncSelections takes nothing returns nothing
-// 为游戏状态设置一个浮点值
+// 设置游戏浮动值（指定浮动游戏状态）
 native SetFloatGameState takes fgamestate whichFloatGameState, real value returns nothing
-// 获取游戏状态浮点值
+// 获取游戏浮动值（指定浮动游戏状态）
 constant native GetFloatGameState takes fgamestate whichFloatGameState returns real
-// 为游戏状态设置一个整数
+// 设置游戏整数（指定整数游戏状态）
 native SetIntegerGameState takes igamestate whichIntegerGameState, integer value returns nothing
-// 获取游戏状态整数
+// 获取游戏整数（指定整数游戏状态）
 constant native GetIntegerGameState takes igamestate whichIntegerGameState returns integer
 
 
@@ -6004,7 +6140,7 @@ native SaveItemPoolHandle takes hashtable table, integer parentKey, integer chil
 native SaveQuestHandle takes hashtable table, integer parentKey, integer childKey, quest whichQuest returns boolean
 // <1.24> 保存任务要求 [C]
 native SaveQuestItemHandle takes hashtable table, integer parentKey, integer childKey, questitem whichQuestitem returns boolean
-// <1.24> 保存失败条件 [C]
+// <1.24> 保存任务失败条件 [C]
 native SaveDefeatConditionHandle takes hashtable table, integer parentKey, integer childKey, defeatcondition whichDefeatcondition returns boolean
 // <1.24> 保存计时器窗口 [C]
 native SaveTimerDialogHandle takes hashtable table, integer parentKey, integer childKey, timerdialog whichTimerdialog returns boolean
@@ -6095,7 +6231,7 @@ native LoadItemPoolHandle takes hashtable table, integer parentKey, integer chil
 native LoadQuestHandle takes hashtable table, integer parentKey, integer childKey returns quest
 // <1.24> 从哈希表提取任务要求 [C]
 native LoadQuestItemHandle takes hashtable table, integer parentKey, integer childKey returns questitem
-// <1.24> 从哈希表提取失败条件 [C]
+// <1.24> 从哈希表提取任务失败条件 [C]
 native LoadDefeatConditionHandle	takes hashtable table, integer parentKey, integer childKey returns defeatcondition
 // <1.24> 从哈希表提取计时器窗口 [C]
 native LoadTimerDialogHandle takes hashtable table, integer parentKey, integer childKey returns timerdialog
@@ -6243,9 +6379,9 @@ native PauseGame takes boolean flag returns nothing
 native UnitAddIndicator takes unit whichUnit, integer red, integer green, integer blue, integer alpha returns nothing
 // 添加闪动指示器(指定目标)
 native AddIndicator takes widget whichWidget, integer red, integer green, integer blue, integer alpha returns nothing
-// 小地图信号(所有玩家) [R]
+// 发送小地图信号(对所有玩家发送) [R]
 native PingMinimap takes real x, real y, real duration returns nothing
-// 小地图信号(指定颜色)(所有玩家) [R]
+// 发送小地图信号(指定颜色)(对所有玩家发送) [R]
 native PingMinimapEx takes real x, real y, real duration, integer red, integer green, integer blue, boolean extraEffects returns nothing
 // 创建小地图特殊图标（指定单位）
 native CreateMinimapIconOnUnit takes unit whichUnit, integer red, integer green, integer blue, string pingPath, fogstate fogVisibility returns minimapicon
@@ -6279,7 +6415,7 @@ native ForceUIKey takes string key returns nothing
 native ForceUICancel takes nothing returns nothing
 // 显示加载对话框
 native DisplayLoadDialog takes nothing returns nothing
-// 改变小地图的特殊图标
+// 设置小地图的特殊图标
 native SetAltMinimapIcon takes string iconPath returns nothing
 // 禁用 重新开始任务按钮
 native DisableRestartMission takes boolean flag returns nothing
@@ -6288,13 +6424,13 @@ native DisableRestartMission takes boolean flag returns nothing
 native CreateTextTag takes nothing returns texttag
 // 摧毁漂浮文字 [R]
 native DestroyTextTag takes texttag t returns nothing
-// 改变漂浮文字内容 [R]
+// 设置漂浮文字内容 [R]
 native SetTextTagText takes texttag t, string s, real height returns nothing
-// 改变漂浮文字位置(指定坐标) [R]
+// 设置漂浮文字位置(指定坐标) [R]
 native SetTextTagPos takes texttag t, real x, real y, real heightOffset returns nothing
-// 改变漂浮文字位置(指定坐标) [R]
+// 设置漂浮文字位置(指定坐标) [R]
 native SetTextTagPosUnit takes texttag t, unit whichUnit, real heightOffset returns nothing
-// 改变漂浮文字颜色 [R]
+// 设置漂浮文字颜色 [R]
 native SetTextTagColor takes texttag t, integer red, integer green, integer blue, integer alpha returns nothing
 // 设置漂浮文字速率 [R]
 native SetTextTagVelocity takes texttag t, real xvel, real yvel returns nothing
@@ -6313,9 +6449,9 @@ native SetTextTagFadepoint takes texttag t, real fadepoint returns nothing
 
 // 保留英雄按钮（左上角英雄图标，F1~FN）
 native SetReservedLocalHeroButtons takes integer reserved returns nothing
-// 结盟滤色镜的设置值
+// 联盟滤色镜的设置值
 native GetAllyColorFilterState takes nothing returns integer
-// 设置结盟滤色镜
+// 设置联盟滤色镜
 native SetAllyColorFilterState takes integer state returns nothing
 // 野生单位显示是开启的
 native GetCreepCampFilterState takes nothing returns boolean
@@ -6377,11 +6513,11 @@ native QuestItemSetCompleted takes questitem whichQuestItem, boolean completed r
 // 查询任务要求是否已完成
 native IsQuestItemCompleted takes questitem whichQuestItem returns boolean
 
-// 创建失败条件
+// 创建任务失败条件
 native CreateDefeatCondition takes nothing returns defeatcondition
-// 销毁失败条件
+// 销毁任务失败条件
 native DestroyDefeatCondition takes defeatcondition whichCondition returns nothing
-// 失败条件描述
+// 任务失败条件描述
 native DefeatConditionSetDescription takes defeatcondition whichCondition, string description returns nothing
 // 闪动任务按钮
 native FlashQuestDialogButton takes nothing returns nothing
@@ -6396,9 +6532,9 @@ native CreateTimerDialog takes timer t returns timerdialog
 native DestroyTimerDialog takes timerdialog whichDialog returns nothing
 // 设置计时器窗口标题
 native TimerDialogSetTitle takes timerdialog whichDialog, string title returns nothing
-// 改变计时器窗口文字颜色 [R]
+// 设置计时器窗口文字颜色 [R]
 native TimerDialogSetTitleColor takes timerdialog whichDialog, integer red, integer green, integer blue, integer alpha returns nothing
-// 改变计时器窗口计时颜色 [R]
+// 设置计时器窗口计时颜色 [R]
 native TimerDialogSetTimeColor takes timerdialog whichDialog, integer red, integer green, integer blue, integer alpha returns nothing
 // 设置计时器窗口速率 [R]
 native TimerDialogSetSpeed takes timerdialog whichDialog, real speedMultFactor returns nothing
@@ -6625,15 +6761,15 @@ native CameraSetDepthOfFieldScale takes real scale returns nothing
 native SetCineFilterTexture takes string filename returns nothing
 // 设置滤镜混合模式
 native SetCineFilterBlendMode takes blendmode whichMode returns nothing
-// 设置滤镜文本地图参数
+// 设置滤镜纹理贴图标志
 native SetCineFilterTexMapFlags takes texmapflags whichFlags returns nothing
 // 设置滤镜初始紫外线滤光镜
 native SetCineFilterStartUV takes real minu, real minv, real maxu, real maxv returns nothing
-// 设置滤镜停止紫外线滤光镜
+// 设置滤镜结束紫外线滤光镜
 native SetCineFilterEndUV takes real minu, real minv, real maxu, real maxv returns nothing
 // 设置滤镜初始颜色
 native SetCineFilterStartColor takes integer red, integer green, integer blue, integer alpha returns nothing
-// 设置滤镜停止颜色
+// 设置滤镜结束颜色
 native SetCineFilterEndColor takes integer red, integer green, integer blue, integer alpha returns nothing
 // 设置滤镜持续时长
 native SetCineFilterDuration takes real duration returns nothing
@@ -6887,11 +7023,11 @@ native SetWaterDeforms takes boolean val returns nothing
 native GetTerrainType takes real x, real y returns integer
 // 地形样式(指定坐标) [R]
 native GetTerrainVariance takes real x, real y returns integer
-// 改变地形类型(指定坐标) [R]
+// 设置地形类型(指定坐标) [R]
 native SetTerrainType takes real x, real y, integer terrainType, integer variation, integer area, integer shape returns nothing
-// 地形通行状态关闭(指定坐标) [R]
+// 路径类型状态是否关闭(指定坐标) [R]
 native IsTerrainPathable takes real x, real y, pathingtype t returns boolean
-// 设置地形通行状态(指定坐标) [R]
+// 设置路径类型状态(指定坐标) [R]
 native SetTerrainPathable takes real x, real y, pathingtype t, boolean flag returns nothing
 
 
@@ -6903,19 +7039,19 @@ native CreateImage takes string file, real sizeX, real sizeY, real sizeZ, real p
 native DestroyImage takes image whichImage returns nothing
 // 显示/隐藏 [R]
 native ShowImage takes image whichImage, boolean flag returns nothing
-// 改变图像高度
+// 设置图像高度
 native SetImageConstantHeight takes image whichImage, boolean flag, real height returns nothing
-// 改变图像位置(指定坐标) [R]
+// 设置图像位置(指定坐标) [R]
 native SetImagePosition takes image whichImage, real x, real y, real z returns nothing
-// 改变图像颜色 [R]
+// 设置图像颜色 [R]
 native SetImageColor takes image whichImage, integer red, integer green, integer blue, integer alpha returns nothing
-// 改变图像着色状态
+// 设置图像着色状态
 native SetImageRender takes image whichImage, boolean flag returns nothing
-// 改变图像永久着色状态
+// 设置图像永久着色状态
 native SetImageRenderAlways takes image whichImage, boolean flag returns nothing
-// 改变图像水上状态
+// 设置图像水上状态
 native SetImageAboveWater takes image whichImage, boolean flag, boolean useWaterAlpha returns nothing
-// 改变图像类型
+// 设置图像类型
 native SetImageType takes image whichImage, integer imageType returns nothing
 
 
@@ -6931,21 +7067,21 @@ native ResetUbersplat takes ubersplat whichSplat returns nothing
 native FinishUbersplat takes ubersplat whichSplat returns nothing
 // 显示/隐藏 地面纹理变化[R]
 native ShowUbersplat takes ubersplat whichSplat, boolean flag returns nothing
-// 改变地面纹理着色状态
+// 设置地面纹理着色状态
 native SetUbersplatRender takes ubersplat whichSplat, boolean flag returns nothing
-// 改变地面纹理永久着色状态
+// 设置地面纹理永久着色状态
 native SetUbersplatRenderAlways takes ubersplat whichSplat, boolean flag returns nothing
 
 
 // Blight API
 //
-// 创建/删除荒芜地表（不死族）(圆范围)(指定坐标) [R]
+// 创建/删除荒芜地表（不死族）(圆形区域)(指定坐标) [R]
 native SetBlight takes player whichPlayer, real x, real y, real radius, boolean addBlight returns nothing
 // 创建/删除荒芜地表（不死族）(矩形区域) [R]
 native SetBlightRect takes player whichPlayer, rect r, boolean addBlight returns nothing
 // 设置荒芜地表（不死族）（指定坐标）
 native SetBlightPoint takes player whichPlayer, real x, real y, boolean addBlight returns nothing
-// 设置荒芜地表（不死族）（圆范围）（指定点）
+// 设置荒芜地表（不死族）（圆形区域）（指定点）
 native SetBlightLoc takes player whichPlayer, location whichLocation, real radius, boolean addBlight returns nothing
 // 新建不死族金矿 [R]
 native CreateBlightedGoldmine takes player id, real x, real y, real face returns unit
@@ -6955,7 +7091,7 @@ native IsPointBlighted takes real x, real y returns boolean
 
 // Doodad API
 //
-// 播放圆范围内地形装饰物动画 [R]
+// 播放圆形区域内地形装饰物动画 [R]
 native SetDoodadAnimation takes real x, real y, real radius, integer doodadID, boolean nearestOnly, string animName, boolean animRandom returns nothing
 // 播放矩形区域内地形装饰物动画 [R]
 native SetDoodadAnimationRect takes rect r, integer doodadID, string animName, boolean animRandom returns nothing
@@ -7389,13 +7525,13 @@ native BlzFrameGetChildrenCount takes framehandle frame returns integer
 native BlzFrameGetChild takes framehandle frame, integer index returns framehandle
 
 
-// 注册Frame事件
+// 注册框架（UI）事件
 native BlzTriggerRegisterFrameEvent takes trigger whichTrigger, framehandle frame, frameeventtype eventId returns event
-// 获取触发的Frame
+// 获取框架（UI）触发事件
 native BlzGetTriggerFrame takes nothing returns framehandle
-// 获取frame触发的事件类型
+// 获取frame/框架（UI）事件类型
 native BlzGetTriggerFrameEvent takes nothing returns frameeventtype
-// 获取触发的Frame值
+// 获取框架（UI）触发事件的值
 native BlzGetTriggerFrameValue takes nothing returns real
 // 获取触发的Frame文本
 native BlzGetTriggerFrameText takes nothing returns string
@@ -7488,13 +7624,13 @@ native BlzGetAbilityIntegerLevelField takes ability whichAbility, abilityinteger
 native BlzGetAbilityRealLevelField takes ability whichAbility, abilityreallevelfield whichField, integer level returns real
 // 获取技能随等级改变的字符串域
 native BlzGetAbilityStringLevelField takes ability whichAbility, abilitystringlevelfield whichField, integer level returns string
-// 获取技能随等级改变的数组布尔值域
+// 获取技能随等级改变的布尔值数组域
 native BlzGetAbilityBooleanLevelArrayField takes ability whichAbility, abilitybooleanlevelarrayfield whichField, integer level, integer index returns boolean
-// 获取技能随等级改变的数组整数域
+// 获取技能随等级改变的整数数组域
 native BlzGetAbilityIntegerLevelArrayField takes ability whichAbility, abilityintegerlevelarrayfield whichField, integer level, integer index returns integer
-// 获取技能随等级改变的数组实数域
+// 获取技能随等级改变的实数数组域
 native BlzGetAbilityRealLevelArrayField takes ability whichAbility, abilityreallevelarrayfield whichField, integer level, integer index returns real
-// 获取技能随等级改变的数组字符串域
+// 获取技能随等级改变的字符串数组域
 native BlzGetAbilityStringLevelArrayField takes ability whichAbility, abilitystringlevelarrayfield whichField, integer level, integer index returns string
 // 设置技能的布尔值域
 native BlzSetAbilityBooleanField takes ability whichAbility, abilitybooleanfield whichField, boolean value returns boolean
@@ -7512,34 +7648,34 @@ native BlzSetAbilityIntegerLevelField takes ability whichAbility, abilityinteger
 native BlzSetAbilityRealLevelField takes ability whichAbility, abilityreallevelfield whichField, integer level, real value returns boolean
 // 设置技能随等级改变的字符串域
 native BlzSetAbilityStringLevelField takes ability whichAbility, abilitystringlevelfield whichField, integer level, string value returns boolean
-// 设置技能随等级改变的数组布尔值域
+// 设置技能随等级改变的布尔值数组域
 native BlzSetAbilityBooleanLevelArrayField takes ability whichAbility, abilitybooleanlevelarrayfield whichField, integer level, integer index, boolean value returns boolean
-// 设置技能随等级改变的数组整数域
+// 设置技能随等级改变的整数数组域
 native BlzSetAbilityIntegerLevelArrayField takes ability whichAbility, abilityintegerlevelarrayfield whichField, integer level, integer index, integer value returns boolean
-// 设置技能随等级改变的数组实数域
+// 设置技能随等级改变的实数数组域
 native BlzSetAbilityRealLevelArrayField takes ability whichAbility, abilityreallevelarrayfield whichField, integer level, integer index, real value returns boolean
-// 设置技能随等级改变的数组字符串域
+// 设置技能随等级改变的字符串数组域
 native BlzSetAbilityStringLevelArrayField takes ability whichAbility, abilitystringlevelarrayfield whichField, integer level, integer index, string value returns boolean
-// 添加技能随等级改变的数组布尔值域
+// 添加技能随等级改变的布尔值数组域
 native BlzAddAbilityBooleanLevelArrayField takes ability whichAbility, abilitybooleanlevelarrayfield whichField, integer level, boolean value returns boolean
-// 添加技能随等级改变的数组整数域
+// 添加技能随等级改变的整数数组域
 native BlzAddAbilityIntegerLevelArrayField takes ability whichAbility, abilityintegerlevelarrayfield whichField, integer level, integer value returns boolean
-// 添加技能随等级改变的数组实数域
+// 添加技能随等级改变的实数数组域
 native BlzAddAbilityRealLevelArrayField takes ability whichAbility, abilityreallevelarrayfield whichField, integer level, real value returns boolean
-// 添加技能随等级改变的数组字符串域
+// 添加技能随等级改变的字符串数组域
 native BlzAddAbilityStringLevelArrayField takes ability whichAbility, abilitystringlevelarrayfield whichField, integer level, string value returns boolean
-// 移除技能随等级改变的数组布尔值域
+// 移除技能随等级改变的布尔值数组域
 native BlzRemoveAbilityBooleanLevelArrayField takes ability whichAbility, abilitybooleanlevelarrayfield whichField, integer level, boolean value returns boolean
-// 移除技能随等级改变的数组整数域
+// 移除技能随等级改变的整数数组域
 native BlzRemoveAbilityIntegerLevelArrayField takes ability whichAbility, abilityintegerlevelarrayfield whichField, integer level, integer value returns boolean
-// 移除技能随等级改变的数组实数域
+// 移除技能随等级改变的实数数组域
 native BlzRemoveAbilityRealLevelArrayField takes ability whichAbility, abilityreallevelarrayfield whichField, integer level, real value returns boolean
-// 移除技能随等级改变的数组字符串域
+// 移除技能随等级改变的字符串数组域
 native BlzRemoveAbilityStringLevelArrayField takes ability whichAbility, abilitystringlevelarrayfield whichField, integer level, string value returns boolean
 
 // Item 
 // 获取物品技能
-// @param 引索为 0-5
+// @param index 引索为 0-5
 native BlzGetItemAbilityByIndex takes item whichItem, integer index returns ability
 // 获取物品技能
 native BlzGetItemAbility takes item whichItem, integer abilCode returns ability
@@ -7547,21 +7683,21 @@ native BlzGetItemAbility takes item whichItem, integer abilCode returns ability
 native BlzItemAddAbility takes item whichItem, integer abilCode returns boolean
 // 物品的布尔值域
 native BlzGetItemBooleanField takes item whichItem, itembooleanfield whichField returns boolean
-// 获取物品的整数域
+// 获取物品整数域
 native BlzGetItemIntegerField takes item whichItem, itemintegerfield whichField returns integer
-// 物品的实数域
+// 获取物品实数域
 native BlzGetItemRealField takes item whichItem, itemrealfield whichField returns real
 // 获取物品字符串域
 native BlzGetItemStringField takes item whichItem, itemstringfield whichField returns string
-// 改变物品的布尔值域
+// 设置物品布尔值域
 native BlzSetItemBooleanField takes item whichItem, itembooleanfield whichField, boolean value returns boolean
-// 改变物品的整数域
+// 设置物品整数域
 native BlzSetItemIntegerField takes item whichItem, itemintegerfield whichField, integer value returns boolean
-// 改变物品的实数域
+// 设置物品实数域
 native BlzSetItemRealField takes item whichItem, itemrealfield whichField, real value returns boolean
-// 改变物品的字符串域
+// 设置物品字符串域
 native BlzSetItemStringField takes item whichItem, itemstringfield whichField, string value returns boolean
-// 物品移除技能
+// 移除物品技能
 native BlzItemRemoveAbility takes item whichItem, integer abilCode returns boolean
 
 // Unit 
@@ -7573,13 +7709,13 @@ native BlzGetUnitIntegerField takes unit whichUnit, unitintegerfield whichField 
 native BlzGetUnitRealField takes unit whichUnit, unitrealfield whichField returns real
 // 获取单位字符串域
 native BlzGetUnitStringField takes unit whichUnit, unitstringfield whichField returns string
-// 改变单位的布尔值域
+// 设置单位布尔值域
 native BlzSetUnitBooleanField takes unit whichUnit, unitbooleanfield whichField, boolean value returns boolean
-// 改变单位的整数域
+// 设置单位整数域
 native BlzSetUnitIntegerField takes unit whichUnit, unitintegerfield whichField, integer value returns boolean
-// 改变单位的实数域
+// 设置单位实数域
 native BlzSetUnitRealField takes unit whichUnit, unitrealfield whichField, real value returns boolean
-// 改变单位的字符串域
+// 设置单位字符串域
 native BlzSetUnitStringField takes unit whichUnit, unitstringfield whichField, string value returns boolean
 
 // Unit Weapon
@@ -7591,27 +7727,27 @@ native BlzGetUnitWeaponIntegerField takes unit whichUnit, unitweaponintegerfield
 native BlzGetUnitWeaponRealField takes unit whichUnit, unitweaponrealfield whichField, integer index returns real
 // 获取单位武器字符串域
 native BlzGetUnitWeaponStringField takes unit whichUnit, unitweaponstringfield whichField, integer index returns string
-// 改变单位武器布尔值域
+// 设置单位武器布尔值域
 native BlzSetUnitWeaponBooleanField takes unit whichUnit, unitweaponbooleanfield whichField, integer index, boolean value returns boolean
-// 改变单位武器整数域
+// 设置单位武器整数域
 native BlzSetUnitWeaponIntegerField takes unit whichUnit, unitweaponintegerfield whichField, integer index, integer value returns boolean
-// 改变单位武器实数域
+// 设置单位武器实数域
 native BlzSetUnitWeaponRealField takes unit whichUnit, unitweaponrealfield whichField, integer index, real value returns boolean
-// 改变单位武器字符串域
+// 设置单位武器字符串域
 native BlzSetUnitWeaponStringField takes unit whichUnit, unitweaponstringfield whichField, integer index, string value returns boolean
 
 // Skin
 // 获取单位皮肤
 native BlzGetUnitSkin takes unit whichUnit returns integer
-// 改变物品皮肤
+// 设置物品皮肤
 native BlzGetItemSkin takes item whichItem returns integer
 // 获取可破坏物皮肤
 // native BlzGetDestructableSkin                         takes destructable whichDestructable returns integer
-// 改变单位皮肤
+// 设置单位皮肤
 native BlzSetUnitSkin takes unit whichUnit, integer skinId returns nothing
-// 改变物品皮肤
+// 设置物品皮肤
 native BlzSetItemSkin takes item whichItem, integer skinId returns nothing
-// 改变可破坏物皮肤
+// 设置可破坏物皮肤
 // native BlzSetDestructableSkin                         takes destructable whichDestructable, integer skinId returns nothing
 // 创建物品皮肤
 native BlzCreateItemWithSkin takes integer itemid, real x, real y, integer skinId returns item

--- a/static/common.j
+++ b/static/common.j
@@ -5435,7 +5435,7 @@ constant native IsUnitInForce takes unit whichUnit, force whichForce returns boo
 constant native IsUnitOwnedByPlayer takes unit whichUnit, player whichPlayer returns boolean
 // 指定单位的所属玩家是AI的盟友
 constant native IsUnitAlly takes unit whichUnit, player whichPlayer returns boolean
-// 指定单位的所属玩家是AI敌人
+// 指定单位的所属玩家是AI的敌人
 constant native IsUnitEnemy takes unit whichUnit, player whichPlayer returns boolean
 // 指定单位对于玩家可见
 constant native IsUnitVisible takes unit whichUnit, player whichPlayer returns boolean
@@ -5642,7 +5642,7 @@ native SetUnitUserData takes unit whichUnit, integer data returns nothing
 
 // Player API
 // 根据ID查询玩家
-// @param number
+// @param number玩家ID
 constant native Player takes integer number returns player
 // 本地玩家 [R]
 // 通常用于异步判断
@@ -5668,38 +5668,43 @@ constant native IsMaskedToPlayer takes real x, real y, player whichPlayer return
 // 点被黑色阴影遮挡
 constant native IsLocationMaskedToPlayer takes location whichLocation, player whichPlayer returns boolean
 
-// 玩家的种族
+// 查询玩家的种族
 constant native GetPlayerRace takes player whichPlayer returns race
-// 玩家ID - 1 [R]
+// 查询玩家ID [R]
 constant native GetPlayerId takes player whichPlayer returns integer
-// 单位数量
+// 获取玩家指定单位类型的数量
+// @param includeIncomplete是否仅包含已完成训练/建造/研究的单位/建筑/科技
 constant native GetPlayerUnitCount takes player whichPlayer, boolean includeIncomplete returns integer
-// 获取玩家特定单位数
+// 获取玩家指定单位类型的数量
+// @param includeIncomplete是否仅包含已完成训练/建造的单位/建筑
+// @param includeUpgrades是否仅包含已完成研究的科技
 constant native GetPlayerTypedUnitCount takes player whichPlayer, string unitName, boolean includeIncomplete, boolean includeUpgrades returns integer
-// 获得建筑数量
+// 获得玩家的建筑的数量
+// @param includeIncomplete是否仅包含已完成建造的建筑
 constant native GetPlayerStructureCount takes player whichPlayer, boolean includeIncomplete returns integer
-// 获得玩家属性
+// 获取玩家属性
 constant native GetPlayerState takes player whichPlayer, playerstate whichPlayerState returns integer
-// 获得玩家得分
+// 获取玩家得分
 constant native GetPlayerScore takes player whichPlayer, playerscore whichPlayerScore returns integer
-// 玩家与玩家结盟
+// 玩家与玩家的联盟状态是否是指定状态
+// @param whichAllianceSetting指定联盟状态
 constant native GetPlayerAlliance takes player sourcePlayer, player otherPlayer, alliancetype whichAllianceSetting returns boolean
 
-// 经验上限 [R]
+// 获取玩家经验上限 [R]
 constant native GetPlayerHandicap takes player whichPlayer returns real
-// 经验获得率 [R]
+// 获取玩家经验获得率 [R]
 constant native GetPlayerHandicapXP takes player whichPlayer returns real
 // 玩家障碍恢复时间
 constant native GetPlayerHandicapReviveTime takes player whichPlayer returns real
-// 玩家遭受残疾伤害
+// 获取玩家损伤
 constant native GetPlayerHandicapDamage takes player whichPlayer returns real
-// 设置经验上限 [R]
+// 设置玩家经验上限 [R]
 constant native SetPlayerHandicap takes player whichPlayer, real handicap returns nothing
-// 设置经验获得率 [R]
+// 设置玩家经验获得率 [R]
 constant native SetPlayerHandicapXP takes player whichPlayer, real handicap returns nothing
 // 设置玩家障碍恢复时间
 constant native SetPlayerHandicapReviveTime takes player whichPlayer, real handicap returns nothing
-// 设置玩家残障伤害
+// 设置玩家损伤
 constant native SetPlayerHandicapDamage takes player whichPlayer, real handicap returns nothing
 // 设置玩家的科技上限
 constant native SetPlayerTechMaxAllowed takes player whichPlayer, integer techid, integer maximum returns nothing

--- a/static/common.j
+++ b/static/common.j
@@ -233,7 +233,7 @@ constant native ConvertMouseButtonType takes integer i returns mousebuttontype
 constant native ConvertAnimType takes integer i returns animtype
 // 转换子动画类型
 constant native ConvertSubAnimType takes integer i returns subanimtype
-// 转换原点框架类型
+// 转换原生框架（原生UI）类型
 constant native ConvertOriginFrameType takes integer i returns originframetype
 // 转换frame点（框架）类型
 constant native ConvertFramePointType takes integer i returns framepointtype
@@ -247,7 +247,7 @@ constant native ConvertOsKeyType takes integer i returns oskeytype
 constant native ConvertAbilityIntegerField takes integer i returns abilityintegerfield
 // 转换技能实数域
 constant native ConvertAbilityRealField takes integer i returns abilityrealfield
-// 转换技能布尔域
+// 转换技能布尔值域
 constant native ConvertAbilityBooleanField takes integer i returns abilitybooleanfield
 // 转换技能字符串域
 constant native ConvertAbilityStringField takes integer i returns abilitystringfield
@@ -345,7 +345,7 @@ globals
 	
 	// 假 false
  constant boolean FALSE = false
-        // 真 true
+    // 真 true
 	constant boolean TRUE = true
 	// 数组最大值，1.28及以下版本该值是8192
 	constant integer JASS_MAX_ARRAY_SIZE = 32768
@@ -413,13 +413,13 @@ globals
 	constant race RACE_DEMON = ConvertRace(5)
 	// 其他种族
 	constant race RACE_OTHER = ConvertRace(7)
-	// 玩家游戏结果-胜利
+	// 玩家游戏结果 胜利
 	constant playergameresult PLAYER_GAME_RESULT_VICTORY = ConvertPlayerGameResult(0)
-	// 玩家游戏结果-失败
+	// 玩家游戏结果 失败
 	constant playergameresult PLAYER_GAME_RESULT_DEFEAT = ConvertPlayerGameResult(1)
-	// 玩家游戏结果-平局
+	// 玩家游戏结果 平局
 	constant playergameresult PLAYER_GAME_RESULT_TIE = ConvertPlayerGameResult(2)
-	// 玩家游戏结果-不确定
+	// 玩家游戏结果 不确定
 	constant playergameresult PLAYER_GAME_RESULT_NEUTRAL = ConvertPlayerGameResult(3)
 	// 被动联盟
 	constant alliancetype ALLIANCE_PASSIVE = ConvertAllianceType(0)
@@ -441,68 +441,68 @@ globals
 	constant alliancetype ALLIANCE_RESCUABLE = ConvertAllianceType(8)
 	// 联盟势力共享视野
 	constant alliancetype ALLIANCE_SHARED_VISION_FORCED = ConvertAllianceType(9)
-	// 游戏版本--混乱之治
+	// 游戏版本 混乱之治
 	constant version VERSION_REIGN_OF_CHAOS = ConvertVersion(0)
-	// 游戏版本--冰封王座
+	// 游戏版本 冰封王座
 	constant version VERSION_FROZEN_THRONE = ConvertVersion(1)
-	// 正常
+	// 攻击类型 普通
 	constant attacktype ATTACK_TYPE_NORMAL = ConvertAttackType(0)
-	// 普通
+	// 攻击类型 近战
 	constant attacktype ATTACK_TYPE_MELEE = ConvertAttackType(1)
-	// 穿刺
+	// 攻击类型 穿刺
 	constant attacktype ATTACK_TYPE_PIERCE = ConvertAttackType(2)
-	// 攻城
+	// 攻击类型 攻城
 	constant attacktype ATTACK_TYPE_SIEGE = ConvertAttackType(3)
-	// 魔法
+	// 攻击类型 魔法
 	constant attacktype ATTACK_TYPE_MAGIC = ConvertAttackType(4)
-	// 混乱
+	// 攻击类型 混乱
 	constant attacktype ATTACK_TYPE_CHAOS = ConvertAttackType(5)
-	// 英雄
+	// 攻击类型 英雄
 	constant attacktype ATTACK_TYPE_HERO = ConvertAttackType(6)
 	
-	// 未知
+	// 伤害类型 未知
 	constant damagetype DAMAGE_TYPE_UNKNOWN = ConvertDamageType(0)
-	// 正常
+	// 伤害类型 普通
 	constant damagetype DAMAGE_TYPE_NORMAL = ConvertDamageType(4)
-	// 增强
+	// 伤害类型 增强
 	constant damagetype DAMAGE_TYPE_ENHANCED = ConvertDamageType(5)
-	// 火焰
+	// 伤害类型 火焰
 	constant damagetype DAMAGE_TYPE_FIRE = ConvertDamageType(8)
-	// 寒冰
+	// 伤害类型 寒冰
 	constant damagetype DAMAGE_TYPE_COLD = ConvertDamageType(9)
-	// 闪电
+	// 伤害类型 闪电
 	constant damagetype DAMAGE_TYPE_LIGHTNING = ConvertDamageType(10)
-	// 毒
+	// 伤害类型 毒
 	constant damagetype DAMAGE_TYPE_POISON = ConvertDamageType(11)
-	// 瘟疫
+	// 伤害类型 瘟疫
 	constant damagetype DAMAGE_TYPE_DISEASE = ConvertDamageType(12)
-	// 瘟疫
+	// 伤害类型 神圣
 	constant damagetype DAMAGE_TYPE_DIVINE = ConvertDamageType(13)
-	// 神圣
+	// 伤害类型 魔法
 	constant damagetype DAMAGE_TYPE_MAGIC = ConvertDamageType(14)
-	// 音速
+	// 伤害类型 声波
 	constant damagetype DAMAGE_TYPE_SONIC = ConvertDamageType(15)
-	// 酸性
+	// 伤害类型 酸性
 	constant damagetype DAMAGE_TYPE_ACID = ConvertDamageType(16)
-	// 势力
+	// 伤害类型 势力
 	constant damagetype DAMAGE_TYPE_FORCE = ConvertDamageType(17)
-	// 死亡
+	// 伤害类型 死亡
 	constant damagetype DAMAGE_TYPE_DEATH = ConvertDamageType(18)
-	// 精神
+	// 伤害类型 精神
 	constant damagetype DAMAGE_TYPE_MIND = ConvertDamageType(19)
-	// 植物
+	// 伤害类型 植物
 	constant damagetype DAMAGE_TYPE_PLANT = ConvertDamageType(20)
-	// 防御
+	// 伤害类型 防御
 	constant damagetype DAMAGE_TYPE_DEFENSIVE = ConvertDamageType(21)
-	// 破坏
+	// 伤害类型 破坏
 	constant damagetype DAMAGE_TYPE_DEMOLITION = ConvertDamageType(22)
-	// 慢性毒药
+	// 伤害类型 慢性毒药
 	constant damagetype DAMAGE_TYPE_SLOW_POISON = ConvertDamageType(23)
-	// 灵魂锁链
+	// 伤害类型 灵魂锁链
 	constant damagetype DAMAGE_TYPE_SPIRIT_LINK = ConvertDamageType(24)
-	// 暗影打击
+	// 伤害类型 暗影打击
 	constant damagetype DAMAGE_TYPE_SHADOW_STRIKE = ConvertDamageType(25)
-	// 通用
+	// 伤害类型 通用
 	constant damagetype DAMAGE_TYPE_UNIVERSAL = ConvertDamageType(26)
 	
 	// 武器声音 无
@@ -838,7 +838,7 @@ globals
 	
 	// 单位移动声音
  constant volumegroup SOUND_VOLUMEGROUP_UNITMOVEMENT = ConvertVolumeGroup(0)
-        // 单位回应声音
+    // 单位回应声音
 	constant volumegroup SOUND_VOLUMEGROUP_UNITSOUNDS = ConvertVolumeGroup(1)
 	// 战斗声音
 	constant volumegroup SOUND_VOLUMEGROUP_COMBAT = ConvertVolumeGroup(2)
@@ -937,12 +937,12 @@ globals
 	constant aidifficulty AI_DIFFICULTY_NEWBIE = ConvertAIDifficulty(0)
 	// AI难度-普通
 	constant aidifficulty AI_DIFFICULTY_NORMAL = ConvertAIDifficulty(1)
-        // AI难度-困难
+    // AI难度-困难
 	constant aidifficulty AI_DIFFICULTY_INSANE = ConvertAIDifficulty(2)
 	
 	// 玩家积分-训练单位数量 player score values
  constant playerscore PLAYER_SCORE_UNITS_TRAINED = ConvertPlayerScore(0)
-        // 玩家积分-消灭单位数量
+    // 玩家积分-消灭单位数量
 	constant playerscore PLAYER_SCORE_UNITS_KILLED = ConvertPlayerScore(1)
 	// 玩家积分-已建造建筑数量
 	constant playerscore PLAYER_SCORE_STRUCT_BUILT = ConvertPlayerScore(2)
@@ -1086,11 +1086,11 @@ globals
 	// 玩家升级科技完成
 	constant playerunitevent EVENT_PLAYER_UNIT_UPGRADE_FINISH = ConvertPlayerUnitEvent(31)
 	
-        // 玩家开始训练单位
+    // 玩家开始训练单位
 	constant playerunitevent EVENT_PLAYER_UNIT_TRAIN_START = ConvertPlayerUnitEvent(32)
 	// 玩家取消训练单位
 	constant playerunitevent EVENT_PLAYER_UNIT_TRAIN_CANCEL = ConvertPlayerUnitEvent(33)
-        // 玩家完成训练单位
+    // 玩家完成训练单位
 	constant playerunitevent EVENT_PLAYER_UNIT_TRAIN_FINISH = ConvertPlayerUnitEvent(34)
 	// 玩家开始研究科技
 	constant playerunitevent EVENT_PLAYER_UNIT_RESEARCH_START = ConvertPlayerUnitEvent(35)
@@ -1102,15 +1102,15 @@ globals
 	constant playerunitevent EVENT_PLAYER_UNIT_ISSUED_ORDER = ConvertPlayerUnitEvent(38)
 	// 玩家单位命令事件（指定点）
 	constant playerunitevent EVENT_PLAYER_UNIT_ISSUED_POINT_ORDER = ConvertPlayerUnitEvent(39)
-        // 玩家单位命令事件（指定单位）
+    // 玩家单位命令事件（指定单位）
 	constant playerunitevent EVENT_PLAYER_UNIT_ISSUED_TARGET_ORDER = ConvertPlayerUnitEvent(40)
 	// 玩家单位命令事件（指定单位）
 	constant playerunitevent EVENT_PLAYER_UNIT_ISSUED_UNIT_ORDER = ConvertPlayerUnitEvent(40)    // for compat
-        // 玩家英雄升级事件
+    // 玩家英雄升级事件
 	constant playerunitevent EVENT_PLAYER_HERO_LEVEL = ConvertPlayerUnitEvent(41)
-        // 玩家英雄学习技能事件
+    // 玩家英雄学习技能事件
 	constant playerunitevent EVENT_PLAYER_HERO_SKILL = ConvertPlayerUnitEvent(42)
-        // 玩家英雄可复活
+    // 玩家英雄可复活
 	constant playerunitevent EVENT_PLAYER_HERO_REVIVABLE = ConvertPlayerUnitEvent(43)
 	// 玩家英雄开始复活
 	constant playerunitevent EVENT_PLAYER_HERO_REVIVE_START = ConvertPlayerUnitEvent(44)
@@ -1142,7 +1142,7 @@ globals
 	constant unitevent EVENT_UNIT_DAMAGING = ConvertUnitEvent(314)
 	// 單位死亡
 	constant unitevent EVENT_UNIT_DEATH = ConvertUnitEvent(53)
-        // 單位（尸体）開始腐爛
+    // 單位（尸体）開始腐爛
 	constant unitevent EVENT_UNIT_DECAY = ConvertUnitEvent(54)
 	// 单位可检测
 	constant unitevent EVENT_UNIT_DETECTED = ConvertUnitEvent(55)
@@ -1297,7 +1297,7 @@ globals
  constant playerunitevent EVENT_PLAYER_UNIT_SPELL_FINISH = ConvertPlayerUnitEvent(275)
 	// 玩家單位停止施放技能
  constant playerunitevent EVENT_PLAYER_UNIT_SPELL_ENDCAST = ConvertPlayerUnitEvent(276)
-        // 玩家單位抵押物品
+    // 玩家單位抵押物品
 	constant playerunitevent EVENT_PLAYER_UNIT_PAWN_ITEM = ConvertPlayerUnitEvent(277)
 	// 玩家单位物品栏中有物品堆叠
 	constant playerunitevent EVENT_PLAYER_UNIT_STACK_ITEM = ConvertPlayerUnitEvent(319)
@@ -1334,7 +1334,7 @@ globals
 	
 	// 小于
  constant limitop LESS_THAN = ConvertLimitOp(0)
-        // 小于 或 等于
+    // 小于 或 等于
 	constant limitop LESS_THAN_OR_EQUAL = ConvertLimitOp(1)
 	// 等于
 	constant limitop EQUAL = ConvertLimitOp(2)
@@ -1348,81 +1348,81 @@ globals
 	
 	// Unit Type Constants for use with IsUnitType()
 	
-	// 单位分类是 英雄
+	// 单位类型 英雄
 	constant unittype UNIT_TYPE_HERO = ConvertUnitType(0)
-	// 单位 已死亡
+	// 单位类型 已死亡
 	constant unittype UNIT_TYPE_DEAD = ConvertUnitType(1)
-	// 单位是 一座建筑
+	// 单位类型 建筑
 	constant unittype UNIT_TYPE_STRUCTURE = ConvertUnitType(2)
-	// 单位是 一个飞行单位
+	// 单位类型 飞行单位
 	constant unittype UNIT_TYPE_FLYING = ConvertUnitType(3)
-	// 单位是 一个地面单位
+	// 单位类型 地面单位
 	constant unittype UNIT_TYPE_GROUND = ConvertUnitType(4)
-	// 单位是 可以攻击飞行单位
+	// 单位类型 可以攻击飞行单位
 	constant unittype UNIT_TYPE_ATTACKS_FLYING = ConvertUnitType(5)
-	// 单位是 可以攻击地面单位
+	// 单位类型 可以攻击地面单位
 	constant unittype UNIT_TYPE_ATTACKS_GROUND = ConvertUnitType(6)
-	// 单位是 近战攻击单位
+	// 单位类型 近战攻击单位
 	constant unittype UNIT_TYPE_MELEE_ATTACKER = ConvertUnitType(7)
-	// 单位是 远程攻击单位
+	// 单位类型 远程攻击单位
 	constant unittype UNIT_TYPE_RANGED_ATTACKER = ConvertUnitType(8)
-	// 单位分类是 泰坦
+	// 单位类型 泰坦
 	constant unittype UNIT_TYPE_GIANT = ConvertUnitType(9)
-	// 单位是 召唤的
+	// 单位类型 召唤物
 	constant unittype UNIT_TYPE_SUMMONED = ConvertUnitType(10)
-	// 单位是 被击晕的
+	// 单位类型 被击晕的
 	constant unittype UNIT_TYPE_STUNNED = ConvertUnitType(11)
-	// 单位是 受折磨的
+	// 单位类型 受折磨的
 	constant unittype UNIT_TYPE_PLAGUED = ConvertUnitType(12)
-	// 单位是 被诱捕的（被网住）
+	// 单位类型 被诱捕（被网住）
 	constant unittype UNIT_TYPE_SNARED = ConvertUnitType(13)
-	// 单位分类 不死族
+	// 单位类型 不死族
 	constant unittype UNIT_TYPE_UNDEAD = ConvertUnitType(14)
-	// 单位分类 机械的
+	// 单位类型 机械
 	constant unittype UNIT_TYPE_MECHANICAL = ConvertUnitType(15)
-	// 单位分类 工人
+	// 单位类型 工人
 	constant unittype UNIT_TYPE_PEON = ConvertUnitType(16)
-	// 单位分类 自爆工兵
+	// 单位类型 自爆工兵
 	constant unittype UNIT_TYPE_SAPPER = ConvertUnitType(17)
-	// 单位分类 城镇
+	// 单位类型 城镇
 	constant unittype UNIT_TYPE_TOWNHALL = ConvertUnitType(18)
-	// 单位分类 古树
+	// 单位类型 古树
 	constant unittype UNIT_TYPE_ANCIENT = ConvertUnitType(19)
-	// 单位分类 牛头人
+	// 单位类型 牛头人
 	constant unittype UNIT_TYPE_TAUREN = ConvertUnitType(20)
-	// 单位 已中毒
+	// 单位类型 已中毒
 	constant unittype UNIT_TYPE_POISONED = ConvertUnitType(21)
-	// 单位 被变形
+	// 单位类型 被变形
 	constant unittype UNIT_TYPE_POLYMORPHED = ConvertUnitType(22)
-	// 单位 被催眠
+	// 单位类型 被催眠
 	constant unittype UNIT_TYPE_SLEEPING = ConvertUnitType(23)
-	// 单位 有抗性皮肤
+	// 单位类型 有抗性皮肤
 	constant unittype UNIT_TYPE_RESISTANT = ConvertUnitType(24)
-	// 单位 处于虚无状态
+	// 单位类型 处于虚无状态
 	constant unittype UNIT_TYPE_ETHEREAL = ConvertUnitType(25)
-	// 单位 免疫魔法
+	// 单位类型 免疫魔法
 	constant unittype UNIT_TYPE_MAGIC_IMMUNE = ConvertUnitType(26)
 	
 	
 	// Unit Type Constants for use with ChooseRandomItemEx()
 	
-	// 物品分类属于 永久
+	// 物品分类 永久
 	constant itemtype ITEM_TYPE_PERMANENT = ConvertItemType(0)
-	// 物品分类属于 可充
+	// 物品分类 可充
 	constant itemtype ITEM_TYPE_CHARGED = ConvertItemType(1)
-	// 物品分类属于 力量提升
+	// 物品分类 力量提升
 	constant itemtype ITEM_TYPE_POWERUP = ConvertItemType(2)
-	// 物品分类属于 人造
+	// 物品分类 人造
 	constant itemtype ITEM_TYPE_ARTIFACT = ConvertItemType(3)
-	// 物品分类属于 可购买
+	// 物品分类 可购买
 	constant itemtype ITEM_TYPE_PURCHASABLE = ConvertItemType(4)
-	// 物品分类属于 战役
+	// 物品分类 战役
 	constant itemtype ITEM_TYPE_CAMPAIGN = ConvertItemType(5)
-	// 物品分类属于 混杂（假）
+	// 物品分类 混杂（假）
 	constant itemtype ITEM_TYPE_MISCELLANEOUS = ConvertItemType(6)
-	// 物品分类属于 未知
+	// 物品分类 未知
 	constant itemtype ITEM_TYPE_UNKNOWN = ConvertItemType(7)
-	// 物品分类属于 任何
+	// 物品分类 任何
 	constant itemtype ITEM_TYPE_ANY = ConvertItemType(8)
 	
 	// 弃用事件， Deprecated, should use ITEM_TYPE_POWERUP
@@ -1467,9 +1467,9 @@ globals
 	constant blendmode BLEND_MODE_MODULATE = ConvertBlendMode(4)
 	// 混合方式 调整的2x混合
 	constant blendmode BLEND_MODE_MODULATE_2X = ConvertBlendMode(5)
-  // 频率控制 普通频率
+    // 频率控制 普通频率
 	constant raritycontrol RARITY_FREQUENT = ConvertRarityControl(0)
-  // 频率控制 罕见频率
+    // 频率控制 罕见频率
 	constant raritycontrol RARITY_RARE = ConvertRarityControl(1)
 	// 地图涂层标志 无
 	constant texmapflags TEXMAP_FLAG_NONE = ConvertTexMapFlags(0)
@@ -1523,72 +1523,114 @@ globals
 	
 	// Custom UI API constants
 	
-	
+	// 原生UI 初始化游戏UI，必要，没有它，什么都不显示
  constant originframetype ORIGIN_FRAME_GAME_UI = ConvertOriginFrameType(0)
+    // 原生UI 单位操作面板按钮（技能栏，含移动/停止/巡逻/攻击，共12格），每次选择单位时它会重新出现/更新
 	constant originframetype ORIGIN_FRAME_COMMAND_BUTTON = ConvertOriginFrameType(1)
+	// 原生UI 英雄栏（F1、F2按钮对应的英雄头像所在区域），所有 HERO_BUTTONS 的父类，由 HeroButtons 控制可见性
 	constant originframetype ORIGIN_FRAME_HERO_BAR = ConvertOriginFrameType(2)
+	// 原生UI 英雄按钮，屏幕左侧的自己/共享控制盟友的英雄可点击按钮
 	constant originframetype ORIGIN_FRAME_HERO_BUTTON = ConvertOriginFrameType(3)
+	// 原生UI 英雄按钮下的血量条，与 HeroButtons 关联
 	constant originframetype ORIGIN_FRAME_HERO_HP_BAR = ConvertOriginFrameType(4)
+	// 原生UI 英雄按钮下的魔法条，与 HeroButtons 关联
 	constant originframetype ORIGIN_FRAME_HERO_MANA_BAR = ConvertOriginFrameType(5)
+	// 原生UI 英雄获得新技能点时，英雄按钮发光; 与 HeroButtons 关联。当英雄新技能点时，即使所有原生UI都被隐藏，闪光也会出现
 	constant originframetype ORIGIN_FRAME_HERO_BUTTON_INDICATOR = ConvertOriginFrameType(6)
+	// 原生UI 物品栏格按钮（共6格）。当其父级可见时，每次选择物品时它会重新出现/更新
 	constant originframetype ORIGIN_FRAME_ITEM_BUTTON = ConvertOriginFrameType(7)
+	// 原生UI 小地图
 	constant originframetype ORIGIN_FRAME_MINIMAP = ConvertOriginFrameType(8)
+	// 原生UI 小地图按钮，0是顶部按钮，到底部的共4个按钮（发送信号、显示/隐藏地形、切换敌友/玩家颜色、显示中立敌对单位营地、编队方式）
 	constant originframetype ORIGIN_FRAME_MINIMAP_BUTTON = ConvertOriginFrameType(9)
+	// 原生UI 系统按钮，菜单，盟友，日志/聊天，任务
 	constant originframetype ORIGIN_FRAME_SYSTEM_BUTTON = ConvertOriginFrameType(10)
+	// 原生UI 工具提示
 	constant originframetype ORIGIN_FRAME_TOOLTIP = ConvertOriginFrameType(11)
+	// 原生UI 用户工具提示窗口柄句
 	constant originframetype ORIGIN_FRAME_UBERTOOLTIP = ConvertOriginFrameType(12)
+	// 原生UI 聊天信息显示框（玩家聊天信息）
 	constant originframetype ORIGIN_FRAME_CHAT_MSG = ConvertOriginFrameType(13)
+	// 原生UI 游戏消息显示框（如 DisplayTextToPlayer 发送的信息）
 	constant originframetype ORIGIN_FRAME_UNIT_MSG = ConvertOriginFrameType(14)
+	// 原生UI 持续显示的变更警告消息，显示在昼夜时钟下方
 	constant originframetype ORIGIN_FRAME_TOP_MSG = ConvertOriginFrameType(15)
+	// 原生UI 主选单位的模型视图（模型肖像区域，攻击力左边，看到单位头和嘴巴那块区域），其使用了特殊的协调系统,0在左下角绝对位置，这使得它很难与其他框架一起使用(不像其他4:3)
 	constant originframetype ORIGIN_FRAME_PORTRAIT = ConvertOriginFrameType(16)
+	// 原生UI 世界UI，游戏区域、单位、物品、特效、雾... 游戏的每个对象都显示在这
 	constant originframetype ORIGIN_FRAME_WORLD_FRAME = ConvertOriginFrameType(17)
+	// 原生UI 简易UI（父级）
 	constant originframetype ORIGIN_FRAME_SIMPLE_UI_PARENT = ConvertOriginFrameType(18)
+	// 原生UI 主选单位的模型视图（ORIGIN_FRAME_PORTRAIT）下方的生命值文字
 	constant originframetype ORIGIN_FRAME_PORTRAIT_HP_TEXT = ConvertOriginFrameType(19)
+	// 原生UI 主选单位的模型视图（ORIGIN_FRAME_PORTRAIT）下方的魔法值文字
 	constant originframetype ORIGIN_FRAME_PORTRAIT_MANA_TEXT = ConvertOriginFrameType(20)
+	// 原生UI BUFF状态栏（单位当前拥有光环的显示区域），尺寸固定，最多显示8个BUFF
 	constant originframetype ORIGIN_FRAME_UNIT_PANEL_BUFF_BAR = ConvertOriginFrameType(21)
+	// 原生UI BUFF状态栏标题（单位当前拥有光环的显示区域的标题），默认值是 Status:（状态：）
 	constant originframetype ORIGIN_FRAME_UNIT_PANEL_BUFF_BAR_LABEL = ConvertOriginFrameType(22)
 	
-	// 左上
+	// 框架点（UI） 左上
 	constant framepointtype FRAMEPOINT_TOPLEFT = ConvertFramePointType(0)
-	// 上
+	// 框架点（UI） 上
 	constant framepointtype FRAMEPOINT_TOP = ConvertFramePointType(1)
-	// 右上
+	// 框架点（UI） 右上
 	constant framepointtype FRAMEPOINT_TOPRIGHT = ConvertFramePointType(2)
-	// 左
+	// 框架点（UI） 左
 	constant framepointtype FRAMEPOINT_LEFT = ConvertFramePointType(3)
-	// 中间
+	// 框架点（UI） 中间
 	constant framepointtype FRAMEPOINT_CENTER = ConvertFramePointType(4)
-	// 右
+	// 框架点（UI） 右
 	constant framepointtype FRAMEPOINT_RIGHT = ConvertFramePointType(5)
-	// 左下
+	// 框架点（UI） 左下
 	constant framepointtype FRAMEPOINT_BOTTOMLEFT = ConvertFramePointType(6)
-	// 下
+	// 框架点（UI） 下
 	constant framepointtype FRAMEPOINT_BOTTOM = ConvertFramePointType(7)
-	// 右下
+	// 框架点（UI） 右下
 	constant framepointtype FRAMEPOINT_BOTTOMRIGHT = ConvertFramePointType(8)
-	
+	// 文本对齐方式 顶部对齐
 	constant textaligntype TEXT_JUSTIFY_TOP = ConvertTextAlignType(0)
+	// 文本对齐方式 中部对齐
 	constant textaligntype TEXT_JUSTIFY_MIDDLE = ConvertTextAlignType(1)
+	// 文本对齐方式 底部对齐
 	constant textaligntype TEXT_JUSTIFY_BOTTOM = ConvertTextAlignType(2)
+	// 文本对齐方式 左侧对齐
 	constant textaligntype TEXT_JUSTIFY_LEFT = ConvertTextAlignType(3)
+	// 文本对齐方式 居中对齐
 	constant textaligntype TEXT_JUSTIFY_CENTER = ConvertTextAlignType(4)
+	// 文本对齐方式 右侧对齐
 	constant textaligntype TEXT_JUSTIFY_RIGHT = ConvertTextAlignType(5)
-	
+	// 框架（UI）事件类型 控制点击
 	constant frameeventtype FRAMEEVENT_CONTROL_CLICK = ConvertFrameEventType(1)
+	// 框架（UI）事件类型 鼠标移入
 	constant frameeventtype FRAMEEVENT_MOUSE_ENTER = ConvertFrameEventType(2)
+	// 框架（UI）事件类型 鼠标移出
 	constant frameeventtype FRAMEEVENT_MOUSE_LEAVE = ConvertFrameEventType(3)
+	// 框架（UI）事件类型 鼠标松开
 	constant frameeventtype FRAMEEVENT_MOUSE_UP = ConvertFrameEventType(4)
+	// 框架（UI）事件类型 鼠标按下
 	constant frameeventtype FRAMEEVENT_MOUSE_DOWN = ConvertFrameEventType(5)
+	// 框架（UI）事件类型 鼠标滚轴滚动
 	constant frameeventtype FRAMEEVENT_MOUSE_WHEEL = ConvertFrameEventType(6)
+	// 框架（UI）事件类型 复选框-选中
 	constant frameeventtype FRAMEEVENT_CHECKBOX_CHECKED = ConvertFrameEventType(7)
+	// 框架（UI）事件类型 复选框-未选中
 	constant frameeventtype FRAMEEVENT_CHECKBOX_UNCHECKED = ConvertFrameEventType(8)
+	// 框架（UI）事件类型 输入框-文本变化
 	constant frameeventtype FRAMEEVENT_EDITBOX_TEXT_CHANGED = ConvertFrameEventType(9)
+	// 框架（UI）事件类型 弹出菜单按钮变化
 	constant frameeventtype FRAMEEVENT_POPUPMENU_ITEM_CHANGED = ConvertFrameEventType(10)
+	// 框架（UI）事件类型 鼠标双击
 	constant frameeventtype FRAMEEVENT_MOUSE_DOUBLECLICK = ConvertFrameEventType(11)
+	// 框架（UI）事件类型 独立元素动画更新
 	constant frameeventtype FRAMEEVENT_SPRITE_ANIM_UPDATE = ConvertFrameEventType(12)
+	// 框架（UI）事件类型 滑块数值变化
 	constant frameeventtype FRAMEEVENT_SLIDER_VALUE_CHANGED = ConvertFrameEventType(13)
+	// 框架（UI）事件类型 对话框-点击取消
 	constant frameeventtype FRAMEEVENT_DIALOG_CANCEL = ConvertFrameEventType(14)
+	// 框架（UI）事件类型 对话框-点击接受
 	constant frameeventtype FRAMEEVENT_DIALOG_ACCEPT = ConvertFrameEventType(15)
+	// 框架（UI）事件类型 输入框-文本输入
 	constant frameeventtype FRAMEEVENT_EDITBOX_ENTER = ConvertFrameEventType(16)
 	
 	
@@ -3534,17 +3576,17 @@ native MoveRectTo takes rect whichRect, real newCenterX, real newCenterY returns
 // 移动区域
 native MoveRectToLoc takes rect whichRect, location newCenterLoc returns nothing
 
-// 区域中心的 X 坐标
+// 获取区域中心的 X 坐标
 native GetRectCenterX takes rect whichRect returns real
-// 区域中心的 Y 坐标
+// 获取区域中心的 Y 坐标
 native GetRectCenterY takes rect whichRect returns real
-// 区域最小 X 坐标
+// 获取区域最小 X 坐标
 native GetRectMinX takes rect whichRect returns real
-// 区域最小 Y 坐标
+// 获取区域最小 Y 坐标
 native GetRectMinY takes rect whichRect returns real
-// 区域最大 X 坐标
+// 获取区域最大 X 坐标
 native GetRectMaxX takes rect whichRect returns real
-// 区域最大 Y 坐标
+// 获取区域最大 Y 坐标
 native GetRectMaxY takes rect whichRect returns real
 
 // 新建区域 [R]
@@ -3557,13 +3599,13 @@ native RegionAddRect takes region whichRegion, rect r returns nothing
 // 移除区域 [R]
 native RegionClearRect takes region whichRegion, rect r returns nothing
 
-// 添加单元点(指定坐标) [R]
+// 添加坐标(指定区域) [R]
 native RegionAddCell takes region whichRegion, real x, real y returns nothing
-// 添加单元点(指定点) [R]
+// 添加点(指定区域) [R]
 native RegionAddCellAtLoc takes region whichRegion, location whichLocation returns nothing
-// 移除单元点(指定坐标) [R]
+// 移除坐标(指定区域) [R]
 native RegionClearCell takes region whichRegion, real x, real y returns nothing
-// 移除单元点(指定点) [R]
+// 移除点(指定区域) [R]
 native RegionClearCellAtLoc takes region whichRegion, location whichLocation returns nothing
 
 // 转换坐标到点
@@ -3760,7 +3802,7 @@ constant native GetTournamentFinishNowPlayer takes nothing returns player
 constant native GetTournamentScore takes player whichPlayer returns integer
 
 // EVENT_GAME_SAVE
-// 获取储存游戏文件名
+// 获取游戏存档的文件名
 constant native GetSaveBasicFilename takes nothing returns string
 
 
@@ -3930,7 +3972,7 @@ constant native GetIssuedOrderId takes nothing returns integer
 // EVENT_PLAYER_UNIT_ISSUED_POINT_ORDER
 // 获取命令目标点 X 坐标 [R]
 constant native GetOrderPointX takes nothing returns real
-// 获取命令目标点 Y 标 [R]
+// 获取命令目标点 Y 坐标 [R]
 constant native GetOrderPointY takes nothing returns real
 // 获取命令目标点
 constant native GetOrderPointLoc takes nothing returns location
@@ -3963,9 +4005,9 @@ constant native GetSpellAbilityId takes nothing returns integer
 constant native GetSpellAbility takes nothing returns ability
 // 获取被释放技能目标点
 constant native GetSpellTargetLoc takes nothing returns location
-// 获取被释放技能目标点 x 坐标
+// 获取被释放技能目标点 X 坐标
 constant native GetSpellTargetX takes nothing returns real
-// 获取被释放技能目标点 y 坐标
+// 获取被释放技能目标点 Y 坐标
 constant native GetSpellTargetY takes nothing returns real
 // 获取被释放技能目标可毁坏物
 constant native GetSpellTargetDestructable takes nothing returns destructable
@@ -3995,7 +4037,7 @@ native TriggerRegisterPlayerChatEvent takes trigger whichTrigger, player whichPl
 constant native GetEventPlayerChatString takes nothing returns string
 
 // returns the string that you registered for
-// 匹配的聊天字符
+// 获取匹配的聊天字符
 constant native GetEventPlayerChatStringMatched takes nothing returns string
 
 // 单位死亡事件
@@ -4042,7 +4084,7 @@ native TriggerRegisterFilterUnitEvent takes trigger whichTrigger, unit whichUnit
 
 // EVENT_UNIT_ACQUIRED_TARGET
 // EVENT_UNIT_TARGET_IN_RANGE
-// 目标单位
+// 获取目标单位
 constant native GetEventTargetUnit takes nothing returns unit
 
 // EVENT_UNIT_ATTACKED
@@ -4406,12 +4448,12 @@ native SetUnitExploded takes unit whichUnit, boolean exploded returns nothing
 native SetUnitInvulnerable takes unit whichUnit, boolean flag returns nothing
 // 暂停/恢复 [R]
 native PauseUnit takes unit whichUnit, boolean flag returns nothing
-// 单位是否暂停
+// 查询单位是否暂停
 native IsUnitPaused takes unit whichHero returns boolean
-// 设置碰撞 打开/关闭
+// 打开/关闭单位碰撞体积
 native SetUnitPathing takes unit whichUnit, boolean flag returns nothing
 
-// 清除所有选定
+// 清除所有选择
 native ClearSelection takes nothing returns nothing
 // 选择单位
 native SelectUnit takes unit whichUnit, boolean flag returns nothing
@@ -4429,9 +4471,9 @@ native UnitAddItem takes unit whichUnit, item whichItem returns boolean
 native UnitAddItemById takes unit whichUnit, integer itemId returns item
 // 把物品移动到指定物品栏格数 [R]
 native UnitAddItemToSlotById takes unit whichUnit, integer itemId, integer itemSlot returns boolean
-// 丢弃物品
+// 丢弃物品（指定物品）
 native UnitRemoveItem takes unit whichUnit, item whichItem returns nothing
-// 丢弃物品
+// 丢弃物品（指定物品栏格数：0-5，不论哪个物品在该格中，都会执行该命令，丢弃成功的前提是该物品允许丢弃）
 // @param itemSlot 0-5
 native UnitRemoveItemFromSlot takes unit whichUnit, integer itemSlot returns item
 // 单位是否持有指定物品
@@ -4456,36 +4498,36 @@ native UnitUseItemPoint takes unit whichUnit, item whichItem, real x, real y ret
 // 对单位使用物品
 native UnitUseItemTarget takes unit whichUnit, item whichItem, widget target returns boolean
 
-// 单位所在 X 轴坐标 [R]
+// 获取指定单位所在 X 轴坐标 [R]
 constant native GetUnitX takes unit whichUnit returns real
-// 单位所在 Y 轴坐标 [R]
+// 获取指定单位所在 Y 轴坐标 [R]
 constant native GetUnitY takes unit whichUnit returns real
-// 单位的位置
+// 获取指定单位的位置
 constant native GetUnitLoc takes unit whichUnit returns location
-// 单位面向角度
+// 获取指定单位面向角度
 constant native GetUnitFacing takes unit whichUnit returns real
-// 单位移动速度 (当前值)
+// 获取指定单位移动速度 (当前值)
 constant native GetUnitMoveSpeed takes unit whichUnit returns real
-// 单位移动速度 (默认值)
+// 获取指定单位移动速度 (默认值)
 constant native GetUnitDefaultMoveSpeed takes unit whichUnit returns real
-// 指定单位的指定属性值，如当前生命值/魔法值，最大生命/魔法值 [R]
+// 获取指定单位的指定属性值，如当前生命值/魔法值，最大生命/魔法值 [R]
 // @param whichUnitState [UNIT_STATE_LIFE, UNIT_STATE_MAX_LIFE, UNIT_STATE_MANA, UNIT_STATE_MAX_MANA]
 constant native GetUnitState takes unit whichUnit, unitstate whichUnitState returns real
-// 单位的所属玩家
+// 获取指定单位的所属玩家
 constant native GetOwningPlayer takes unit whichUnit returns player
-// 单位的类型
+// 获取指定单位的类型
 constant native GetUnitTypeId takes unit whichUnit returns integer
-// 单位的种族
+// 获取指定单位的种族
 constant native GetUnitRace takes unit whichUnit returns race
-// 单位的名字
+// 获取指定单位的名字
 constant native GetUnitName takes unit whichUnit returns string
-// 单位使用人口
+// 获取指定单位使用的人口数量（单个）
 constant native GetUnitFoodUsed takes unit whichUnit returns integer
-// 单位提供人口数量
+// 获取指定单位提供的人口数量（单个）
 constant native GetUnitFoodMade takes unit whichUnit returns integer
-// 单位-类型 提供的人口
+// 获取指定单位类型 提供的人口数量（单个）
 constant native GetFoodMade takes integer unitId returns integer
-// 单位-类型 使用的人口
+// 获取指定单位类型 使用的人口数量（单个）
 constant native GetFoodUsed takes integer unitId returns integer
 // 启用/禁用 人口占用 [R]
 native SetUnitUseFood takes unit whichUnit, boolean useFood returns nothing
@@ -4540,9 +4582,9 @@ constant native IsUnitInTransport takes unit whichUnit, unit whichTransport retu
 // 指定单位是否被装载（进入暗夜金矿、运输飞艇、运输船都属于装载）
 constant native IsUnitLoaded takes unit whichUnit returns boolean
 
-// 单位类型是否英雄单位
+// 指定单位类型是否英雄单位
 constant native IsHeroUnitId takes integer unitId returns boolean
-// 检查单位-类型 分类
+// 单位类型是否匹配
 constant native IsUnitIdType takes integer unitId, unittype whichUnitType returns boolean
 
 // 设定指定单位和指定玩家的共享视野状态（共享或不共享） [R]
@@ -4582,9 +4624,9 @@ native UnitIsSleeping takes unit whichUnit returns boolean
 native UnitWakeUp takes unit whichUnit returns nothing
 // 设置生命周期 [R]
 native UnitApplyTimedLife takes unit whichUnit, integer buffId, real duration returns nothing
-//设置指定单位的忽略报警状态
+// 设置指定单位的忽略报警状态
 native UnitIgnoreAlarm takes unit whichUnit, boolean flag returns boolean
-//读取指定单位忽略报警的开关状态
+// 读取指定单位忽略报警的开关状态
 native UnitIgnoreAlarmToggled takes unit whichUnit returns boolean
 // 重设单位技能冷却时间 Cooldown
 native UnitResetCooldown takes unit whichUnit returns nothing
@@ -4672,9 +4714,9 @@ native WaygateGetDestinationX takes unit waygate returns real
 native WaygateGetDestinationY takes unit waygate returns real
 // 设置传送门目的坐标 [R]
 native WaygateSetDestination takes unit waygate, real x, real y returns nothing
-//设置传送门激活状态
+// 设置传送门激活状态
 native WaygateActivate takes unit waygate, boolean activate returns nothing
-//获取传送门激活状态
+// 获取传送门激活状态
 native WaygateIsActive takes unit waygate returns boolean
 
 // 增加 物品-类型 (到所有商店)
@@ -5924,7 +5966,7 @@ native GetAbilitySoundById takes integer abilityId, soundtype t returns string
 native GetTerrainCliffLevel takes real x, real y returns integer
 // 设置水颜色 [R]
 native SetWaterBaseColor takes integer red, integer green, integer blue, integer alpha returns nothing
-// 设置 水变形 开/关
+// 启用/禁用 水变形
 native SetWaterDeforms takes boolean val returns nothing
 // 指定坐标地形 [R]
 native GetTerrainType takes real x, real y returns integer
@@ -6006,9 +6048,9 @@ native SetDoodadAnimationRect takes rect r, integer doodadID, string animName, b
 
 // Computer AI interface
 //
-// 启动对战 AI 
+// 启用对战 AI 脚本
 native StartMeleeAI takes player num, string script returns nothing
-// 启动战役 AI 
+// 启用战役 AI 脚本
 native StartCampaignAI takes player num, string script returns nothing
 // 发送 AI 命令
 native CommandAI takes player num, integer command, integer data returns nothing
@@ -6290,7 +6332,7 @@ native BlzSetEventAttackType takes attacktype attackType returns boolean
 native BlzSetEventDamageType takes damagetype damageType returns boolean
 // 设置事件武器类型
 native BlzSetEventWeaponType takes weapontype weaponType returns boolean
-// 是否普通攻击
+// 是否攻击事件
 native BlzGetEventIsAttack takes nothing returns boolean
 // 获取额外的整数数据
 native RequestExtraIntegerData takes integer dataType, player whichPlayer, string param1, string param2, boolean param3, integer param4, integer param5, integer param6 returns integer
@@ -6301,7 +6343,7 @@ native RequestExtraStringData takes integer dataType, player whichPlayer, string
 // 获取额外的实数数据
 native RequestExtraRealData takes integer dataType, player whichPlayer, string param1, string param2, boolean param3, integer param4, integer param5, integer param6 returns real
 // Add this function to follow the style of GetUnitX and GetUnitY, it has the same result as BlzGetLocalUnitZ
-// 获取单位 Z 坐标
+// 获取单位 Z 轴高度
 native BlzGetUnitZ takes unit whichUnit returns real
 // 开启/关闭选择和选择圈
 native BlzEnableSelections takes boolean enableSelection, boolean enableSelectionCircle returns nothing
@@ -6326,7 +6368,7 @@ native BlzEndRecording takes nothing returns nothing
 // 显示黄金
 native BlzShowUnitTeamGlow takes unit whichUnit, boolean show returns nothing
 
-// 获取原生UI
+// 获取原生框架（原生UI）
 native BlzGetOriginFrame takes originframetype frameType, integer index returns framehandle
 // UI自动设置位置
 native BlzEnableUIAutoPosition takes boolean enable returns nothing
@@ -6386,23 +6428,23 @@ native BlzFrameGetEnable takes framehandle frame returns boolean
 native BlzFrameSetAlpha takes framehandle frame, integer alpha returns nothing
 // 获取Frame透明度
 native BlzFrameGetAlpha takes framehandle frame returns integer
-// 设置Frame动画
+// 设置Frame独立元素动画
 native BlzFrameSetSpriteAnimate takes framehandle frame, integer primaryProp, integer flags returns nothing
-// 设置Frame图片
+// 设置Frame文本
 native BlzFrameSetTexture takes framehandle frame, string texFile, integer flag, boolean blend returns nothing
 // 缩放Frame
 native BlzFrameSetScale takes framehandle frame, real scale returns nothing
 // 设置Frame提示
 native BlzFrameSetTooltip takes framehandle frame, framehandle tooltip returns nothing
-// 锁定鼠标
+// 锁定frame鼠标
 native BlzFrameCageMouse takes framehandle frame, boolean enable returns nothing
-// 设置当前值
+// 设置frame当前值
 native BlzFrameSetValue takes framehandle frame, real value returns nothing
-// 获取当前值
+// 获取frame当前值
 native BlzFrameGetValue takes framehandle frame returns real
-// 设置最大最小值
+// 设置frame最大最小值
 native BlzFrameSetMinMaxValue takes framehandle frame, real minValue, real maxValue returns nothing
-// 设置Step值
+// 设置frame的Step值
 native BlzFrameSetStepSize takes framehandle frame, real stepSize returns nothing
 // 设置Frame大小
 native BlzFrameSetSize takes framehandle frame, real width, real height returns nothing
@@ -6418,9 +6460,9 @@ native BlzFrameGetParent takes framehandle frame returns framehandle
 native BlzFrameGetHeight takes framehandle frame returns real
 // 获取Frame宽度
 native BlzFrameGetWidth takes framehandle frame returns real
-// 设置字体
+// 设置frame字体
 native BlzFrameSetFont takes framehandle frame, string fileName, real height, integer flags returns nothing
-// 设置字体对齐方式
+// 设置frame字体对齐方式
 native BlzFrameSetTextAlignment takes framehandle frame, textaligntype vert, textaligntype horz returns nothing
 
 // 获取Frame子组件数量 (1.32.7)
@@ -6433,7 +6475,7 @@ native BlzFrameGetChild takes framehandle frame, integer index returns framehand
 native BlzTriggerRegisterFrameEvent takes trigger whichTrigger, framehandle frame, frameeventtype eventId returns event
 // 获取触发的Frame
 native BlzGetTriggerFrame takes nothing returns framehandle
-// 获取触发的事件类型
+// 获取frame触发的事件类型
 native BlzGetTriggerFrameEvent takes nothing returns frameeventtype
 // 获取触发的Frame值
 native BlzGetTriggerFrameValue takes nothing returns real
@@ -6512,69 +6554,69 @@ native BlzBitXor takes integer x, integer y returns integer
 // Intanced Object Operations
 // Ability
 
-// 技能布尔类型字段
+// 获取技能布尔值域
 native BlzGetAbilityBooleanField takes ability whichAbility, abilitybooleanfield whichField returns boolean
-// 技能的整数类型字段
+// 获取技能的整数域
 native BlzGetAbilityIntegerField takes ability whichAbility, abilityintegerfield whichField returns integer
-// 技能的实数类型字段
+// 获取技能的实数域
 native BlzGetAbilityRealField takes ability whichAbility, abilityrealfield whichField returns real
-// 技能字符串字段
+// 获取技能字符串域
 native BlzGetAbilityStringField takes ability whichAbility, abilitystringfield whichField returns string
-// 技能随等级改变的布尔类型字段
+// 获取技能随等级改变的布尔值域
 native BlzGetAbilityBooleanLevelField takes ability whichAbility, abilitybooleanlevelfield whichField, integer level returns boolean
-// 技能随等级改变的整数类型字段
+// 获取技能随等级改变的整数域
 native BlzGetAbilityIntegerLevelField takes ability whichAbility, abilityintegerlevelfield whichField, integer level returns integer
-// 技能随等级改变的实数类型字段
+// 获取技能随等级改变的实数域
 native BlzGetAbilityRealLevelField takes ability whichAbility, abilityreallevelfield whichField, integer level returns real
-// 技能字符串等级字段
+// 获取技能随等级改变的字符串域
 native BlzGetAbilityStringLevelField takes ability whichAbility, abilitystringlevelfield whichField, integer level returns string
-// 技能随等级改变的布尔类型字段
+// 获取技能随等级改变的数组布尔值域
 native BlzGetAbilityBooleanLevelArrayField takes ability whichAbility, abilitybooleanlevelarrayfield whichField, integer level, integer index returns boolean
-// 技能随等级改变的整数类型字段
+// 获取技能随等级改变的数组整数域
 native BlzGetAbilityIntegerLevelArrayField takes ability whichAbility, abilityintegerlevelarrayfield whichField, integer level, integer index returns integer
-// 技能随等级改变的实数类型字段
+// 获取技能随等级改变的数组实数域
 native BlzGetAbilityRealLevelArrayField takes ability whichAbility, abilityreallevelarrayfield whichField, integer level, integer index returns real
-// 技能字符串等级数组字段
+// 获取技能随等级改变的数组字符串域
 native BlzGetAbilityStringLevelArrayField takes ability whichAbility, abilitystringlevelarrayfield whichField, integer level, integer index returns string
-// 改变技能的布尔类型字段
+// 设置技能的布尔值域
 native BlzSetAbilityBooleanField takes ability whichAbility, abilitybooleanfield whichField, boolean value returns boolean
-// 改变技能的整数类型字段
+// 设置技能的整数域
 native BlzSetAbilityIntegerField takes ability whichAbility, abilityintegerfield whichField, integer value returns boolean
-// 改变技能的实数类型字段
+// 设置技能的实数域
 native BlzSetAbilityRealField takes ability whichAbility, abilityrealfield whichField, real value returns boolean
-// 改变技能的字符串类型字段
+// 设置技能的字符串域
 native BlzSetAbilityStringField takes ability whichAbility, abilitystringfield whichField, string value returns boolean
-// 改变技能的随等级改变的布尔类型字段
+// 设置技能随等级改变的布尔值域
 native BlzSetAbilityBooleanLevelField takes ability whichAbility, abilitybooleanlevelfield whichField, integer level, boolean value returns boolean
-// 改变技能随等级改变的整数类型字段
+// 设置技能随等级改变的整数域
 native BlzSetAbilityIntegerLevelField takes ability whichAbility, abilityintegerlevelfield whichField, integer level, integer value returns boolean
-// 改变技能随等级改变的实数类型字段
+// 设置技能随等级改变的实数域
 native BlzSetAbilityRealLevelField takes ability whichAbility, abilityreallevelfield whichField, integer level, real value returns boolean
-// 改变技能随等级改变的字符串类型字段
+// 设置技能随等级改变的字符串域
 native BlzSetAbilityStringLevelField takes ability whichAbility, abilitystringlevelfield whichField, integer level, string value returns boolean
-// 改变技能随等级改变的布尔数组类型字段
+// 设置技能随等级改变的数组布尔值域
 native BlzSetAbilityBooleanLevelArrayField takes ability whichAbility, abilitybooleanlevelarrayfield whichField, integer level, integer index, boolean value returns boolean
-// 改变技能随等级改变的整数数组类型字段
+// 设置技能随等级改变的数组整数域
 native BlzSetAbilityIntegerLevelArrayField takes ability whichAbility, abilityintegerlevelarrayfield whichField, integer level, integer index, integer value returns boolean
-// 改变技能随等级改变的实数数组类型字段
+// 设置技能随等级改变的数组实数域
 native BlzSetAbilityRealLevelArrayField takes ability whichAbility, abilityreallevelarrayfield whichField, integer level, integer index, real value returns boolean
-// 改变技能随等级改变的字符串数组类型字段
+// 设置技能随等级改变的数组字符串域
 native BlzSetAbilityStringLevelArrayField takes ability whichAbility, abilitystringlevelarrayfield whichField, integer level, integer index, string value returns boolean
-// 技能随等级改变的布尔类型字段 - 添加值
+// 添加技能随等级改变的数组布尔值域
 native BlzAddAbilityBooleanLevelArrayField takes ability whichAbility, abilitybooleanlevelarrayfield whichField, integer level, boolean value returns boolean
-// 技能随等级改变的整数类型字段 - 添加值
+// 添加技能随等级改变的数组整数域
 native BlzAddAbilityIntegerLevelArrayField takes ability whichAbility, abilityintegerlevelarrayfield whichField, integer level, integer value returns boolean
-// 技能随等级改变的实数类型字段 - 添加值
+// 添加技能随等级改变的数组实数域
 native BlzAddAbilityRealLevelArrayField takes ability whichAbility, abilityreallevelarrayfield whichField, integer level, real value returns boolean
-// 技能随等级改变的字符串类型字段 - 添加值
+// 添加技能随等级改变的数组字符串域
 native BlzAddAbilityStringLevelArrayField takes ability whichAbility, abilitystringlevelarrayfield whichField, integer level, string value returns boolean
-// 技能随等级改变的布尔类型字段 - 移除值
+// 移除技能随等级改变的数组布尔值域
 native BlzRemoveAbilityBooleanLevelArrayField takes ability whichAbility, abilitybooleanlevelarrayfield whichField, integer level, boolean value returns boolean
-// 技能随等级改变的整数类型字段 - 移除值
+// 移除技能随等级改变的数组整数域
 native BlzRemoveAbilityIntegerLevelArrayField takes ability whichAbility, abilityintegerlevelarrayfield whichField, integer level, integer value returns boolean
-// 技能随等级改变的实数类型字段 - 移除值
+// 移除技能随等级改变的数组实数域
 native BlzRemoveAbilityRealLevelArrayField takes ability whichAbility, abilityreallevelarrayfield whichField, integer level, real value returns boolean
-// 技能随等级改变的字符串类型字段 - 移除值
+// 移除技能随等级改变的数组字符串域
 native BlzRemoveAbilityStringLevelArrayField takes ability whichAbility, abilitystringlevelarrayfield whichField, integer level, string value returns boolean
 
 // Item 
@@ -6585,59 +6627,59 @@ native BlzGetItemAbilityByIndex takes item whichItem, integer index returns abil
 native BlzGetItemAbility takes item whichItem, integer abilCode returns ability
 // 物品添加技能
 native BlzItemAddAbility takes item whichItem, integer abilCode returns boolean
-// 物品的布尔类型字段
+// 物品的布尔值域
 native BlzGetItemBooleanField takes item whichItem, itembooleanfield whichField returns boolean
-// 获取物品的整数类型字段
+// 获取物品的整数域
 native BlzGetItemIntegerField takes item whichItem, itemintegerfield whichField returns integer
-// 物品的实数类型字段
+// 物品的实数域
 native BlzGetItemRealField takes item whichItem, itemrealfield whichField returns real
-// 获取物品字符串字段
+// 获取物品字符串域
 native BlzGetItemStringField takes item whichItem, itemstringfield whichField returns string
-// 改变物品的布尔类型字段
+// 改变物品的布尔值域
 native BlzSetItemBooleanField takes item whichItem, itembooleanfield whichField, boolean value returns boolean
-// 改变物品的整数类型字段
+// 改变物品的整数域
 native BlzSetItemIntegerField takes item whichItem, itemintegerfield whichField, integer value returns boolean
-// 改变物品的实数类型字段
+// 改变物品的实数域
 native BlzSetItemRealField takes item whichItem, itemrealfield whichField, real value returns boolean
-// 改变物品的字符串类型字段
+// 改变物品的字符串域
 native BlzSetItemStringField takes item whichItem, itemstringfield whichField, string value returns boolean
 // 物品移除技能
 native BlzItemRemoveAbility takes item whichItem, integer abilCode returns boolean
 
 // Unit 
-// 获取单位布尔类型字段
+// 获取单位布尔值域
 native BlzGetUnitBooleanField takes unit whichUnit, unitbooleanfield whichField returns boolean
-// 获取单位整数类型字段
+// 获取单位整数域
 native BlzGetUnitIntegerField takes unit whichUnit, unitintegerfield whichField returns integer
-// 获取单位实数类型字段
+// 获取单位实数域
 native BlzGetUnitRealField takes unit whichUnit, unitrealfield whichField returns real
-// 获取单位字符串字段
+// 获取单位字符串域
 native BlzGetUnitStringField takes unit whichUnit, unitstringfield whichField returns string
-// 改变单位的布尔类型字段
+// 改变单位的布尔值域
 native BlzSetUnitBooleanField takes unit whichUnit, unitbooleanfield whichField, boolean value returns boolean
-// 改变单位的整数类型字段
+// 改变单位的整数域
 native BlzSetUnitIntegerField takes unit whichUnit, unitintegerfield whichField, integer value returns boolean
-// 改变单位的实数类型字段
+// 改变单位的实数域
 native BlzSetUnitRealField takes unit whichUnit, unitrealfield whichField, real value returns boolean
-// 改变单位的字符串类型字段
+// 改变单位的字符串域
 native BlzSetUnitStringField takes unit whichUnit, unitstringfield whichField, string value returns boolean
 
 // Unit Weapon
-// 获取单位武器布尔类型字段
+// 获取单位武器布尔值域
 native BlzGetUnitWeaponBooleanField takes unit whichUnit, unitweaponbooleanfield whichField, integer index returns boolean
-// 获取单位武器整数类型字段
+// 获取单位武器整数域
 native BlzGetUnitWeaponIntegerField takes unit whichUnit, unitweaponintegerfield whichField, integer index returns integer
-// 获取单位武器实数类型字段
+// 获取单位武器实数域
 native BlzGetUnitWeaponRealField takes unit whichUnit, unitweaponrealfield whichField, integer index returns real
-// 获取单位武器字符串类型字段
+// 获取单位武器字符串域
 native BlzGetUnitWeaponStringField takes unit whichUnit, unitweaponstringfield whichField, integer index returns string
-// 改变单位武器布尔类型字段
+// 改变单位武器布尔值域
 native BlzSetUnitWeaponBooleanField takes unit whichUnit, unitweaponbooleanfield whichField, integer index, boolean value returns boolean
-// 改变单位武器整数类型字段
+// 改变单位武器整数域
 native BlzSetUnitWeaponIntegerField takes unit whichUnit, unitweaponintegerfield whichField, integer index, integer value returns boolean
-// 改变单位武器实数类型字段
+// 改变单位武器实数域
 native BlzSetUnitWeaponRealField takes unit whichUnit, unitweaponrealfield whichField, integer index, real value returns boolean
-// 改变单位武器字符串类型字段
+// 改变单位武器字符串域
 native BlzSetUnitWeaponStringField takes unit whichUnit, unitweaponstringfield whichField, integer index, string value returns boolean
 
 // Skin

--- a/static/common.j
+++ b/static/common.j
@@ -892,11 +892,11 @@ globals
 	constant playerstate PLAYER_STATE_RESOURCE_LUMBER = ConvertPlayerState(2)
 	// 玩家英雄数量
 	constant playerstate PLAYER_STATE_RESOURCE_HERO_TOKENS = ConvertPlayerState(3)
-        // 玩家人口上限数
+    // 玩家可用人口数（人口建筑提供的数量）
 	constant playerstate PLAYER_STATE_RESOURCE_FOOD_CAP = ConvertPlayerState(4)
-	// 玩家人口使用数
+	// 玩家已用人口数
 	constant playerstate PLAYER_STATE_RESOURCE_FOOD_USED = ConvertPlayerState(5)
-	// 玩家可用人口数	
+	// 玩家人口上限数（平衡常数或触发限制的最大数量），默认为100
 	constant playerstate PLAYER_STATE_FOOD_CAP_CEILING = ConvertPlayerState(6)
 	// 玩家状态-给予奖励
 	constant playerstate PLAYER_STATE_GIVES_BOUNTY = ConvertPlayerState(7)

--- a/static/common.j
+++ b/static/common.j
@@ -6181,11 +6181,15 @@ native DisplayTimedTextToPlayer takes player toPlayer, real x, real y, real dura
 native DisplayTimedTextFromPlayer takes player toPlayer, real x, real y, real duration, string message returns nothing
 // 清空文本信息(所有玩家) [R]
 native ClearTextMessages takes nothing returns nothing
-// 设置昼夜（指定文件）
+// 设置昼夜
+// @param terrainDNCFile迷雾模型文件路径
+// @param unitDNCFile单位模型文件路径
 native SetDayNightModels takes string terrainDNCFile, string unitDNCFile returns nothing
-// 设置肖像打光器（指定文件）
+// 设置肖像打光器
+// @param portraitDNCFile肖像打光器文件路径
 native SetPortraitLight takes string portraitDNCFile returns nothing
-// 设置天空（指定文件）
+// 设置天空
+// @param skyModelFile天空模型文件路径
 native SetSkyModel takes string skyModelFile returns nothing
 // 启用/禁用玩家控制权(所有玩家) [R]
 native EnableUserControl takes boolean b returns nothing
@@ -6941,7 +6945,7 @@ native RecycleGuardPosition takes unit hUnit returns nothing
 native RemoveAllGuardPositions takes player num returns nothing
 
 
-// ** Cheat标签 **
+// ** Cheat 标签 **
 native Cheat takes string cheatStr returns nothing
 // 无法胜利 [R]
 native IsNoVictoryCheat takes nothing returns boolean
@@ -6950,7 +6954,7 @@ native IsNoDefeatCheat takes nothing returns boolean
 
 // 预读文件
 native Preload takes string filename returns nothing
-// 开始预读
+// 停止预读文件时间
 native PreloadEnd takes real timeout returns nothing
 
 // 预加载开始


### PR DESCRIPTION
CJ开头部分的变量类型汉化不起用作，但我不知道如何让这部分汉化生效......... @naichabaobao 

`// 可破坏物
type destructable extends widget
// 物品
type item extends widget
// 技能
type ability extends agent
// 魔法效果
type buff extends ability
// 玩家组
type force extends agent
// 单位组
type group extends agent`


原生UI的解释搬运自HIVE
XX域等重置版函数/变量的翻译搬运自幻象的仪式重置版编辑器汉化补丁，稍有修正
部分AI函数翻译搬运自搜索结果
此次合并后，3大函数文件应该就全部翻译完成了，但估计仍有错误/不准确/词不达意/啰嗦等问题，希望在更新日志加一句：注释如有错误，望海涵